### PR TITLE
support being a transient or temporary app by resetting to noops

### DIFF
--- a/src/opentelemetry_app.erl
+++ b/src/opentelemetry_app.erl
@@ -20,6 +20,7 @@
 -behaviour(application).
 
 -export([start/2,
+         prep_stop/1,
          stop/1]).
 
 start(_StartType, _StartArgs) ->
@@ -31,6 +32,16 @@ start(_StartType, _StartArgs) ->
     setup_http_propagators(Opts),
 
     opentelemetry_sup:start_link(Opts).
+
+%% called before the supervision tree is shutdown.
+prep_stop(_State) ->
+    %% on application stop set context manager and tracer to the
+    %% noop implementations. This is to ensure no crashes if the
+    %% sdk isn't the last thing to shutdown or if the opentelemetry
+    %% application crashed.
+    opentelemetry:set_default_context_manager({ot_ctx_noop, []}),
+    opentelemetry:set_default_tracer({ot_tracer_noop, []}),
+    ok.
 
 stop(_State) ->
     ok.


### PR DESCRIPTION
This is particularly important so that the application can be configured as `temporary` or `transient` in the release and either manually disabled or if it crashes allow the release to continue operating fine.