### PR TITLE
register named tracers and add library_resource to tracer/spans

### DIFF
--- a/include/ot_sampler.hrl
+++ b/include/ot_sampler.hrl
@@ -1,3 +1,21 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%-------------------------------------------------------------------------
+
 -define(NOT_RECORD, not_record).
 -define(RECORD, record).
 -define(RECORD_AND_PROPAGATE, record_and_propagate).

--- a/include/ot_span.hrl
+++ b/include/ot_span.hrl
@@ -1,0 +1,71 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%-------------------------------------------------------------------------
+
+-record(library_resource, {name    :: atom() | undefined,
+                           version :: string() | undefined}).
+
+-record(span, {
+          %% 128 bit int trace id
+          trace_id                                :: opentelemetry:trace_id() | undefined,
+
+          %% 64 bit int span id
+          span_id                                 :: opentelemetry:span_id() | undefined,
+
+          tracestate                              :: opentelemetry:tracestate() | undefined,
+
+          %% 64 bit int parent span
+          parent_span_id                          :: opentelemetry:span_id() | undefined,
+
+          %% name of the span
+          name                                    :: unicode:unicode_binary(),
+
+          %% Distinguishes between spans generated in a particular context. For example,
+          %% two spans with the same name may be distinguished using `CLIENT` (caller)
+          %% and `SERVER` (callee) to identify queueing latency associated with the span.status
+          kind                                    :: opentelemetry:span_kind() | undefined,
+
+          start_time                              :: wts:timestamp(),
+          end_time                                :: wts:timestamp() | undefined,
+
+          %% A set of attributes on the span.
+          %% Kept as a list so ets:select_replace/2 can be used to add new elements
+          attributes = []                         :: opentelemetry:attributes() | undefined,
+
+          %% A time-stamped event in the Span.
+          timed_events = []                       :: opentelemetry:timed_events(),
+
+          %% links to spans in other traces
+          links = []                              :: opentelemetry:links(),
+
+          %% An optional final status for this span.
+          status                                  :: opentelemetry:status() | undefined,
+
+          %% An optional number of child spans that were generated while this span
+          %% was active. If set, allows implementation to detect missing child spans.
+          child_span_count = undefined            :: integer() | undefined,
+
+          %% 8-bit integer, lowest bit is if it is sampled
+          trace_options = 1                       :: integer() | undefined,
+
+          %% this field is not propagated and is only here as an implementation optimization
+          %% If true updates like adding events are done on the span. The same as if the
+          %% trace flags lowest bit is 1 but simply not propagated.
+          is_recorded                             :: boolean() | undefined,
+
+          library_resource                        :: ot_tracer_server:library_resource()
+         }).

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,9 @@
 {"1.1.0",
-[{<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.9.0">>},1},
+[{<<"opentelemetry_api">>,
+  {git,"https://github.com/open-telemetry/opentelemetry-erlang-api",
+       {ref,"e00b63595155436c5f69fd5fa63495ebb1dab128"}},
+  0},
+ {<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.9.0">>},1},
  {<<"wts">>,{pkg,<<"wts">>,<<"0.3.0">>},0}]}.
 [
 {pkg_hash,[

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,9 +1,5 @@
 {"1.1.0",
-[{<<"opentelemetry_api">>,
-  {git,"https://github.com/open-telemetry/opentelemetry-erlang-api",
-       {ref,"a93505140cc23fa76e5f7450564dd55382a4f9ee"}},
-  0},
- {<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.9.0">>},1},
+[{<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.9.0">>},1},
  {<<"wts">>,{pkg,<<"wts">>,<<"0.3.0">>},0}]}.
 [
 {pkg_hash,[

--- a/src/opentelemetry.app.src
+++ b/src/opentelemetry.app.src
@@ -12,6 +12,11 @@
   {env, [{sampler, {always_on, #{}}},
          {propagators, [fun ot_correlations:get_http_propagators/0,
                         fun ot_tracer_default:w3c_propagators/0]},
+
+         %% list of disabled tracers
+         {deny_list, []},
+
+         %% list of span processors
          {processors, [%% #{id => my_processor,
                        %%   module => ot_batch_processor,
                        %%   config => #{}}

--- a/src/opentelemetry_sup.erl
+++ b/src/opentelemetry_sup.erl
@@ -35,11 +35,11 @@ init([Opts]) ->
 
     %% configuration server
     TracerServer = #{id => ot_tracer_server,
-                     start => {ot_tracer_server, start_link, [Opts]},
+                     start => {ot_tracer_provider, start_link, [ot_tracer_server, Opts]},
                      restart => permanent,
                      shutdown => 5000,
                      type => worker,
-                     modules => [ot_tracer_server]},
+                     modules => [ot_tracer_provider, ot_tracer_server]},
 
     Processors = proplists:get_value(processors, Opts, []),
     BatchProcessorOpts = proplists:get_value(ot_batch_processor, Processors, []),

--- a/src/ot_batch_processor.erl
+++ b/src/ot_batch_processor.erl
@@ -46,6 +46,7 @@
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include_lib("kernel/include/logger.hrl").
+-include("ot_span.hrl").
 
 %% behaviour for exporters to implement
 -type opts() :: term().

--- a/src/ot_sampler.erl
+++ b/src/ot_sampler.erl
@@ -27,6 +27,7 @@
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include("ot_sampler.hrl").
+-include("ot_span.hrl").
 
 -type sampling_decision() :: ?NOT_RECORD | ?RECORD | ?RECORD_AND_PROPAGATE.
 -type sampling_hint() :: sampling_decision() | undefined.

--- a/src/ot_span_ets.erl
+++ b/src/ot_span_ets.erl
@@ -26,8 +26,8 @@
          handle_call/3,
          handle_cast/2]).
 
--export([start_span/2,
-         start_span/3,
+-export([start_span/3,
+         start_span/4,
          end_span/1,
          end_span/2,
          get_ctx/1,
@@ -40,6 +40,8 @@
          update_name/2]).
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
+-include("ot_tracer.hrl").
+-include("ot_span.hrl").
 -include("ot_span_ets.hrl").
 
 -record(state, {}).
@@ -47,13 +49,14 @@
 start_link(Opts) ->
     gen_server:start_link(?MODULE, Opts, []).
 
-start_span(Name, Opts) ->
-    start_span(Name, Opts, fun(Span) -> Span end).
+start_span(Name, Opts, LibraryResource) ->
+    start_span(Name, Opts, fun(Span) -> Span end, LibraryResource).
 
 %% @doc Start a span and insert into the active span ets table.
--spec start_span(opentelemetry:span_name(), ot_span:start_opts(), fun()) -> opentelemetry:span_ctx().
-start_span(Name, Opts, Processors) ->
-    {SpanCtx, Span} = ot_span_utils:start_span(Name, Opts),
+-spec start_span(opentelemetry:span_name(), ot_span:start_opts(), fun(), ot_tracer_server:library_resource())
+                -> opentelemetry:span_ctx().
+start_span(Name, Opts, Processors, LibraryResource) ->
+    {SpanCtx, Span} = ot_span_utils:start_span(Name, Opts, LibraryResource),
     Span1 = Processors(Span),
     _ = storage_insert(Span1),
     SpanCtx.

--- a/src/ot_span_sweeper.erl
+++ b/src/ot_span_sweeper.erl
@@ -34,6 +34,7 @@
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include("ot_span_ets.hrl").
 -include("ot_tracer.hrl").
+-include("ot_span.hrl").
 -include_lib("kernel/include/logger.hrl").
 
 -record(data, {interval :: integer() | infinity,

--- a/src/ot_tracer.hrl
+++ b/src/ot_tracer.hrl
@@ -1,11 +1,13 @@
--record(tracer, {name :: unicode:unicode_binary() | undefined,
-                 module :: module(),
+
+-record(tracer, {module :: module(),
                  span_module :: module(),
                  ctx_module :: module(),
                  on_start_processors :: fun((opentelemetry:span()) -> opentelemetry:span()),
                  on_end_processors :: fun((opentelemetry:span()) -> boolean() | {error, term()}),
                  sampler :: ot_sampler:sampler(),
+                 library_resource :: ot_tracer_server:library_resource() | undefined,
                  resource :: term() | undefined}).
+-type tracer() :: #tracer{}.
 
 -record(tracer_ctx, {active :: opentelemetry:span_ctx() | undefined,
                      parent :: #tracer_ctx{} | undefined}).

--- a/src/ot_tracer_default.erl
+++ b/src/ot_tracer_default.erl
@@ -52,8 +52,9 @@ maybe_set_sampler(_Tracer, Opts) when is_map_key(sampler, Opts) ->
 maybe_set_sampler({_, #tracer{sampler=Sampler}}, Opts) ->
     Opts#{sampler => Sampler}.
 
-start_span({_, #tracer{on_start_processors=Processors}}, Name, ParentTracerCtx, Opts) ->
-    SpanCtx1 = ot_span_ets:start_span(Name, Opts, Processors),
+start_span({_, #tracer{on_start_processors=Processors,
+                       library_resource=LibraryResource}}, Name, ParentTracerCtx, Opts) ->
+    SpanCtx1 = ot_span_ets:start_span(Name, Opts, Processors, LibraryResource),
     ot_ctx:set_value(?TRACER_KEY, ?SPAN_CTX, #tracer_ctx{active=SpanCtx1,
                                                          parent=ParentTracerCtx}),
     SpanCtx1.

--- a/test/ot_sweeper_SUITE.erl
+++ b/test/ot_sweeper_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 -include("ot_test_utils.hrl").
+-include("ot_span.hrl").
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 
 -include("../src/ot_span_ets.hrl").


### PR DESCRIPTION
This adds support for registering tracers. Registered tracers have a LibraryResource attached to them that is then put on each span created by that tracer.