### PR TITLE
samplers

### DIFF
--- a/include/opentelemetry.hrl
+++ b/include/opentelemetry.hrl
@@ -22,7 +22,7 @@
 %% is actually used (at the time of exporting).
 
 %% for use in guards: sampling bit is the first bit in 8-bit trace options
--define(IS_SPAN_ENABLED(X), (X band 1) =/= 0).
+-define(IS_SPAN_ENABLED(TraceOptions), (TraceOptions band 1) =/= 0).
 
 -define(MESSAGE_EVENT_TYPE_UNSPECIFIED, 'TYPE_UNSPECIFIED').
 -define(MESSAGE_EVENT_TYPE_SENT, 'SENT').
@@ -41,14 +41,20 @@
           %% 64 bit int span id
           span_id           :: opentelemetry:span_id() | undefined,
           %% 8-bit integer, lowest bit is if it is sampled
-          trace_options = 1 :: integer() | undefined,
+          trace_flags = 1 :: integer() | undefined,
           %% Tracestate represents tracing-system specific context in a list of key-value pairs.
           %% Tracestate allows different vendors propagate additional information and
           %% inter-operate with their legacy Id formats.
           tracestate        :: opentelemetry:tracestate() | undefined,
           %% IsValid is a boolean flag which returns true if the SpanContext has a non-zero
           %% TraceID and a non-zero SpanID.
-          is_valid          :: boolean() | undefined
+          is_valid          :: boolean() | undefined,
+          %% true if the span context came from a remote process
+          is_remote         :: boolean() | undefined,
+          %% this field is not propagated and is only here as an implementation optimization
+          %% If true updates like adding events are done on the span. The same as if the
+          %% trace flags lowest bit is 1 but simply not propagated.
+          is_recorded       :: boolean() | undefined                                
          }).
 
 -record(span, {
@@ -101,7 +107,12 @@
 
           %% An optional number of child spans that were generated while this span
           %% was active. If set, allows implementation to detect missing child spans.
-          child_span_count = undefined            :: integer() | undefined
+          child_span_count = undefined            :: integer() | undefined,
+
+          %% this field is not propagated and is only here as an implementation optimization
+          %% If true updates like adding events are done on the span. The same as if the
+          %% trace flags lowest bit is 1 but simply not propagated.
+          is_recorded       :: boolean() | undefined                                
          }).
 
 -record(link, {

--- a/include/ot_sampler.hrl
+++ b/include/ot_sampler.hrl
@@ -1,0 +1,3 @@
+-define(NOT_RECORD, not_record).
+-define(RECORD, record).
+-define(RECORD_AND_PROPAGATE, record_and_propagate).

--- a/src/opentelemetry.app.src
+++ b/src/opentelemetry.app.src
@@ -8,8 +8,8 @@
     stdlib,
     wts
    ]},
-  {env, [{tracer, {ot_tracer_default, #{span => {ot_span_ets, []},
-                                        ctx => {ot_ctx_pdict, []}}}}]},
+  {env, [{tracer, #{span => {ot_span_ets, []},
+                    ctx => {ot_ctx_pdict, []}}}]},
   {modules, []},
 
   {licenses, ["Apache 2.0"]},

--- a/src/opentelemetry.app.src
+++ b/src/opentelemetry.app.src
@@ -8,8 +8,8 @@
     stdlib,
     wts
    ]},
-  {env, [{tracer, #{span => {ot_span_ets, []},
-                    ctx => {ot_ctx_pdict, []}}}]},
+  {env, [{tracer, {ot_tracer_default, #{span => {ot_span_ets, []},
+                                        ctx => {ot_ctx_pdict, []}}}}]},
   {modules, []},
 
   {licenses, ["Apache 2.0"]},

