### PR TITLE
lookup and update only the events or attributes changing in ot_span_ets

### DIFF
--- a/src/ot_span_ets.erl
+++ b/src/ot_span_ets.erl
@@ -98,11 +98,10 @@ set_attribute(#span_ctx{span_id=SpanId}, Key, Value) ->
 
 -spec set_attributes(opentelemetry:span_ctx(), opentelemetry:attributes()) -> boolean().
 set_attributes(#span_ctx{span_id=SpanId}, NewAttributes) ->
-    case ets:lookup(?SPAN_TAB, SpanId) of
-        [Span=#span{attributes=Attributes}] ->
-            Span1 = Span#span{attributes=Attributes++NewAttributes},
-            1 =:= ets:select_replace(?SPAN_TAB, [{Span, [], [{const, Span1}]}]);
-        _ ->
+    try ets:lookup_element(?SPAN_TAB, SpanId, #span.attributes) of
+        Attributes ->
+            ets:update_element(?SPAN_TAB, SpanId, {#span.attributes, Attributes++NewAttributes})
+    catch error:badarg ->
             false
     end.
 
@@ -114,11 +113,10 @@ add_event(SpanCtx, Name, Attributes) ->
 
 -spec add_events(opentelemetry:span_ctx(), opentelemetry:timed_events()) -> boolean().
 add_events(#span_ctx{span_id=SpanId}, NewTimedEvents) ->
-    case ets:lookup(?SPAN_TAB, SpanId) of
-        [Span=#span{timed_events=TimeEvents}] ->
-            Span1 = Span#span{timed_events=TimeEvents++NewTimedEvents},
-            1 =:= ets:select_replace(?SPAN_TAB, [{Span, [], [{const, Span1}]}]);
-        _ ->
+    try ets:lookup_element(?SPAN_TAB, SpanId, #span.timed_events) of
+        TimedEvents ->
+            ets:update_element(?SPAN_TAB, SpanId, {#span.timed_events, TimedEvents++NewTimedEvents})
+    catch error:badarg ->
             false
     end.
 

--- a/src/ot_span_ets.erl
+++ b/src/ot_span_ets.erl
@@ -96,6 +96,11 @@ is_recording_events(#span_ctx{is_recorded=IsRecorded}) ->
 set_attribute(#span_ctx{span_id=SpanId}, Key, Value) ->
     set_attributes(#span_ctx{span_id=SpanId}, [{Key, Value}]).
 
+%% Note: Spans are referenced through the current active span context in a process
+%% and thus modified only by a single process, so concurrent updates of the same field
+%% are not a real concern. This allows `add_events' and `set_attributes' to lookup and
+%% update only the specific element of the `span' without worrying about it having been
+%% changed by another process between the lookup and update.
 -spec set_attributes(opentelemetry:span_ctx(), opentelemetry:attributes()) -> boolean().
 set_attributes(#span_ctx{span_id=SpanId}, NewAttributes) ->
     try ets:lookup_element(?SPAN_TAB, SpanId, #span.attributes) of


### PR DESCRIPTION
We can save on copying by only looking up and updating the particular
element being changed, instead of looking up the whole span and doing
a compare and swap.

Spans are referenced through the current active span context and thus
modified only by a single process, so concurrent updates of the same
field are not a real concern.