### PR TITLE
W3C interop tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,22 @@ If an Elixir script is wanted for the benchmarks they could be run like:
 $ ERL_LIBS=_build/bench/lib/ mix run --no-mix-exs samples/run.exs
 ```
 
+## W3C Trace Context Interop Tests
+
+Start the interop web server in a shell:
+
+``` shell
+$ rebar3 as interop shell
+
+> w3c_trace_context_interop:run().
+```
+
+Then, clone the [W3C Trace Context repo](https://github.com/w3c/trace-context) and run the tests:
+
+``` shell
+$ cd test
+$ python3 test.py http://127.0.0.1:5000/test
+```
+
 ## Contributing
 

--- a/interop/w3c_trace_context_interop.erl
+++ b/interop/w3c_trace_context_interop.erl
@@ -1,0 +1,62 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%-----------------------------------------------------------------------
+-module(w3c_trace_context_interop).
+
+-export([run/0,
+         do/1]).
+
+-include_lib("inets/include/httpd.hrl").
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
+
+run() ->
+    {ok, _Pid} = inets:start(httpd, [{port, 5000},
+                                     {server_root, "/tmp"},
+                                     {document_root, "/tmp"},
+                                     {server_name, "trace_context_interop"},
+                                     {bind_address, "localhost"},
+                                     {modules, [?MODULE]}]),
+    ok.
+
+do(Req) ->
+    Body = Req#mod.entity_body,
+
+    %% inets gives headers in the reverse order they came in
+    Headers = headers_to_binary(lists:reverse(Req#mod.parsed_header)),
+    List = jsone:decode(list_to_binary(Body)),
+
+    lists:foreach(fun(#{<<"arguments">> := Arguments,
+                        <<"url">> := Url}) ->
+                          ot_propagation:http_extract(Headers),
+                          otel:start_span(<<"interop-test">>),
+                          InjectedHeaders = ot_propagation:http_inject([]),
+                          httpc:request(post, {binary_to_list(Url),
+                                               headers_to_list(InjectedHeaders),
+                                               "application/json",
+                                               jsone:encode(Arguments)}, [], [{body_format, binary}]),
+                          otel:end_span()
+                  end, List),
+
+    {proceed, [{response, {200, "ok"}}]}.
+
+%%
+
+headers_to_binary(Headers) ->
+    [{list_to_binary(K), list_to_binary(V)} || {K, V} <- Headers].
+
+headers_to_list(Headers) ->
+    [{binary_to_list(K), binary_to_list(iolist_to_binary(V))} || {K, V} <- Headers].

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 {deps, [{wts, "~> 0.3"},
-        {opentelemetry_api, {git, "https://github.com/tsloughter/opentelemetry-erlang-api",
-                             {branch, "fq-funs"}}}]}.
+        {opentelemetry_api, {git, "https://github.com/open-telemetry/opentelemetry-erlang-api",
+                             {branch, "master"}}}]}.
 
 {shell, [{apps, [opentelemetry]},
          {config, "config/sys.config"}]}.
@@ -11,6 +11,9 @@
 {profiles,
  [{test, [{erl_opts, [nowarn_export_all]},
           {ct_opts, [{ct_hooks, [cth_surefire]}]}]},
+
+  {interop, [{deps, [jsone]},
+             {extra_src_dirs, ["interop"]}]},
 
   {bench, [{deps, [benchee]},
            {extra_src_dirs, ["samples"]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"opentelemetry_api">>,
-  {git,"https://github.com/tsloughter/opentelemetry-erlang-api",
-       {ref,"39664e7c180d58ca27d8485f5a05c5711473f1dc"}},
+  {git,"https://github.com/open-telemetry/opentelemetry-erlang-api",
+       {ref,"12cbbd265997aa2e8231f18de8d7574fe67a8f37"}},
   0},
  {<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.9.0">>},1},
  {<<"wts">>,{pkg,<<"wts">>,<<"0.3.0">>},0}]}.

--- a/src/opentelemetry_app.erl
+++ b/src/opentelemetry_app.erl
@@ -27,13 +27,13 @@ start(_StartType, _StartArgs) ->
 
     {BaggageHttpExtractor, BaggageHttpInjector} = ot_baggage:get_http_propagators(),
     {CorrelationsHttpExtractor, CorrelationsHttpInjector} = ot_correlations:get_http_propagators(),
-    {B3HttpExtractor, B3HttpInjector} = ot_tracer_default:b3_propagators(),
+    {W3CHttpExtractor, W3CHttpInjector} = ot_tracer_default:w3c_propagators(),
     opentelemetry:set_http_extractor([BaggageHttpExtractor,
                                       CorrelationsHttpExtractor,
-                                      B3HttpExtractor]),
+                                      W3CHttpExtractor]),
     opentelemetry:set_http_injector([BaggageHttpInjector,
                                      CorrelationsHttpInjector,
-                                     B3HttpInjector]),
+                                     W3CHttpInjector]),
 
     opentelemetry_sup:start_link(Opts).
 

--- a/src/ot_span_sweeper.erl
+++ b/src/ot_span_sweeper.erl
@@ -33,6 +33,7 @@
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include("ot_span_ets.hrl").
+-include("ot_tracer.hrl").
 -include_lib("kernel/include/logger.hrl").
 
 -record(data, {interval :: integer() | infinity,
@@ -161,6 +162,5 @@ expired_match_spec(Time, Return) ->
 end_span(Span=#span{tracestate=Tracestate}) ->
     %% hack to not lose tracestate when ending without span ctx
     Span1 = ot_span_utils:end_span(Span#span{tracestate=Tracestate}),
-    Tracer = opentelemetry:get_tracer(),
-    Processors = ot_tracer_default:on_end(Tracer),
+    {_, #tracer{on_end_processors=Processors}} = opentelemetry:get_tracer(),
     Processors(Span1).

--- a/src/ot_tracer.hrl
+++ b/src/ot_tracer.hrl
@@ -7,6 +7,7 @@
                  module :: module(),
                  span_module :: module(),
                  ctx_module :: module(),
-                 processors :: [{module(), term()}],
+                 on_start_processors :: fun((opentelemetry:span()) -> opentelemetry:span()),
+                 on_end_processors :: fun((opentelemetry:span()) -> boolean() | {error, term()}),
                  sampler :: ot_sampler:sampler(),
                  resource :: term() | undefined}).

--- a/src/ot_tracer_server.erl
+++ b/src/ot_tracer_server.erl
@@ -44,7 +44,8 @@ init(Opts) ->
 
     Tracer = #tracer{module=ot_tracer_default,
                      sampler=SamplerFun,
-                     processors=Processors,
+                     on_start_processors=on_start(Processors),
+                     on_end_processors=on_end(Processors),
                      span_module=ot_span_ets,
                      ctx_module=ot_ctx_pdict},
     opentelemetry:set_default_tracer({ot_tracer_default, Tracer}),
@@ -60,3 +61,11 @@ handle_call(_Msg, _From, State) ->
 
 handle_cast(_Msg, State) ->
     {noreply, State}.
+
+%%
+
+on_start(Processors) ->
+    fun(Span) -> [P:on_start(Span, Config) || {P, Config} <- Processors] end.
+
+on_end(Processors) ->
+    fun(Span) -> [P:on_end(Span, Config) || {P, Config} <- Processors] end.


### PR DESCRIPTION
Currently not a part of the CI. I was planning to do something like `rebar3 as interop shell -s w3c_trace_context_interop run` but that isn't an option currently, so it is manual.

Second commit moves the creation of the on_span/on_end function to the creation of the tracer instead of doing it every time they are needed.