--- a/src/opentelemetry.app.src
+++ b/src/opentelemetry.app.src
@@ -9,7 +9,8 @@
     wts
    ]},
   {env, [{tracer, {ot_tracer_default, #{span => {ot_span_ets, []},
-                                        ctx => {ot_ctx_pdict, []}}}}]},
+                                        ctx => {ot_ctx_pdict, []}}}},
+         {sampler, {always_on, #{}}}]},
   {modules, []},
 
   {licenses, ["Apache 2.0"]},

--- a/src/opentelemetry_app.erl
+++ b/src/opentelemetry_app.erl
@@ -26,10 +26,15 @@ start(_StartType, _StartArgs) ->
 
     %% if the span impl needs to have a process supervised it must be
     %% setup after the supervision tree has started.
-    {tracer, {Tracer, TracerOpts}} = lists:keyfind(tracer, 1, Opts),
-    Children = ot_tracer:setup(Tracer, TracerOpts),
+    {sampler, {Sampler, SamplerOpts}} = lists:keyfind(sampler, 1, Opts),
+    SamplerFun = ot_sampler:setup(Sampler, SamplerOpts),
 
-    opentelemetry_sup:start_link(Children, Opts).
+    %% if the span impl needs to have a process supervised it must be
+    %% setup after the supervision tree has started.
+    {tracer, {Tracer, TracerOpts}} = lists:keyfind(tracer, 1, Opts),
+    TracerChildren = ot_tracer:setup(Tracer, TracerOpts, SamplerFun),
+
+    opentelemetry_sup:start_link(TracerChildren, Opts).
 
 stop(_State) ->
     ok.

--- a/src/opentelemetry_app.erl
+++ b/src/opentelemetry_app.erl
@@ -24,13 +24,13 @@
 start(_StartType, _StartArgs) ->
     Opts = application:get_all_env(opentelemetry),
 
-    %% if the span impl needs to have a process supervised it must be
-    %% setup after the supervision tree has started.
     {sampler, {Sampler, SamplerOpts}} = lists:keyfind(sampler, 1, Opts),
     SamplerFun = ot_sampler:setup(Sampler, SamplerOpts),
 
-    %% if the span impl needs to have a process supervised it must be
-    %% setup after the supervision tree has started.
+    %% The default sampler implementation must be passed to the tracer chosen.
+    %% Since the tracer is started after the rest of the supervision tree has started
+    %% and we only get its children, we must instantiate the sampler before anything else.
+    %% The sampler turns out to be instantiated before any supervision tree is started.
     {tracer, {Tracer, TracerOpts}} = lists:keyfind(tracer, 1, Opts),
     TracerChildren = ot_tracer:setup(Tracer, TracerOpts, SamplerFun),
 

--- a/src/ot_sampler.erl
+++ b/src/ot_sampler.erl
@@ -39,7 +39,7 @@
               sampling_decision/0,
               sampler/0]).
 
