### PR TITLE
make sampler funs fully qualified

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 {deps, [{wts, "~> 0.3"},
         {opentelemetry_api, {git, "https://github.com/tsloughter/opentelemetry-erlang-api",
-                             {branch, "otep-66"}}}]}.
+                             {branch, "fq-funs"}}}]}.
 
 {shell, [{apps, [opentelemetry]},
          {config, "config/sys.config"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"opentelemetry_api">>,
   {git,"https://github.com/tsloughter/opentelemetry-erlang-api",
-       {ref,"f0d91bb3b1964484426051a483da8ddefd40a1aa"}},
+       {ref,"39664e7c180d58ca27d8485f5a05c5711473f1dc"}},
   0},
  {<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.9.0">>},1},
  {<<"wts">>,{pkg,<<"wts">>,<<"0.3.0">>},0}]}.

--- a/src/ot_sampler.erl
+++ b/src/ot_sampler.erl
@@ -19,7 +19,11 @@
 %%%-------------------------------------------------------------------------
 -module(ot_sampler).
 
--export([setup/2]).
+-export([setup/2,
+         always_on/9,
+         always_off/9,
+         always_parent/9,
+         probability/9]).
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include("ot_sampler.hrl").
@@ -27,14 +31,15 @@
 -type sampling_decision() :: ?NOT_RECORD | ?RECORD | ?RECORD_AND_PROPAGATE.
 -type sampling_hint() :: sampling_decision() | undefined.
 -type sampling_result() :: {sampling_decision(), opentelemetry:attributes()}.
--type sampler() :: fun((opentelemetry:trace_id(),
-                        opentelemetry:span_id(),
-                        opentelemetry:span_ctx() | undefined,
-                        sampling_hint(),
-                        opentelemetry:links(),
-                        opentelemetry:span_name(),
-                        opentelemetry:kind(),
-                        opentelemetry:attributes()) -> sampling_result()).
+-type sampler() :: {fun((opentelemetry:trace_id(),
+                         opentelemetry:span_id(),
+                         opentelemetry:span_ctx() | undefined,
+                         sampling_hint(),
+                         opentelemetry:links(),
+                         opentelemetry:span_name(),
+                         opentelemetry:kind(),
+                         opentelemetry:attributes(),
+                         term()) -> sampling_result()), term()}.
 -export_type([sampling_result/0,
               sampling_decision/0,
               sampler/0]).
@@ -47,21 +52,13 @@
 
 -spec setup(atom() | module(), map()) -> sampler().
 setup(always_on, _Opts) ->
-    fun(_TraceId, _SpanId, _SpanCtx, _SamplingHint, _Links, _SpanName, _Kind, _Attributes) ->
-            {?RECORD_AND_PROPAGATE, []}
-    end;
+    {fun ?MODULE:always_on/9, []};
 setup(always_off, _Opts) ->
-    fun(_TraceId, _SpanId, _SpanCtx, _SamplingHint, _Links, _SpanName, _Kind, _Attributes) ->
-            {?NOT_RECORD, []}
-    end;
+    {fun ?MODULE:always_off/9, []};
 setup(always_parent, _Opts) ->
