### PR TITLE
Updates for OTEP 66

### DIFF
--- a/src/ot_propagation_http_b3.erl
+++ b/src/ot_propagation_http_b3.erl
@@ -47,16 +47,15 @@ inject(_, #tracer_ctx{active=#span_ctx{trace_id=TraceId,
 inject(_, undefined) ->
     [].
 
--spec extract(ot_propagation:http_headers(), term()) -> tracer_ctx() | undefined.
+-spec extract(ot_propagation:http_headers(), term()) -> opentelemetry:span_ctx() | undefined.
 extract(Headers, _) when is_list(Headers) ->
     try
         TraceId = trace_id(Headers),
         SpanId = span_id(Headers),
         Sampled = lookup(?B3_SAMPLED, Headers),
-        #tracer_ctx{active=#span_ctx{trace_id=string_to_integer(TraceId, 16),
-                                     span_id=string_to_integer(SpanId, 16),
-                                     trace_flags=case Sampled of True when ?IS_SAMPLED(True) -> 1; _ -> 0 end},
-                    parent=undefined}
+        #span_ctx{trace_id=string_to_integer(TraceId, 16),
+                  span_id=string_to_integer(SpanId, 16),
+                  trace_flags=case Sampled of True when ?IS_SAMPLED(True) -> 1; _ -> 0 end}
     catch
         throw:invalid ->
             undefined;

--- a/src/ot_propagation_http_w3c.erl
+++ b/src/ot_propagation_http_w3c.erl
@@ -67,7 +67,7 @@ encode_tracestate(#span_ctx{tracestate=Entries}) ->
     StateHeaderValue = lists:join($,, [[Key, $=, Value] || {Key, Value} <- Entries]),
     [{?STATE_HEADER_KEY, StateHeaderValue}].
 
--spec extract(ot_propagation:http_headers(), term()) -> tracer_ctx() | undefined.
+-spec extract(ot_propagation:http_headers(), term()) -> opentelemetry:span_ctx()| undefined.
 extract(Headers, _) when is_list(Headers) ->
     case header_take(?HEADER_KEY, Headers) of
         [{_, Value} | RestHeaders] ->
@@ -81,8 +81,7 @@ extract(Headers, _) when is_list(Headers) ->
                             undefined;
                         SpanCtx ->
                             Tracestate = tracestate_from_headers(Headers),
-                            #tracer_ctx{active=SpanCtx#span_ctx{tracestate=Tracestate},
-                                        parent=undefined}
+                            SpanCtx#span_ctx{tracestate=Tracestate}
                     end
             end;
         _ ->

--- a/src/ot_tracer.hrl
+++ b/src/ot_tracer.hrl
@@ -1,8 +1,3 @@
--define(SPAN_CTX, {ot_tracer_default, span_ctx}).
--define(CTX_IMPL_KEY, {ot_tracer_default, ctx}).
-
--define(ctx, (persistent_term:get(?CTX_IMPL_KEY))).
-
 -record(tracer, {name :: unicode:unicode_binary() | undefined,
                  module :: module(),
                  span_module :: module(),


### PR DESCRIPTION
This brings the implementation of OTEP 66 (https://github.com/open-telemetry/oteps/pull/66) into line with the latest, and soon to be merged, design. Now propagated context is kept in a separate variable. This is especially good so there isn't the possibility to end local span and end up then updating/ending what is actually a remote span: https://github.com/open-telemetry/oteps/blob/3f5ef37f28a0a38a252c3c6b669f42c2dcb7ef79/text/0066-separate-context-propagation.md#extract