--define(MAX_VALUE, 9223372036854775807).
+-define(MAX_VALUE, 9223372036854775807). %% 2^63 - 1
 -define(DEFAULT_PROBABILITY, 0.5).
 
 -define(IGNORE_HINT(SamplingHint, IgnoreHints), SamplingHint =:= undefined
@@ -91,17 +91,15 @@ setup(probability, Opts) ->
                 andalso not(lists:member(SamplingHint, IgnoreHints)) of
                 true ->
                     {?RECORD_AND_PROPAGATE, []};
-                false when OnlyRoot =:= false andalso IsRemote =:= true ->
-                    case do_probability_sample(TraceId, IdUpperBound) of
+                false ->
+                    case OnlyRoot =:= false andalso IsRemote =:= true
+                        andalso do_probability_sample(TraceId, IdUpperBound) of
                         ?RECORD_AND_PROPAGATE ->
                             {?RECORD_AND_PROPAGATE, []};
-                        ?NOT_RECORD ->
+                        _ ->
                             %% sampling hint could still be ?RECORD
                             maybe_sampling_hint(SamplingHint, IgnoreHints)
-                    end;
-                false ->
-                    %% sampling hint could still be ?RECORD
-                    maybe_sampling_hint(SamplingHint, IgnoreHints)
+                    end
             end
     end;
 setup(Sampler, Opts) ->

--- a/src/ot_sampler.erl
+++ b/src/ot_sampler.erl
@@ -1,0 +1,126 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% A sampler is a function run on each started span that returns whether to
+%% record and propagate, only record or not record the span.
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_sampler).
+
+-export([setup/2]).
+
+-include("opentelemetry.hrl").
+-include("ot_sampler.hrl").
+
+-type sampling_decision() :: ?NOT_RECORD | ?RECORD | ?RECORD_AND_PROPAGATE.
+-type sampling_hint() :: sampling_decision() | undefined.
+-type sampling_result() :: {sampling_decision(), opentelemetry:attributes()}.
+-type sampler() :: fun((opentelemetry:trace_id(),
+                        opentelemetry:span_id(),
+                        opentelemetry:span_ctx(),
+                        sampling_hint(),
+                        opentelemetry:links(),
+                        opentelemetry:span_name(),
+                        opentelemetry:kind(),
+                        opentelemetry:attributes()) -> sampling_result()).
+-export_type([sampling_result/0,
+              sampling_decision/0,
+              sampler/0]).
+
+-define(MAX_VALUE, 9223372036854775807).
+-define(DEFAULT_PROBABILITY, 0.5).
+
+-define(IGNORE_HINT(SamplingHint, IgnoreHints), SamplingHint =:= undefined
+        orelse lists:member(SamplingHint, IgnoreHints)).
+
+-spec setup(atom() | module(), map()) -> sampler().
+setup(always_on, _Opts) ->
+    fun(_TraceId, _SpanId, _SpanCtx, _SamplingHint, _Links, _SpanName, _Kind, _Attributes) ->
+            {?RECORD_AND_PROPAGATE, []}
+    end;
+setup(always_off, _Opts) ->
+    fun(_TraceId, _SpanId, _SpanCtx, _SamplingHint, _Links, _SpanName, _Kind, _Attributes) ->
+            {?NOT_RECORD, []}
+    end;
+setup(always_parent, _Opts) ->
+    fun(_, _, #span_ctx{trace_flags=TraceFlags}, _, _, _, _, _) when ?IS_SPAN_ENABLED(TraceFlags) ->
+            {?RECORD_AND_PROPAGATE, []};
+       (_, _, _, _, _, _, _, _) ->
+            {?NOT_RECORD, []}
+    end;
+setup(probability, Opts) ->
+    IdUpperBound = 
+        case maps:get(probability, Opts, ?DEFAULT_PROBABILITY) of
+            P when P =:= 0.0 ->
+                0;
+            P when P =:= 1.0 ->
+                ?MAX_VALUE;
+            P when P >= 0.0 andalso P =< 1.0 ->
+                P * ?MAX_VALUE
+        end,
+
+    %% by default only ignore the RECORD hint
+    IgnoreHints = maps:get(ignore_hints, Opts, [?RECORD]),
+    IgnoreParentFlag = maps:get(ignore_parent_flag, Opts, false),
+    OnlyRoot = maps:get(only_root_spans, Opts, true),
+
+    fun(TraceId, _SpanId, Parent, SamplingHint, _Links, _SpanName, _Kind, _Attributes) when
+              IgnoreParentFlag =:= true orelse Parent =:= undefined ->
+            case ?IGNORE_HINT(SamplingHint, IgnoreHints) of
+                true ->
+                    {do_probability_sample(TraceId, IdUpperBound), []};
+                false ->
+                    {SamplingHint, []}
+            end;
+       (_, _, #span_ctx{trace_flags=TraceFlags}, _, _, _, _, _) when ?IS_SPAN_ENABLED(TraceFlags) ->
+            {?RECORD_AND_PROPAGATE, []};
+       (TraceId, _, #span_ctx{is_remote=IsRemote}, SamplingHint, _, _, _, _) ->
+            case SamplingHint =:= ?RECORD_AND_PROPAGATE
+                andalso not(lists:member(SamplingHint, IgnoreHints)) of
+                true ->
+                    {?RECORD_AND_PROPAGATE, []};
+                false when OnlyRoot =:= false andalso IsRemote =:= true ->
+                    case do_probability_sample(TraceId, IdUpperBound) of
+                        ?RECORD_AND_PROPAGATE ->
+                            {?RECORD_AND_PROPAGATE, []};
+                        ?NOT_RECORD ->
+                            %% sampling hint could still be ?RECORD
+                            maybe_sampling_hint(SamplingHint, IgnoreHints)
+                    end;
+                false ->
+                    %% sampling hint could still be ?RECORD
+                    maybe_sampling_hint(SamplingHint, IgnoreHints)
+            end
+    end;
+setup(Sampler, Opts) ->
+    Sampler:setup(Opts).
+
+maybe_sampling_hint(SamplingHint, IgnoreHints) ->
+    case ?IGNORE_HINT(SamplingHint, IgnoreHints) of
+        true ->
+            {?NOT_RECORD, []};
+        false ->
+            {SamplingHint, []}
+    end.
+
+do_probability_sample(TraceId, IdUpperBound) ->
+    Lower64Bits = TraceId band ?MAX_VALUE,
+    case erlang:abs(Lower64Bits) < IdUpperBound of
+        true ->
+            ?RECORD_AND_PROPAGATE;
+        false ->
+            ?NOT_RECORD
+    end.
+

--- a/src/ot_span.erl
+++ b/src/ot_span.erl
@@ -19,7 +19,7 @@
 -module(ot_span).
 
 -type start_opts() :: #{parent => undefined | opentelemetry:span() | opentelemetry:span_ctx(),
-                        sampler => module(),
+                        sampler => ot_sampler:sampler(),
                         links => opentelemetry:links(),
                         is_recorded => boolean(),
                         kind => opentelemetry:span_kind()}.
@@ -32,7 +32,6 @@
 -callback is_recording_events(opentelemetry:span_ctx()) -> boolean().
 -callback set_attributes(opentelemetry:span_ctx(), opentelemetry:attributes()) -> ok.
 -callback add_events(opentelemetry:span_ctx(), opentelemetry:time_events()) -> ok.
--callback add_links(opentelemetry:span_ctx(), opentelemetry:links()) -> ok.
 -callback set_status(opentelemetry:span_ctx(), opentelemetry:status()) -> ok.
 -callback update_name(opentelemetry:span_ctx(), opentelemetry:span_name()) -> ok.
 

--- a/src/ot_span.erl
+++ b/src/ot_span.erl
@@ -26,7 +26,6 @@
 
 -export_type([start_opts/0]).
 
--callback setup(map()) -> ok.
 -callback start_span(opentelemetry:span_name(), start_opts()) -> opentelemetry:span_ctx().
 -callback finish_span(opentelemetry:span_ctx()) -> ok.
 -callback get_ctx(opentelemetry:span()) -> opentelemetry:span_ctx().

--- a/src/ot_span.erl
+++ b/src/ot_span.erl
@@ -26,6 +26,7 @@
 
 -export_type([start_opts/0]).
 
+-callback setup(map()) -> ok.
 -callback start_span(opentelemetry:span_name(), start_opts()) -> opentelemetry:span_ctx().
 -callback finish_span(opentelemetry:span_ctx()) -> ok.
 -callback get_ctx(opentelemetry:span()) -> opentelemetry:span_ctx().

--- a/src/ot_span_ets.erl
+++ b/src/ot_span_ets.erl
@@ -32,7 +32,6 @@
          is_recording_events/1,
          set_attributes/2,
          add_events/2,
-         add_links/2,
          set_status/2,
          update_name/2]).
 