-    fun(_, _, #span_ctx{trace_flags=TraceFlags}, _, _, _, _, _) when ?IS_SPAN_ENABLED(TraceFlags) ->
-            {?RECORD_AND_PROPAGATE, []};
-       (_, _, _, _, _, _, _, _) ->
-            {?NOT_RECORD, []}
-    end;
+    {fun ?MODULE:always_parent/9, []};
 setup(probability, Opts) ->
-    IdUpperBound = 
+    IdUpperBound =
         case maps:get(probability, Opts, ?DEFAULT_PROBABILITY) of
             P when P =:= 0.0 ->
                 0;
@@ -76,34 +73,56 @@ setup(probability, Opts) ->
     IgnoreParentFlag = maps:get(ignore_parent_flag, Opts, false),
     OnlyRoot = maps:get(only_root_spans, Opts, true),
 
-    fun(TraceId, _SpanId, Parent, SamplingHint, _Links, _SpanName, _Kind, _Attributes) when
-              IgnoreParentFlag =:= true orelse Parent =:= undefined ->
-            case ?IGNORE_HINT(SamplingHint, IgnoreHints) of
-                true ->
-                    {do_probability_sample(TraceId, IdUpperBound), []};
-                false ->
-                    {SamplingHint, []}
-            end;
-       (_, _, #span_ctx{trace_flags=TraceFlags}, _, _, _, _, _) when ?IS_SPAN_ENABLED(TraceFlags) ->
-            {?RECORD_AND_PROPAGATE, []};
-       (TraceId, _, #span_ctx{is_remote=IsRemote}, SamplingHint, _, _, _, _) ->
-            case SamplingHint =:= ?RECORD_AND_PROPAGATE
-                andalso not(lists:member(SamplingHint, IgnoreHints)) of
-                true ->
-                    {?RECORD_AND_PROPAGATE, []};
-                false ->
-                    case OnlyRoot =:= false andalso IsRemote =:= true
-                        andalso do_probability_sample(TraceId, IdUpperBound) of
-                        ?RECORD_AND_PROPAGATE ->
-                            {?RECORD_AND_PROPAGATE, []};
-                        _ ->
-                            %% sampling hint could still be ?RECORD
-                            maybe_sampling_hint(SamplingHint, IgnoreHints)
-                    end
-            end
-    end;
+    {fun ?MODULE:probability/9, {IdUpperBound, IgnoreHints, IgnoreParentFlag, OnlyRoot}};
 setup(Sampler, Opts) ->
     Sampler:setup(Opts).
+
+always_on(_TraceId, _SpanId, _SpanCtx, _SamplingHint, _Links, _SpanName, _Kind, _Attributes, _Opts) ->
+    {?RECORD_AND_PROPAGATE, []}.
+
+always_off(_TraceId, _SpanId, _SpanCtx, _SamplingHint, _Links, _SpanName, _Kind, _Attributes, _Opts) ->
+    {?NOT_RECORD, []}.
+
+always_parent(_, _, #span_ctx{trace_flags=TraceFlags}, _, _, _, _, _, _) when ?IS_SPAN_ENABLED(TraceFlags) ->
+    {?RECORD_AND_PROPAGATE, []};
+always_parent(_, _, _, _, _, _, _, _, _) ->
+    {?NOT_RECORD, []}.
+
+probability(TraceId, _, Parent, SamplingHint, _, _, _, _, {IdUpperBound,
+                                                           IgnoreHints,
+                                                           IgnoreParentFlag,
+                                                           _OnlyRoot})
+  when IgnoreParentFlag =:= true orelse Parent =:= undefined ->
+    case ?IGNORE_HINT(SamplingHint, IgnoreHints) of
+        true ->
+            {do_probability_sample(TraceId, IdUpperBound), []};
+        false ->
+            {SamplingHint, []}
+    end;
+probability(_, _, #span_ctx{trace_flags=TraceFlags}, _, _, _, _, _, {_IdUpperBound,
+                                                                     _IgnoreHints,
+                                                                     _IgnoreParentFlag,
+                                                                     _OnlyRoot})
+  when ?IS_SPAN_ENABLED(TraceFlags) ->
+    {?RECORD_AND_PROPAGATE, []};
+probability(TraceId, _, #span_ctx{is_remote=IsRemote}, SamplingHint, _, _, _, _, {IdUpperBound,
+                                                                                  IgnoreHints,
+                                                                                  _IgnoreParentFlag,
+                                                                                  OnlyRoot}) ->
+    case SamplingHint =:= ?RECORD_AND_PROPAGATE
+        andalso not(lists:member(SamplingHint, IgnoreHints)) of
+        true ->
+            {?RECORD_AND_PROPAGATE, []};
+        false ->
+            case OnlyRoot =:= false andalso IsRemote =:= true
+                andalso do_probability_sample(TraceId, IdUpperBound) of
+                ?RECORD_AND_PROPAGATE ->
+                    {?RECORD_AND_PROPAGATE, []};
+                _ ->
+                    %% sampling hint could still be ?RECORD
+                    maybe_sampling_hint(SamplingHint, IgnoreHints)
+            end
+    end.
 
 maybe_sampling_hint(SamplingHint, IgnoreHints) ->
     case ?IGNORE_HINT(SamplingHint, IgnoreHints) of

--- a/src/ot_span_utils.erl
+++ b/src/ot_span_utils.erl
@@ -97,9 +97,9 @@ end_span(Span) ->
 
 %%
 
-sample(Sampler, TraceId, SpanId, Parent, SamplingHint, Links, SpanName, Kind, Attributes) ->
+sample({Sampler, Opts}, TraceId, SpanId, Parent, SamplingHint, Links, SpanName, Kind, Attributes) ->
     {Decision, Attributes} = Sampler(TraceId, SpanId, Parent, SamplingHint, 
-                                     Links, SpanName, Kind, Attributes),
+                                     Links, SpanName, Kind, Attributes, Opts),
     case Decision of
         ?NOT_RECORD ->
             {0, false, Attributes};


### PR DESCRIPTION
important for being able to run upgrades. without fully qualified
functions the funs will eventually become badfuns after the
third module reload.

---

Will need to do this for the other uses of anonymous functions, like propagation, but starting with samplers.