### PR TITLE
Move remote calls to handler to the behaviour modules

### DIFF
--- a/src/ot_ctx.erl
+++ b/src/ot_ctx.erl
@@ -22,19 +22,27 @@
          with_value/3,
          with_value/4]).
 
--callback get(term(), term()) -> term().
--callback with_value(term(), term()) -> ok.
+-type key() :: term().
+-type instrumented_fun() :: fun(() -> term()).
 
--spec get(Impl :: module(), term()) -> term().
+-export_type([key/0, instrumented_fun/0]).
+
+%% Get value of `Key' from current context and return `Default' if none.
+-callback get(Key :: key(), Default :: term()) -> term().
+
+%% Set value of `Key' in current context to `Value'.
+-callback with_value(Key :: key(), Value :: term()) -> ok.
+
+-spec get(Impl :: module(), key()) -> term().
 get(Module, Key) -> get(Module, Key, undefined).
 
--spec get(Impl :: module(), term(), term()) -> term().
+-spec get(Impl :: module(), key(), term()) -> term().
 get(Module, Key, Default) -> Module:get(Key, Default).
 
--spec with_value(Impl :: module(), term(), term()) -> term().
+-spec with_value(Impl :: module(), key(), term()) -> term().
 with_value(Module, Key, Value) -> Module:with_value(Key, Value).
 
--spec with_value(Impl :: module(), term(), term(), fun()) -> term().
+-spec with_value(Impl :: module(), key(), term(), instrumented_fun()) -> term().
 with_value(Module, Key, Value, Fun) ->
     Orig = get(Module, Key),
     try

--- a/src/ot_ctx.erl
+++ b/src/ot_ctx.erl
@@ -17,7 +17,29 @@
 %%%-------------------------------------------------------------------------
 -module(ot_ctx).
 
--callback get(term()) -> term().
+-export([get/2,
+         get/3,
+         with_value/3,
+         with_value/4]).
+
 -callback get(term(), term()) -> term().
 -callback with_value(term(), term()) -> ok.
--callback with_value(term(), term(), fun()) -> ok.
+
+-spec get(Impl :: module(), term()) -> term().
+get(Module, Key) -> get(Module, Key, undefined).
+
+-spec get(Impl :: module(), term(), term()) -> term().
+get(Module, Key, Default) -> Module:get(Key, Default).
+
+-spec with_value(Impl :: module(), term(), term()) -> term().
+with_value(Module, Key, Value) -> Module:with_value(Key, Value).
+
+-spec with_value(Impl :: module(), term(), term(), fun()) -> term().
+with_value(Module, Key, Value, Fun) ->
+    Orig = get(Module, Key),
+    try
+        with_value(Module, Key, Value),
+        Fun()
+    after
+        with_value(Module, Key, Orig)
+    end.

--- a/src/ot_ctx_pdict.erl
+++ b/src/ot_ctx_pdict.erl
@@ -20,13 +20,7 @@
 -behaviour(ot_ctx).
 
 -export([with_value/2,
-         with_value/3,
-         get/1,
          get/2]).
-
--spec get(term()) -> term().
-get(Key) ->
-    erlang:get(Key).
 
 -spec get(term(), term()) -> term().
 get(Key, Default) ->
@@ -40,13 +34,3 @@ get(Key, Default) ->
 -spec with_value(term(), term()) -> ok.
 with_value(Key, Value) ->
     erlang:put(Key, Value).
-
--spec with_value(term(), term(), fun()) -> ok.
-with_value(Key, Value, Fun) ->
-    Orig = erlang:get(Key),
-    try
-        erlang:put(Key, Value),
-        Fun()
-    after
-        erlang:put(Key, Orig)
-    end.

--- a/src/ot_ctx_seqtrace.erl
+++ b/src/ot_ctx_seqtrace.erl
@@ -19,29 +19,14 @@
 
 -behaviour(ot_ctx).
 
--export([get/1,
-         get/2,
-         with_value/2,
-         with_value/3]).
+-export([get/2,
+         with_value/2]).
 
 -include_lib("kernel/include/logger.hrl").
 
 %% needed until type specs for seq_trace are fixed
--dialyzer({nowarn_function, get/1}).
 -dialyzer({nowarn_function, get/2}).
 -dialyzer({nowarn_function, with_value/2}).
-
--spec get(term()) -> term().
-get(Key) ->
-    case seq_trace:get_token(label) of
-        {label, Label} when is_map(Label) ->
-            maps:get(Key, Label, undefined);
-        [] ->
-            undefined;
-        {label, _Label} ->
-            log_warning(),
-            undefined
-    end.
 
 -spec get(term(), term()) -> term().
 get(Key, Default) ->