@@ -57,7 +56,7 @@ start_span(Name, Opts) ->
 -spec finish_span(opentelemetry:span_ctx()) -> ok.
 finish_span(#span_ctx{span_id=SpanId,
                       tracestate=Tracestate,
-                      trace_options=TraceOptions}) when ?IS_SPAN_ENABLED(TraceOptions) ->
+                      trace_flags=TraceOptions}) when ?IS_SPAN_ENABLED(TraceOptions) ->
     case ets:take(?SPAN_TAB, SpanId) of
         [Span] ->
             _Span1 = ot_span_utils:end_span(Span#span{tracestate=Tracestate}),
@@ -83,10 +82,6 @@ set_attributes(_SpanCtx, _Attributes) ->
 
 -spec add_events(opentelemetry:span_ctx(), opentelemetry:time_events()) -> ok.
 add_events(_SpanCtx, _TimeEvents) ->
-    ok.
-
--spec add_links(opentelemetry:span_ctx(), opentelemetry:links()) -> ok.
-add_links(_SpanCtx, _Links) ->
     ok.
 
 -spec set_status(opentelemetry:span_ctx(), opentelemetry:status()) -> ok.

--- a/src/ot_span_ets.erl
+++ b/src/ot_span_ets.erl
@@ -94,8 +94,6 @@ update_name(_SpanCtx, _SpanName) ->
 
 %%
 
-storage_insert(undefined) ->
-    ok;
 storage_insert(Span) ->
     ets:insert(?SPAN_TAB, Span).
 

--- a/src/ot_span_ets.erl
+++ b/src/ot_span_ets.erl
@@ -26,7 +26,7 @@
          handle_call/3,
          handle_cast/2]).
 
