### PR TITLE
fix probability sampler

### DIFF
--- a/src/ot_sampler.erl
+++ b/src/ot_sampler.erl
@@ -29,7 +29,7 @@
 -type sampling_result() :: {sampling_decision(), opentelemetry:attributes()}.
 -type sampler() :: fun((opentelemetry:trace_id(),
                         opentelemetry:span_id(),
-                        opentelemetry:span_ctx(),
+                        opentelemetry:span_ctx() | undefined,
                         sampling_hint(),
                         opentelemetry:links(),
                         opentelemetry:span_name(),

--- a/src/ot_span_utils.erl
+++ b/src/ot_span_utils.erl
@@ -59,8 +59,14 @@ new_span(Name, Parent=#span_ctx{trace_id=TraceId,
     SpanId = opentelemetry:generate_span_id(),
     SpanCtx = Parent#span_ctx{span_id=SpanId},
 
-    {TraceFlags, IsRecorded, SamplerAttributes} = sample(Sampler, TraceId, SpanId, Parent,
-                                                         SamplingHint, Links, Name, Kind, Attributes),
+    {TraceFlags, IsRecorded, SamplerAttributes} =
+        sample(Sampler, TraceId, SpanId, case Parent of
+                                             #span_ctx{span_id=undefined} ->
+                                                 undefined;
+                                             _ ->
+                                                 Parent
+                                         end,
+               SamplingHint, Links, Name, Kind, Attributes),
     
     Span = #span{trace_id=TraceId,
                  span_id=SpanId,


### PR DESCRIPTION
a parent span context with span id of 'undefined' must be passed
as the atom 'undefined' to the sampler for the logic to work. This
patch updates the typespec for samplers to reflect this.