### PR TITLE
fix probability sampler

### DIFF
--- a/src/ot_sampler.erl
+++ b/src/ot_sampler.erl
@@ -29,7 +29,7 @@
 -type sampling_result() :: {sampling_decision(), opentelemetry:attributes()}.
 -type sampler() :: fun((opentelemetry:trace_id(),
                         opentelemetry:span_id(),
-                        opentelemetry:span_ctx(),
+                        opentelemetry:span_ctx() | undefined,
                         sampling_hint(),
                         opentelemetry:links(),
                         opentelemetry:span_name(),

--- a/src/ot_span_utils.erl
+++ b/src/ot_span_utils.erl
@@ -59,8 +59,16 @@ new_span(Name, Parent=#span_ctx{trace_id=TraceId,
     SpanId = opentelemetry:generate_span_id(),
     SpanCtx = Parent#span_ctx{span_id=SpanId},
 
-    {TraceFlags, IsRecorded, SamplerAttributes} = sample(Sampler, TraceId, SpanId, Parent,
-                                                         SamplingHint, Links, Name, Kind, Attributes),
+    {TraceFlags, IsRecorded, SamplerAttributes} =
+        sample(
+          Sampler, TraceId, SpanId,
+          case Parent of
+              #span_ctx{span_id=undefined} ->
+                  undefined;
+              _ ->
+                  Parent
+          end,
+          SamplingHint, Links, Name, Kind, Attributes),
     
     Span = #span{trace_id=TraceId,
                  span_id=SpanId,

--- a/test/opentelemetry_SUITE.erl
+++ b/test/opentelemetry_SUITE.erl
@@ -27,6 +27,7 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_group(CtxModule, Config) ->
+    application:set_env(opentelemetry, sampler, {probability, #{probability => 1.0}}),
     application:set_env(opentelemetry, tracer, {ot_tracer_default, #{span => {ot_span_ets, []},
                                                                      ctx => {CtxModule, []}}}),
     application:set_env(opentelemetry, exporter, [{exporters, []},


### PR DESCRIPTION
the probability sampler does not work as expected, because when starting a new span, a span_ctx is passed to sampler as parent instead of undefined.