--export([setup/0,
+-export([setup/1,
          start_span/2,
          finish_span/1,
          get_ctx/1,
@@ -44,7 +44,7 @@
 %% table to store active spans
 -define(SPAN_TAB, otel_span_table).
 
-setup() ->
+setup(_Opts) ->
     {ok, _} = ot_span_sup:start_child(#{id => ?MODULE,
                                         start => {?MODULE, start_link, [[]]}}),
     ok.

--- a/src/ot_span_ets.erl
+++ b/src/ot_span_ets.erl
@@ -26,8 +26,7 @@
          handle_call/3,
          handle_cast/2]).
 
--export([setup/1,
-         start_span/2,
+-export([start_span/2,
          finish_span/1,
          get_ctx/1,
          is_recording_events/1,
@@ -43,11 +42,6 @@
 
 %% table to store active spans
 -define(SPAN_TAB, otel_span_table).
-
-setup(_Opts) ->
-    {ok, _} = ot_span_sup:start_child(#{id => ?MODULE,
-                                        start => {?MODULE, start_link, [[]]}}),
-    ok.
 
 start_link(Opts) ->
     gen_server:start_link(?MODULE, Opts, []).

--- a/src/ot_span_ets.erl
+++ b/src/ot_span_ets.erl
@@ -26,7 +26,8 @@
          handle_call/3,
          handle_cast/2]).
 
--export([start_span/2,
+-export([setup/0,
+         start_span/2,
          finish_span/1,
          get_ctx/1,
          is_recording_events/1,
@@ -42,6 +43,11 @@
 
 %% table to store active spans
 -define(SPAN_TAB, otel_span_table).
+
+setup() ->
+    {ok, _} = ot_span_sup:start_child(#{id => ?MODULE,
+                                        start => {?MODULE, start_link, [[]]}}),
+    ok.
 
 start_link(Opts) ->
     gen_server:start_link(?MODULE, Opts, []).
@@ -79,7 +85,7 @@ is_recording_events(_SpanCtx) ->
 
 -spec set_attributes(opentelemetry:span_ctx(), opentelemetry:attributes()) -> ok.
 set_attributes(_SpanCtx, _Attributes) ->
-    ok.
+   ok.
 
 -spec add_events(opentelemetry:span_ctx(), opentelemetry:time_events()) -> ok.
 add_events(_SpanCtx, _TimeEvents) ->

--- a/src/ot_span_utils.erl
+++ b/src/ot_span_utils.erl
@@ -18,14 +18,15 @@
 %%%-------------------------------------------------------------------------
 -module(ot_span_utils).
 
--export([start_span/1,
-         start_span/2,
+-export([start_span/2,
          end_span/1]).
 
 -include("opentelemetry.hrl").
+-include("ot_sampler.hrl").
 
 -type start_opts() :: #{parent => undefined | opentelemetry:span() | opentelemetry:span_ctx(),
-                        sampler => module(),
+                        sampler := ot_sampler:sampler(),
+                        sampling_hint => ot_sampler:sampling_decision(),
                         links => opentelemetry:links(),
                         is_recorded => boolean(),
                         kind => opentelemetry:span_kind()}.
@@ -35,10 +36,6 @@
 %% sampling bit is the first bit in 8-bit trace options
 -define(IS_ENABLED(X), (X band 1) =/= 0).
 
--spec start_span(opentelemetry:span_name()) -> {opentelemetry:span_ctx(), opentelemetry:span()}.
-start_span(Name) ->
-    start_span(Name, #{}).
-
 -spec start_span(opentelemetry:span_name(), start_opts())
                 -> {opentelemetry:span_ctx(), opentelemetry:span() | undefined}.
 start_span(Name, Opts) ->
@@ -46,30 +43,25 @@ start_span(Name, Opts) ->
     Attributes = maps:get(attributes, Opts, []),
     Links = maps:get(links, Opts, []),
     Kind = maps:get(kind, Opts, ?SPAN_KIND_UNSPECIFIED),
+    Sampler = maps:get(sampler, Opts),
+    SamplingHint = maps:get(sampler_hint, Opts, undefined),
+    new_span(Name, Parent, Sampler, SamplingHint, Kind, Attributes, Links).
 
-    %% TODO: support overriding the sampler
-    _Sampler = maps:get(sampler, Opts, undefined),
-
-    new_span(Name, Parent, Kind, Attributes, Links).
-
-%% if parent is undefined, first run sampler
-new_span(Name, undefined, Kind, Attributes, Links) ->
+%% if parent is undefined create a new trace id
+new_span(Name, undefined, Sampler, SamplingHint, Kind, Attributes, Links) ->
     TraceId = opentelemetry:generate_trace_id(),
     Span = #span_ctx{trace_id=TraceId,
-                     trace_options=0},
-    TraceOptions = update_trace_options(should_sample, Span),
-    new_span(Name, Span#span_ctx{trace_options=TraceOptions}, Kind, Attributes, Links);
-%% if parent is remote, first run sampler
-%% new_span_(Name, Span=#span_ctx{}, Kind, Attributes) %% when RemoteParent =:= true
-%%                                              ->
-%%     TraceOptions = update_trace_options(should_sample, Span),
-%%     new_span_(Name, Span#span_ctx{trace_options=TraceOptions}, Kind, Attributes);
+                     trace_flags=0},   
+    new_span(Name, Span, Sampler, SamplingHint, Kind, Attributes, Links);
 new_span(Name, Parent=#span_ctx{trace_id=TraceId,
-                                 trace_options=TraceOptions,
-                                 tracestate=Tracestate,
-                                 span_id=ParentSpanId}, Kind, Attributes, Links)
-  when ?IS_ENABLED(TraceOptions) ->
+                                tracestate=Tracestate,
+                                span_id=ParentSpanId}, Sampler, SamplingHint, Kind, Attributes, Links) ->
     SpanId = opentelemetry:generate_span_id(),
+    SpanCtx = Parent#span_ctx{span_id=SpanId},
+
+    {TraceFlags, IsRecorded, SamplerAttributes} = sample(Sampler, TraceId, SpanId, Parent,
+                                                         SamplingHint, Links, Name, Kind, Attributes),
+    
     Span = #span{trace_id=TraceId,
                  span_id=SpanId,
                  tracestate=Tracestate,
@@ -77,25 +69,12 @@ new_span(Name, Parent=#span_ctx{trace_id=TraceId,
                  parent_span_id=ParentSpanId,
                  kind=Kind,
                  name=Name,
-                 attributes=Attributes,
-                 links=Links},
-    {Parent#span_ctx{span_id=SpanId}, Span};
-new_span(_Name, Parent, _Kind, _, _) ->
-    SpanId = opentelemetry:generate_span_id(),
-    %% since discarded by sampler, create no span
-    {Parent#span_ctx{span_id=SpanId}, undefined}.
+                 attributes=Attributes++SamplerAttributes,
+                 links=Links,
+                 is_recorded=IsRecorded},
 
-%%
-update_trace_options(should_sample, #span_ctx{trace_id=_TraceId,
-                                              span_id=_ParentSpanId,
-                                              trace_options=_ParentTraceOptions}) ->
-    1.
-    %% case oc_sampler:should_sample(TraceId, ParentSpanId, ?IS_ENABLED(ParentTraceOptions)) of
-    %%     true ->
-    %%         1;
-    %%     false ->
-    %%         0
-    %% end.
+    {SpanCtx#span_ctx{trace_flags=TraceFlags,
+                      is_recorded=IsRecorded}, Span}.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -109,3 +88,17 @@ end_span(Span=#span{end_time=undefined,
     Span#span{end_time=EndTime};
 end_span(Span) ->
     Span.
+
+%%
+
+sample(Sampler, TraceId, SpanId, Parent, SamplingHint, Links, SpanName, Kind, Attributes) ->
+    {Decision, Attributes} = Sampler(TraceId, SpanId, Parent, SamplingHint, 
+                                     Links, SpanName, Kind, Attributes),
+    case Decision of
+        ?NOT_RECORD ->
+            {0, false, Attributes};
+        ?RECORD ->
+            {0, true, Attributes};
+        ?RECORD_AND_PROPAGATE ->
+            {1, true, Attributes}
+    end.

--- a/src/ot_tracer_noop.erl
+++ b/src/ot_tracer_noop.erl
@@ -31,7 +31,7 @@
 
 -define(NOOP_SPAN_CTX, #span_ctx{trace_id=0,
                                  span_id=0,
-                                 trace_options=0,
+                                 trace_flags=0,
                                  tracestate=[],
                                  is_valid=false}).
 

--- a/test/ot_samplers_SUITE.erl
+++ b/test/ot_samplers_SUITE.erl
@@ -1,4 +1,4 @@
--module(otel_samplers_SUITE).
+-module(ot_samplers_SUITE).
 
 -compile(export_all).
 

--- a/test/otel_samplers_SUITE.erl
+++ b/test/otel_samplers_SUITE.erl
@@ -1,0 +1,106 @@
+-module(otel_samplers_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include("opentelemetry.hrl").
+-include("ot_sampler.hrl").
+
+all() ->
+    [probability_sampler].
+
+init_per_suite(Config) ->
+    application:load(opentelemetry),
+    %% set application environment variables
+    {ok, _} = application:ensure_all_started(opentelemetry),
+    Config.
+
+end_per_suite(_Config) ->
+    ok = application:stop(opentelemetry).
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+probability_sampler(_Config) ->
+    SpanName = <<"span-prob-sampled">>,
+    Probability = 0.5,
+    DoSample = 120647249294066572380176333851662846319,
+    DoNotSample =  53020601517903903921384168845238205400,
+
+    %% sampler that runs on all spans
+    Sampler = ot_sampler:setup(probability, #{probability => Probability,
+                                              only_root_spans => false}),
+
+    %% checks the trace id is is under the upper bound
+    ?assertMatch({?RECORD_AND_PROPAGATE, []},
+            Sampler(DoSample, 0, undefined, undefined, [], SpanName, undefined, [])),
+
+    %% checks the trace id is is over the upper bound
+    ?assertMatch({?NOT_RECORD, []},
+            Sampler(DoNotSample, 0, undefined, undefined, [], SpanName, undefined, [])),
+
+    %% uses the value from the parent span context
+    ?assertMatch({?RECORD_AND_PROPAGATE, []},
+                 Sampler(DoNotSample, 0, #span_ctx{trace_flags=1,
+                                                   is_remote=true},
+                         ?NOT_RECORD, [], SpanName, undefined, [])),
+
+    %% since parent is not remote it uses the value from the parent span context
+    ?assertMatch({?NOT_RECORD, []},
+                 Sampler(DoSample, 0, #span_ctx{trace_flags=0,
+                                                is_remote=false},
+                         ?NOT_RECORD, [], SpanName, undefined, [])),
+
+    %% since parent is remote it checks the trace id and it is under the upper bound
+    ?assertMatch({?RECORD_AND_PROPAGATE, []},
+                 Sampler(DoSample, 0, #span_ctx{trace_flags=0,
+                                                is_remote=true},
+                         undefined, [], SpanName, undefined, [])),
+
+    %% relies on the sampler hint
+    ?assertMatch({?RECORD_AND_PROPAGATE, []},
+                 Sampler(DoNotSample, 0, #span_ctx{trace_flags=0},
+                         ?RECORD_AND_PROPAGATE, [], SpanName, undefined, [])),
+
+    Sampler1 = ot_sampler:setup(probability, #{probability => Probability,
+                                               only_root_spans => false,
+                                               ignore_hints => [],
+                                               ignore_parent_flag => false}),
+
+    %% relies on the sampler hint
+    ?assertMatch({?RECORD, []},
+                 Sampler1(DoNotSample, 0, #span_ctx{trace_flags=0, is_remote=true},
+                         ?RECORD, [], SpanName, undefined, [])),
+
+    %% a sampler that does not ignore RECORD like it does by default but does ignore the parent
+    SamplerWithAllHints = ot_sampler:setup(probability, #{probability => Probability,
+                                                          ignore_hints => [],
+                                                          ignore_parent_flag => true}),
+
+    %% relies on the sampler hint
+    ?assertMatch({?RECORD, []},
+                 SamplerWithAllHints(DoNotSample, 0, undefined, ?RECORD, [], SpanName, undefined, [])),
+
+    %% relies on the sampler hint
+    ?assertMatch({?NOT_RECORD, []},
+                 SamplerWithAllHints(DoNotSample, 0, undefined, ?NOT_RECORD, [], SpanName, undefined, [])),
+
+    %% since parents are ignored this relies on the sampler hint
+    ?assertMatch({?NOT_RECORD, []},
+                 SamplerWithAllHints(DoNotSample, 0, #span_ctx{trace_flags=1},
+                                     ?NOT_RECORD, [], SpanName, undefined, [])),
+
+    Sampler2 = ot_sampler:setup(probability, #{probability => Probability,
+                                               ignore_parent_flag => false}),
+
+    %% parent not ignored but is 0 and sampler hint RECORD is ignored by default
+    ?assertMatch({?NOT_RECORD, []},
+                 Sampler2(DoNotSample, 0, #span_ctx{trace_flags=0, is_remote=true},
+                          ?RECORD, [], SpanName, undefined, [])),
+
+    ok.


### PR DESCRIPTION
Also depends on #7 so to view just what the sampler changes are look at the last commit in this PR.

Unlike in opencensus this is using funs for samplers and not modules. I think this makes storing state, like the `IdUpperBound` in the probability sampler, simpler and is more efficient to call a fun than if we did a variable module function call.