@@ -66,18 +51,6 @@ with_value(Key, Value) ->
             log_warning(),
             ok
     end.
-
--spec with_value(term(), term(), fun()) -> ok.
-with_value(Key, Value, Fun) ->
-    Orig = ?MODULE:get(Key),
-    try
-        with_value(Key, Value),
-        Fun()
-    after
-        with_value(Key, Orig)
-    end.
-
-%%
 
 log_warning() ->
     ?LOG_WARNING("seq_trace label must be a map to be used for opentelemetry span context").

--- a/src/ot_span.erl
+++ b/src/ot_span.erl
@@ -18,6 +18,16 @@
 %%%-------------------------------------------------------------------------
 -module(ot_span).
 
+-export([start_span/3,
+         finish_span/2,
+         get_ctx/2,
+         is_recording_events/2,
+         set_attributes/3,
+         add_events/3,
+         add_links/3,
+         set_status/3,
+         update_name/3]).
+
 -type start_opts() :: #{parent => undefined | opentelemetry:span() | opentelemetry:span_ctx(),
                         sampler => ot_sampler:sampler(),
                         links => opentelemetry:links(),
@@ -35,3 +45,29 @@
 -callback set_status(opentelemetry:span_ctx(), opentelemetry:status()) -> ok.
 -callback update_name(opentelemetry:span_ctx(), opentelemetry:span_name()) -> ok.
 
+start_span(Module, Name, Opts) ->
+    Module:start_span(Name, Opts).
+
+finish_span(Module, Ctx) ->
+    Module:finish_span(Ctx).
+
+get_ctx(Module, Span) ->
+    Module:get_ctx(Span).
+
+is_recording_events(Module, SpanCtx) ->
+    Module:is_recording_events(SpanCtx).
+
+set_attributes(Module, SpanCtx, Attributes) ->
+    Module:set_attributes(SpanCtx, Attributes).
+
+add_events(Module, SpanCtx, Events) ->
+    Module:add_events(SpanCtx, Events).
+
+add_links(Module, SpanCtx, Links) ->
+    Module:add_links(SpanCtx, Links).
+
+set_status(Module, SpanCtx, Status) ->
+    Module:set_status(SpanCtx, Status).
+
+update_name(Module, SpanCtx, Name) ->
+    Module:update_name(SpanCtx, Name).

--- a/src/ot_tracer.erl
+++ b/src/ot_tracer.erl
@@ -73,8 +73,8 @@ start_span(Tracer, Name, Opts) when is_map_key(sampler, Opts)->
     ot_ctx_pdict:with_value(?CURRENT_TRACER, Tracer),
     Tracer:start_span(Name, Opts);
 start_span(Tracer, Name, Opts) ->
-    ot_ctx_pdict:with_value(?CURRENT_TRACER, Tracer),
-    Tracer:start_span(Name, Opts#{sampler => ?sampler}).
+    ot_ctx:with_value(ot_ctx_pdict, ?CURRENT_TRACER, Tracer),
+    Tracer:start_span(Name, Opts).
 
 -spec with_span(opentelemetry:span_ctx()) -> ok.
 with_span(Span) ->
@@ -82,32 +82,32 @@ with_span(Span) ->
 
 -spec with_span(module() | opentelemetry:span_ctx(), opentelemetry:span_ctx() | fun()) -> ok.
 with_span(Span=#span_ctx{}, Fun) ->
-    Tracer = ot_ctx_pdict:get(?CURRENT_TRACER, ?tracer),
+    Tracer = ot_ctx:get(ot_ctx_pdict, ?CURRENT_TRACER, ?tracer),
     with_span(Tracer, Span, Fun);
 with_span(Tracer, Span) ->
-    ot_ctx_pdict:with_value(?CURRENT_TRACER, Tracer),
+    ot_ctx:with_value(ot_ctx_pdict, ?CURRENT_TRACER, Tracer),
     Tracer:with_span(Span).
 
 -spec with_span(module(), opentelemetry:span_ctx(), fun()) -> ok.
 with_span(Tracer, SpanCtx, Fun) ->
-    ot_ctx_pdict:with_value(?CURRENT_TRACER, Tracer, fun() -> Tracer:with_value(SpanCtx, Fun) end).
+    ot_ctx:with_value(ot_ctx_pdict, ?CURRENT_TRACER, Tracer, fun() -> Tracer:with_value(SpanCtx, Fun) end).
 
 -spec finish() -> ok.
 finish() ->
-    Tracer = ot_ctx_pdict:get(?CURRENT_TRACER, ?tracer),
+    Tracer = ot_ctx:get(ot_ctx_pdict, ?CURRENT_TRACER, ?tracer),
     Tracer:finish().
 
 -spec current_span_ctx() -> opentelemetry:span_ctx().
 current_span_ctx() ->
-    Tracer = ot_ctx_pdict:get(?CURRENT_TRACER, ?tracer),
+    Tracer = ot_ctx:get(ot_ctx_pdict, ?CURRENT_TRACER, ?tracer),
     Tracer:current_span_ctx().
 
 -spec get_binary_format() -> binary().
 get_binary_format() ->
-    Tracer = ot_ctx_pdict:get(?CURRENT_TRACER, ?tracer),
+    Tracer = ot_ctx:get(ot_ctx_pdict, ?CURRENT_TRACER, ?tracer),
     Tracer:get_binary_format().
 
 -spec get_http_text_format() -> opentelemetry:http_headers().
 get_http_text_format() ->
-    Tracer = ot_ctx_pdict:get(?CURRENT_TRACER, ?tracer),
+    Tracer = ot_ctx:get(ot_ctx_pdict, ?CURRENT_TRACER, ?tracer),
     Tracer:get_http_text_format().

--- a/src/ot_tracer_default.erl
+++ b/src/ot_tracer_default.erl
@@ -54,28 +54,28 @@ setup(Opts) ->
 
 -spec start_span(opentelemetry:span_name(), ot_span:start_opts()) -> opentelemetry:span_ctx().
 start_span(Name, Opts) ->
-    case ?ctx:get(?SPAN_CTX) of
+    case ot_ctx:get(?ctx, ?SPAN_CTX) of
         {SpanCtx, _}=Ctx ->
-            SpanCtx1 = ?span:start_span(Name, Opts#{parent => SpanCtx}),
-            ?ctx:with_value(?SPAN_CTX, {SpanCtx1, Ctx}),
+            SpanCtx1 = ot_span:start_span(?span, Name, Opts#{parent => SpanCtx}),
+            ot_ctx:with_value(?ctx, ?SPAN_CTX, {SpanCtx1, Ctx}),
             SpanCtx1;
         _ ->
-            SpanCtx = ?span:start_span(Name, Opts#{parent => undefined}),
-            ?ctx:with_value(?SPAN_CTX, {SpanCtx, undefined}),
+            SpanCtx = ot_span:start_span(?span, Name, Opts#{parent => undefined}),
+            ot_ctx:with_value(?ctx, ?SPAN_CTX, {SpanCtx, undefined}),
             SpanCtx
     end.
 
 -spec with_span(opentelemetry:span_ctx()) -> ok.
 with_span(SpanCtx) ->
-    ?ctx:with_value(?SPAN_CTX, {SpanCtx, undefined}).
+    ot_ctx:with_value(?ctx, ?SPAN_CTX, {SpanCtx, undefined}).
 
 -spec with_span(opentelemetry:span_ctx(), fun()) -> ok.
 with_span(SpanCtx, Fun) ->
-    ?ctx:with_value(?SPAN_CTX, {SpanCtx, undefined}, Fun).
+    ot_ctx:with_value(?ctx, ?SPAN_CTX, {SpanCtx, undefined}, Fun).
 
 -spec current_span_ctx() -> opentelemetry:span_ctx().
 current_span_ctx() ->
-    case ?ctx:get(?SPAN_CTX) of
+    case ot_ctx:get(?ctx, ?SPAN_CTX) of
         {SpanCtx, _ParentPdictSpanCtx} ->
             SpanCtx;
         _ ->
@@ -87,7 +87,7 @@ current_span_ctx() ->
 %% parent trace context, which contains its parent and so on.
 -spec current_ctx() -> pdict_trace_ctx().
 current_ctx() ->
-    ?ctx:get(?SPAN_CTX).
+    ot_ctx:get(?ctx, ?SPAN_CTX).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -98,8 +98,8 @@ current_ctx() ->
 -spec finish() -> ok.
 finish() ->
     {SpanCtx, ParentCtx} = current_ctx(),
-    ?span:finish_span(SpanCtx),
-    ?ctx:with_value(?SPAN_CTX, ParentCtx),
+    ot_span:finish_span(?span, SpanCtx),
+    ot_ctx:with_value(?ctx, ?SPAN_CTX, ParentCtx),
     ok.
 
 -spec get_binary_format() -> binary().


### PR DESCRIPTION
This will make changing the scope of the handlers behaviours easier.
I.e. currently this removes 2 required behaviour callbacks from
the ot_ctx as it can be easily implemented as shared implementation.