### PR TITLE
metrics sdk first iteration

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
 {erl_opts, [debug_info]}.
 {deps, [{wts, "~> 0.4"},
-        {opentelemetry_api, {git, "https://github.com/tsloughter/opentelemetry-erlang-api",
-                             {branch, "metrics-api"}}}]}.
+        {opentelemetry_api,
+         {git, "https://github.com/open-telemetry/opentelemetry-erlang-api",
+          {branch, "master"}}}]}.
 
 {shell, [{apps, [opentelemetry]},
          {config, "config/sys.config"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 {deps, [{wts, "~> 0.4"},
-        {opentelemetry_api, {git, "https://github.com/open-telemetry/opentelemetry-erlang-api",
-                             {branch, "master"}}}]}.
+        {opentelemetry_api, {git, "https://github.com/tsloughter/opentelemetry-erlang-api",
+                             {branch, "metrics-api"}}}]}.
 
 {shell, [{apps, [opentelemetry]},
          {config, "config/sys.config"}]}.

--- a/src/opentelemetry_app.erl
+++ b/src/opentelemetry_app.erl
@@ -41,6 +41,7 @@ prep_stop(_State) ->
     %% application crashed.
     opentelemetry:set_default_context_manager({ot_ctx_noop, []}),
     opentelemetry:set_default_tracer({ot_tracer_noop, []}),
+    opentelemetry:set_default_meter({ot_meter_noop, []}),
     ok.
 
 stop(_State) ->

--- a/src/opentelemetry_sup.erl
+++ b/src/opentelemetry_sup.erl
@@ -41,6 +41,14 @@ init([Opts]) ->
                      type => worker,
                      modules => [ot_tracer_provider, ot_tracer_server]},
 
+    %%
+    MetricSup = #{id => ot_metric_sup,
+                  start => {ot_metric_sup, start_link, [Opts]},
+                  restart => permanent,
+                  shutdown => 5000,
+                  type => supervisor,
+                  modules => [ot_metric_sup]},
+
     Processors = proplists:get_value(processors, Opts, []),
     BatchProcessorOpts = proplists:get_value(ot_batch_processor, Processors, #{}),
     BatchProcessor = #{id => ot_batch_processor,
@@ -60,5 +68,6 @@ init([Opts]) ->
     %% `TracerServer' *must* start before the `BatchProcessor'
     %% `BatchProcessor' relies on getting the `Resource' from
     %% the `TracerServer' process
-    ChildSpecs = [TracerServer, BatchProcessor, SpanSup],
+    ChildSpecs = [MetricSup, TracerServer, BatchProcessor, SpanSup],
+
     {ok, {SupFlags, ChildSpecs}}.

--- a/src/ot_batch_processor.erl
+++ b/src/ot_batch_processor.erl
@@ -59,7 +59,7 @@
 %% spans that have been collected so far and the configuration returned in `init'.
 %% Do whatever needs to be done to export each span here, the caller will block
 %% until it returns.
--callback export(ets:tid(), opts()) -> ok | success | failed_not_retryable | failed_retryable.
+-callback export(ets:tab(), opts()) -> ok | success | failed_not_retryable | failed_retryable.
 
 -record(data, {exporter             :: {module(), term()} | undefined,
                resource             :: ot_resource:t(),

--- a/src/ot_exporter_stdout.erl
+++ b/src/ot_exporter_stdout.erl
@@ -27,6 +27,7 @@ init(_) ->
     {ok, []}.
 
 export(SpansTid, _Resource, _) ->
+    io:format("*SPANS FOR DEBUG*~n"),
     ets:foldl(fun(Span, _Acc) ->
                       io:format("~p~n", [Span])
               end, [], SpansTid),

--- a/src/ot_meter.hrl
+++ b/src/ot_meter.hrl
@@ -1,6 +1,7 @@
--record(meter, {module :: module(),
-                library_resource :: term() | undefined,
-                resource :: term() | undefined}).
+-record(meter, {module                  :: module(),
+                instrumentation_library :: ot_tracer_server:instrumentation_library() | undefined,
+                telemetry_library       :: ot_tracer_server:telemetry_library() | undefined,
+                resource                :: ot_resource:t() | undefined}).
 -type meter() :: #meter{}.
 
 -record(instrument, {name         :: ot_meter:name(),

--- a/src/ot_meter.hrl
+++ b/src/ot_meter.hrl
@@ -1,0 +1,32 @@
+-record(meter, {module :: module(),
+                library_resource :: term() | undefined,
+                resource :: term() | undefined}).
+-type meter() :: #meter{}.
+
+-record(instrument, {name         :: ot_meter:name(),
+                     description  :: ot_meter:description(),
+                     kind         :: ot_meter:metric_kind(),
+                     input_type   :: ot_meter:input_type(),
+                     mode         :: ot_meter:instrument_mode(),
+                     numeric_type :: atom(),
+                     label_keys   :: [atom()],
+                     unit         :: ot_meter:unit()}).
+-type instrument() :: #instrument{}.
+
+-type aggregator() :: module().
+
+-record(active_instrument, {key :: {ot_meter:name(), ot_meter:label_set()},
+                            instrument :: ot_meter:instrument(),
+                            aggregator :: aggregator(),
+                            checkpoint :: number() | undefined,
+                            current :: number() | {number(), integer()} | term()}).
+-type active_instrument() :: #active_instrument{}.
+
+-record(bound_instrument, {key :: {ot_meter:name(), ot_meter:label_set()},
+                           input_type   :: ot_meter:input_type(),
+                           aggregator :: aggregator()}).
+-type bound_instrument() :: #bound_instrument{} | unknown_instrument.
+
+-record(observer, {name       :: ot_meter:name(),
+                   instrument :: ot_observer:observer_instrument(),
+                   callback   :: ot_observer:callback()}).

--- a/src/ot_meter_default.erl
+++ b/src/ot_meter_default.erl
@@ -132,6 +132,11 @@ observe(_, _, _) ->
     ok.
 
 init(_Opts) ->
+    %% TODO: we do not want to lose instrument and observer tables ever
+    %% eventually need to have an heir to take them if this process crashes.
+    %% Another option is to just use persistent_term since these things
+    %% don't change after creation.
+
     %% ets table is required for other parts to not crash so we create
     %% it in init and not in a handle_continue or whatever else
     case ets:info(?TAB, name) of

--- a/src/ot_meter_default.erl
+++ b/src/ot_meter_default.erl
@@ -1,0 +1,184 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_meter_default).
+
+-behaviour(ot_meter).
+-behaviour(gen_server).
+
+-export([start_link/1,
+         new_instruments/2,
+         lookup_instrument/1,
+         record/4,
+         record_batch/3,
+
+         %% functions used for bound instruments
+         record/3,
+         bind/3,
+         release/2,
+
+         %% observer functions
+         observer_tab/0,
+         register_observer/3,
+         set_observer_callback/3,
+         observe/3]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2]).
+
+-include("ot_meter.hrl").
+
+-define(OBSERVER_TAB, ot_metric_accumulator_observers).
+
+-define(TAB, ?MODULE).
+
+-record(state, {}).
+
+start_link(Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Opts, []).
+
+-spec new_instruments(opentelemetry:meter(), [ot_meter:instrument_opts()]) -> boolean().
+new_instruments(_Meter, List) ->
+    gen_server:call(?MODULE, {new, List}).
+
+-spec record(opentelemetry:meter(), bound_instrument(), number()) -> ok.
+record(_Meter, unknown_instrument, Number) when is_number(Number) ->
+    ok;
+record(_Meter, BoundInstrument, Number) when is_number(Number) ->
+    _ = ot_metric_accumulator:record(BoundInstrument, Number),
+    ok;
+record(_, _, _) ->
+    ok.
+
+-spec record(opentelemetry:meter(), ot_meter:name(), ot_meter:label_set(), number()) -> ok.
+record(_Meter, Name, LabelSet, Number) when is_number(Number) ->
+    _ = ot_metric_accumulator:record(Name, LabelSet, Number),
+    ok;
+record(_, _, _, _) ->
+    ok.
+
+-spec record_batch(opentelemetry:meter(), [{ot_meter:name(), number()}], ot_meter:label_set()) -> ok.
+record_batch(_Meter, Measures, LabelSet) ->
+    [ot_metric_accumulator:record(Name, LabelSet, Number) || {Name, Number} <- Measures,  is_number(Number)],
+    ok.
+
+-spec release(opentelemetry:meter(), bound_instrument()) -> ok.
+release(_Meter, _BoundInstrument) ->
+    ok.
+
+-spec bind(opentelemetry:meter(), instrument() | ot_meter:name(), ot_meter:label_set())
+          -> bound_instrument().
+bind(_Meter, Instrument=#instrument{}, LabelSet) ->
+    bind_instrument(Instrument, LabelSet);
+bind(_Meter, Name, LabelSet) ->
+    case lookup_instrument(Name) of
+        unknown_instrument ->
+            unknown_instrument;
+        Instrument ->
+            bind_instrument(Instrument, LabelSet)
+    end.
+
+-spec lookup_instrument(ot_meter:name()) -> instrument() | unknown_instrument.
+lookup_instrument(Name) ->
+    case ets:lookup(?TAB, Name) of
+        [Instrument] ->
+            Instrument;
+        [] ->
+            unknown_instrument
+    end.
+
+observer_tab() ->
+    ?OBSERVER_TAB.
+
+-spec register_observer(opentelemetry:meter(), ot_meter:name(), ot_observer:callback()) -> ok.
+register_observer(_Meter, Name, Callback) ->
+    case lookup_instrument(Name) of
+        unknown_instrument ->
+            unknown_instrument;
+        Instrument ->
+            gen_server:call(?MODULE, {register_observer, Name, Instrument, Callback})
+    end.
+
+-spec set_observer_callback(opentelemetry:meter(), ot_meter:name(), ot_observer:callback())
+                           -> ok | unknown_instrument.
+set_observer_callback(_Meter, Name, Callback) ->
+    case lookup_instrument(Name) of
+        unknown_instrument ->
+            unknown_instrument;
+        Instrument ->
+            gen_server:call(?MODULE, {register_observer, Name, Instrument, Callback})
+    end.
+
+-spec observe(instrument(), number(), ot_meter:label_set()) -> ok.
+observe(ObserverInstrument, Number, LabelSet) when is_number(Number) ->
+    ot_metric_accumulator:observe(ObserverInstrument, Number, LabelSet),
+    ok;
+observe(_, _, _) ->
+    ok.
+
+init(_Opts) ->
+    %% ets table is required for other parts to not crash so we create
+    %% it in init and not in a handle_continue or whatever else
+    case ets:info(?TAB, name) of
+        undefined ->
+            ets:new(?TAB, [named_table,
+                           protected,
+                           {read_concurrency, true},
+                           {keypos, #instrument.name}
+                          ]);
+        _ ->
+            ok
+    end,
+
+    %% observers are stored in a separate table from other instruments
+    case ets:info(?OBSERVER_TAB, name) of
+        undefined ->
+            _ = ets:new(?OBSERVER_TAB, [named_table,
+                                        protected,
+                                        {keypos, #observer.name}]);
+        _ ->
+            ok
+    end,
+
+    {ok, #state{}}.
+
+handle_call({new, List}, _From, State) ->
+    Result = ets:insert_new(?TAB,
+      [#instrument{name=Name,
+                   description=maps:get(description, I, <<>>),
+                   kind=MetricKind,
+                   input_type=maps:get(input_type, I, integer),
+                   unit=maps:get(unit, I, one),
+                   label_keys=maps:get(label_keys, I, [])} || I=#{name := Name,
+                                                                  kind := MetricKind} <- List]),
+    {reply, Result, State};
+handle_call({register_observer, Name, Instrument, Callback}, _From, State) ->
+    _ = ets:insert(?OBSERVER_TAB, #observer{name=Name,
+                                            instrument={ot_meter_default, Instrument},
+                                            callback=Callback}),
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% internal
+
+%% TODO: use a counter ref for `sum' and `mmsc' aggregated
+%% instruments with `input_type' `integer'?
+bind_instrument(Instrument, LabelSet) ->
+    ot_metric_accumulator:lookup_active(Instrument, LabelSet).

--- a/src/ot_meter_server.erl
+++ b/src/ot_meter_server.erl
@@ -26,9 +26,6 @@
 -include("ot_meter.hrl").
 -include("ot_span.hrl").
 
--type library_resource() :: #library_resource{}.
--export_type([library_resource/0]).
-
 -record(state, {meter :: meter(),
                 deny_list :: [atom() | {atom(), string()}]}).
 
@@ -48,8 +45,9 @@ register_meter(Name, Vsn, #state{meter=Meter,
         true ->
             opentelemetry:set_meter(Name, {ot_meter_noop, []});
         false ->
-            LibraryResource = #library_resource{name=Name,
-                                                version=Vsn},
+            InstrumentationLibrary = ot_utils:instrumentation_library(Name, Vsn),
             opentelemetry:set_meter(Name, {Meter#meter.module,
-                                           Meter#meter{library_resource=LibraryResource}})
+                                           Meter#meter{instrumentation_library=InstrumentationLibrary}})
     end.
+
+%%

--- a/src/ot_meter_server.erl
+++ b/src/ot_meter_server.erl
@@ -1,0 +1,55 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_meter_server).
+
+-behaviour(ot_meter_provider).
+
+-export([init/1,
+         register_meter/3]).
+
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
+-include("ot_meter.hrl").
+-include("ot_span.hrl").
+
+-type library_resource() :: #library_resource{}.
+-export_type([library_resource/0]).
+
+-record(state, {meter :: meter(),
+                deny_list :: [atom() | {atom(), string()}]}).
+
+init(Opts) ->
+    DenyList = proplists:get_value(deny_list, Opts, []),
+
+    Meter = #meter{module=ot_meter_default},
+    opentelemetry:set_default_meter({ot_meter_default, Meter}),
+
+    {ok, #state{meter=Meter,
+                deny_list=DenyList}}.
+
+register_meter(Name, Vsn, #state{meter=Meter,
+                                 deny_list=DenyList}) ->
+    %% TODO: support semver constraints in denylist
+    case proplists:is_defined(Name, DenyList) of
+        true ->
+            opentelemetry:set_meter(Name, {ot_meter_noop, []});
+        false ->
+            LibraryResource = #library_resource{name=Name,
+                                                version=Vsn},
+            opentelemetry:set_meter(Name, {Meter#meter.module,
+                                           Meter#meter{library_resource=LibraryResource}})
+    end.

--- a/src/ot_metric_accumulator.erl
+++ b/src/ot_metric_accumulator.erl
@@ -77,8 +77,8 @@ observe(#instrument{name=Name}, Number, LabelSet) ->
     ot_metric_aggregator_last_value:update(?ACTIVE_TAB, {Name, LabelSet}, observer, Number),
     ok.
 
--spec lookup_active(ot_meter:name(), ot_meter:label_set()) -> {ot_meter:input_type(), module()} |
-                                                              unknown_instrument.
+-spec lookup_active(instrument() | ot_meter:name(), ot_meter:label_set())
+                   -> {ot_meter:input_type(), module()} | unknown_instrument.
 lookup_active(Instrument=#instrument{name=Name}, LabelSet) ->
     MatchSpec = ?active_ms(Name, LabelSet),
     case ets:select(?ACTIVE_TAB, MatchSpec) of

--- a/src/ot_metric_accumulator.erl
+++ b/src/ot_metric_accumulator.erl
@@ -1,0 +1,179 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc The Accumulator receives metric updates and when `collect' is called
+%% it sweeps through the instruments calling `checkpoint' with the define
+%% aggregator for each and submitting to the Integrator.
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_accumulator).
+
+-behaviour(gen_server).
+
+-export([start_link/1,
+         active_table/0,
+         record/2,
+         record/3,
+         observe/3,
+         collect/0,
+         lookup_active/2]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2]).
+
+-include_lib("stdlib/include/ms_transform.hrl").
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
+-include("ot_meter.hrl").
+
+-define(ACTIVE_TAB, active_instrument_updates).
+
+-define(active_ms(Name, LabelSet),
+        ets:fun2ms(fun(#active_instrument{key=Key,
+                                          instrument=#instrument{input_type=InputType},
+                                          aggregator=Aggregator}) when Key =:= {Name, LabelSet} ->
+                           {InputType, Aggregator}
+                   end)).
+
+-record(state, {}).
+
+start_link(Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Opts, []).
+
+active_table() ->
+    ?ACTIVE_TAB.
+
+-spec record(ot_meter:bound_instrument(), number()) -> boolean().
+record({Key, {InputType, Aggregator}}, Number) ->
+    Aggregator:update(?ACTIVE_TAB, Key, InputType, Number);
+record(#active_instrument{key=Key,
+                          instrument=#instrument{input_type=InputType},
+                          aggregator=Aggregator}, Number) ->
+    Aggregator:update(?ACTIVE_TAB, Key, InputType, Number).
+
+-spec record(ot_meter:name(), ot_meter:label_set(), number()) -> boolean() | unknown_instrument.
+record(Name, LabelSet, Number) ->
+    case lookup_active(Name, LabelSet) of
+        unknown_instrument ->
+            %% an Instrument must exist to create an Active Instrument
+            unknown_instrument;
+        {InputType, Aggregator} ->
+            Aggregator:update(?ACTIVE_TAB, {Name, LabelSet}, InputType, Number)
+    end.
+
+observe(#instrument{name=Name}, Number, LabelSet) ->
+    _ = lookup_active(Name, LabelSet),
+    ot_metric_aggregator_last_value:update(?ACTIVE_TAB, {Name, LabelSet}, observer, Number),
+    ok.
+
+-spec lookup_active(ot_meter:name(), ot_meter:label_set()) -> {ot_meter:input_type(), module()} |
+                                                              unknown_instrument.
+lookup_active(Instrument=#instrument{name=Name}, LabelSet) ->
+    MatchSpec = ?active_ms(Name, LabelSet),
+    case ets:select(?ACTIVE_TAB, MatchSpec) of
+        [{InputType, Aggregator}] ->
+            {InputType, Aggregator};
+        [] ->
+            add_active_instrument(Instrument, Name, LabelSet)
+    end;
+lookup_active(Name, LabelSet) ->
+    MatchSpec = ?active_ms(Name, LabelSet),
+    case ets:select(?ACTIVE_TAB, MatchSpec) of
+        [{InputType, Aggregator}] ->
+            {InputType, Aggregator};
+        [] ->
+            case ot_meter_default:lookup_instrument(Name) of
+                unknown_instrument ->
+                    unknown_instrument;
+                Instrument ->
+                    add_active_instrument(Instrument, Name, LabelSet)
+            end
+    end.
+
+collect()->
+    gen_server:call(?MODULE, collect).
+
+init(_Opts) ->
+    %% ets table is required for other parts to not crash so we create
+    %% it in init and not in a handle_continue or whatever else
+    case ets:info(?ACTIVE_TAB, name) of
+        undefined ->
+            _ = ets:new(?ACTIVE_TAB, [named_table,
+                                      public,
+                                      {keypos, #active_instrument.key},
+                                      {write_concurrency, true},
+                                      ordered_set]);
+        _ ->
+            ok
+    end,
+
+    {ok, #state{}}.
+
+handle_call(collect, _From, State) ->
+    %% TODO: should observers just checkpoint in the first place?
+    %% TODO: should timeout observer callbacks
+    run_observers(ets:tab2list(ot_meter_default:observer_tab())),
+
+    MS = ets:fun2ms(fun(#active_instrument{key=Key,
+                                           aggregator=Aggregator}) ->
+                            {Key, Aggregator}
+                    end),
+    run_checkpoints(ets:select(?ACTIVE_TAB, MS, 20)),
+
+    {reply, ok, State};
+handle_call(_Msg, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%%
+
+run_checkpoints('$end_of_table') ->
+    ok;
+run_checkpoints({Matches, Continuation}) ->
+    [Aggregator:checkpoint(?ACTIVE_TAB, Key) || {Key, Aggregator} <- Matches],
+    ets:select(Continuation).
+
+
+run_observers([]) ->
+    ok;
+run_observers([Observer | Rest]) ->
+    run_observer(Observer),
+    run_observers(Rest).
+
+run_observer(#observer{instrument=ObserverInstrument,
+                       callback=Callback}) ->
+    try Callback(ObserverInstrument)
+    catch _:_ ->
+            %% TODO: log an error
+            ok
+    end.
+
+aggregator(#instrument{kind=counter}) ->
+    ot_metric_aggregator_sum;
+aggregator(#instrument{kind=observer}) ->
+    ot_metric_aggregator_last_value;
+aggregator(#instrument{kind=measure}) ->
+    ot_metric_aggregator_mmsc.
+
+add_active_instrument(Instrument=#instrument{input_type=InputType}, Name, LabelSet) ->
+    Aggregator = aggregator(Instrument),
+    InitialValue = Aggregator:initial_value(InputType),
+    ActiveInstrument = #active_instrument{key={Name, LabelSet},
+                                          instrument=Instrument,
+                                          aggregator=Aggregator,
+                                          current=InitialValue},
+    _ = ets:insert_new(?ACTIVE_TAB, ActiveInstrument),
+    {InputType, Aggregator}.

--- a/src/ot_metric_accumulator.erl
+++ b/src/ot_metric_accumulator.erl
@@ -105,18 +105,14 @@ collect()->
     gen_server:call(?MODULE, collect).
 
 init(_Opts) ->
-    %% ets table is required for other parts to not crash so we create
-    %% it in init and not in a handle_continue or whatever else
-    case ets:info(?ACTIVE_TAB, name) of
-        undefined ->
-            _ = ets:new(?ACTIVE_TAB, [named_table,
-                                      public,
-                                      {keypos, #active_instrument.key},
-                                      {write_concurrency, true},
-                                      ordered_set]);
-        _ ->
-            ok
-    end,
+    %% This ETS table is required for other parts to not crash so we create
+    %% it in init and not in a handle_continue or whatever else.
+    %% No heir is worried about since active metrics are created dynamicly
+    _ = ets:new(?ACTIVE_TAB, [named_table,
+                              public,
+                              {keypos, #active_instrument.key},
+                              {write_concurrency, true},
+                              ordered_set]),
 
     {ok, #state{}}.
 

--- a/src/ot_metric_aggregator.erl
+++ b/src/ot_metric_aggregator.erl
@@ -1,0 +1,30 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%%
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_aggregator).
+
+-include("ot_meter.hrl").
+
+-callback update(ets:tab(), ot_meter:key(), ot_meter:input_type(), number()) -> boolean().
+
+-callback checkpoint(ets:tab(), ot_meter:key()) -> boolean().
+
+-callback merge(term(), term()) -> term().
+
+%% TODO: rename to `new'
+-callback initial_value(ot_meter:input_type()) -> term().

--- a/src/ot_metric_aggregator_array.erl
+++ b/src/ot_metric_aggregator_array.erl
@@ -1,0 +1,77 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%%
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_aggregator_array).
+
+-behaviour(ot_metric_aggregator).
+
+-export([update/4,
+         checkpoint/2,
+         merge/2,
+         initial_value/1]).
+
+-include("ot_meter.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-spec update(ets:tab(), ot_meter:key(), ot_meter:input_type(), number()) -> boolean().
+update(Tab, Key, _, Number) ->
+    select_replace(Tab, Key, Number).
+
+-spec checkpoint(ets:tab(), {ot_meter:name(), ot_meter:label_set()}) -> boolean().
+checkpoint(Tab, NameLabelSet) ->
+    MS = ets:fun2ms(fun(A=#active_instrument{key=Key,
+                                             aggregator=Aggregator,
+                                             instrument=#instrument{input_type=integer},
+                                             current=Current}) when Key =:= NameLabelSet ->
+                            A#active_instrument{checkpoint=Current,
+                                                current=[]};
+                       (A=#active_instrument{key=Key,
+                                             aggregator=Aggregator,
+                                             instrument=#instrument{input_type=float},
+                                             current=Current}) when Key =:= NameLabelSet ->
+                            A#active_instrument{checkpoint=Current,
+                                                current=[]}
+                    end),
+    case ets:select_replace(Tab, MS) of
+      0 ->
+          false;
+      _ ->
+          true
+    end.
+
+-spec merge([number()], [number()]) -> [number()].
+merge(List1, List2) ->
+    List1 ++ List2.
+
+-spec initial_value(ot_meter:input_type()) -> number().
+initial_value(_) ->
+    [].
+
+%%
+
+select_replace(Tab, NameLabelSet, Number) ->
+    MS = ets:fun2ms(fun(A=#active_instrument{key=Key,
+                                             current=Current}) when Key =:= NameLabelSet ->
+                            A#active_instrument{current=[Number | Current]}
+                    end),
+    case ets:select_replace(Tab, MS) of
+        1 ->
+            true;
+        _ ->
+            false
+    end.

--- a/src/ot_metric_aggregator_array.erl
+++ b/src/ot_metric_aggregator_array.erl
@@ -12,8 +12,8 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc
-%%
+%% @doc An aggregator that keeps each recorded measurement in a list of
+%% values. The list is reset to the empty list after each checkpoint.
 %% @end
 %%%-------------------------------------------------------------------------
 -module(ot_metric_aggregator_array).
@@ -24,6 +24,9 @@
          checkpoint/2,
          merge/2,
          initial_value/1]).
+
+%% ignore the warningi about use of `current=[Number | Current]' in `select_replace'
+-dialyzer(no_improper_lists).
 
 -include("ot_meter.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
@@ -58,7 +61,7 @@ checkpoint(Tab, NameLabelSet) ->
 merge(List1, List2) ->
     List1 ++ List2.
 
--spec initial_value(ot_meter:input_type()) -> number().
+-spec initial_value(ot_meter:input_type()) -> [].
 initial_value(_) ->
     [].
 

--- a/src/ot_metric_aggregator_last_value.erl
+++ b/src/ot_metric_aggregator_last_value.erl
@@ -1,0 +1,92 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%%
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_aggregator_last_value).
+
+-export([update/4,
+         checkpoint/2,
+         merge/2,
+         initial_value/1]).
+
+-include("ot_meter.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-spec update(ets:tab(), ot_meter:key(), observer | ot_meter:input_type(), number()) -> boolean().
+update(Tab, Key, _Type, Number) ->
+    Now = erlang:monotonic_time(),
+    NewCurrent = {Number, Now},
+    select_replace(Tab, Key, NewCurrent).
+
+-spec checkpoint(ets:tab(), {ot_meter:name(), ot_meter:label_set()}) -> boolean().
+checkpoint(Tab, NameLabelSet) ->
+    MS = ets:fun2ms(fun(A=#active_instrument{key=Key,
+                                             aggregator=Aggregator,
+                                             current=Current}) when Key =:= NameLabelSet ->
+                            A#active_instrument{checkpoint=Current,
+                                                current=undefined}
+                    end),
+    case ets:select_replace(Tab, MS) of
+      0 ->
+          false;
+      _ ->
+          true
+    end.
+
+-spec merge({number(), integer()}, {number(), integer()}) -> {number(), integer()}.
+merge({Number1, Timestamp1}, {_Number2, Timestamp2}) when Timestamp1 > Timestamp2 ->
+    {Number1, Timestamp1};
+merge({_Number1, Timestamp1}, {Number2, Timestamp2}) when Timestamp2 > Timestamp1 ->
+    {Number2, Timestamp2};
+%% shouldn't happen since we are using monotonic_time, but better safe than sorry?
+merge({_Number1, _Timestamp1}, {Number2, Timestamp2}) ->
+    {Number2, Timestamp2};
+merge(undefined, {Number2, Timestamp2}) ->
+    {Number2, Timestamp2};
+merge({Number1, Timestamp1}, undefined) ->
+    {Number1, Timestamp1};
+merge(undefined, undefined) ->
+    undefined.
+
+-spec initial_value(ot_meter:input_type()) -> undefined.
+initial_value(_) ->
+    undefined.
+
+%%
+
+select_replace(Tab, NameLabelSet, NewCurrent={_, NewTimestamp}) ->
+    %% ensure recorded measurement is the latest recording
+    MS = ets:fun2ms(fun(A=#active_instrument{key=Key,
+                                             current={_, Timestamp}}) when Key =:= NameLabelSet ,
+                                                                           NewTimestamp >= Timestamp ->
+                            A#active_instrument{current=NewCurrent};
+                       (A=#active_instrument{key=Key,
+                                             current={Value, Timestamp}}) when Key =:= NameLabelSet ,
+                                                                               NewTimestamp < Timestamp ->
+                            A;
+                       (A=#active_instrument{key=Key,
+                                             current=Current}) when Key =:= NameLabelSet ,
+                                                                    Current =:= undefined ->
+                            %% not a tuple, this must be the first recording
+                            A#active_instrument{current=NewCurrent}
+                    end),
+    case ets:select_replace(Tab, MS) of
+        1 ->
+            true;
+        _ ->
+            false
+    end.

--- a/src/ot_metric_aggregator_mmsc.erl
+++ b/src/ot_metric_aggregator_mmsc.erl
@@ -1,0 +1,96 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Min, max, sum, count aggregator.
+%%
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_aggregator_mmsc).
+
+-behaviour(ot_metric_aggregator).
+
+-export([update/4,
+         checkpoint/2,
+         merge/2,
+         initial_value/1]).
+
+-include("ot_meter.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-define(MIN, 1).
+-define(MAX, 2).
+-define(SUM, 3).
+-define(COUNT, 4).
+
+-spec update(ets:tab(), ot_meter:key(), ot_meter:input_type(), number()) -> boolean().
+update(Tab, Key, _, Number) ->
+    update_mmsc(Tab, Key, Number).
+
+-spec checkpoint(ets:tab(), ot_meter:key()) -> boolean().
+checkpoint(Tab, NameLabelSet) ->
+    MS = ets:fun2ms(fun(A=#active_instrument{key=Key,
+                                             aggregator=Aggregator,
+                                             current=Current}) when Key =:= NameLabelSet ,
+                                                                Aggregator =:= ?MODULE ->
+                            A#active_instrument{checkpoint=Current,
+                                                current={infinity, 0, 0, 0}}
+                    end),
+    case ets:select_replace(Tab, MS) of
+        0 ->
+            false;
+        _ ->
+            true
+    end.
+
+-spec merge(term(), term()) -> term().
+merge({Min1, Max1, Sum1, Count1}, {Min2, Max2, Sum2, Count2}) ->
+    {erlang:min(Min1, Min2), erlang:max(Max1, Max2), Sum1+Sum2, Count1+Count2}.
+
+-spec initial_value(ot_meter:input_type()) -> undefined.
+initial_value(integer) ->
+    {infinity, 0, 0, 0};
+initial_value(float) ->
+    {infinity, 0.0, 0.0, 0};
+initial_value(_) ->
+    {infinity, 0, 0, 0}.
+
+%%
+
+update_mmsc(Tab, NameLabelSet, Number) ->
+    %% can't use min/max functions in matchspec body so stuck with this
+    MS = ets:fun2ms(fun(A=#active_instrument{key=Key,
+                                             current={infinity, 0, 0, 0}}) when Key =:= NameLabelSet ->
+                            A#active_instrument{current={Number, Number, Number, 1}};
+                       (A=#active_instrument{key=Key,
+                                             current={Min, Max, Sum, Count}}) when Key =:= NameLabelSet
+                                                                                 andalso Min > Number ->
+                            A#active_instrument{current={Number, Max, Sum+Number, Count+1}};
+                       (A=#active_instrument{key=Key,
+                                             current={Min, Max, Sum, Count}}) when Key =:= NameLabelSet
+                                                                                 andalso Max < Number ->
+                            A#active_instrument{current={Min, Number, Sum+Number, Count+1}};
+                       (A=#active_instrument{key=Key,
+                                             current={Min, Max, Sum, Count}}) when Key =:= NameLabelSet ->
+                            A#active_instrument{current={Min, Max, Sum+Number, Count+1}};
+                       %% this clause is for if the current value doesn't exist yet
+                       (A=#active_instrument{key=Key,
+                                             current=_}) when Key =:= NameLabelSet ->
+                            A#active_instrument{current={Number, Number, Number, 1}}
+                    end),
+    case ets:select_replace(Tab, MS) of
+        1 ->
+            true;
+        _ ->
+            false
+    end.

--- a/src/ot_metric_aggregator_mmsc.erl
+++ b/src/ot_metric_aggregator_mmsc.erl
@@ -57,7 +57,7 @@ checkpoint(Tab, NameLabelSet) ->
 merge({Min1, Max1, Sum1, Count1}, {Min2, Max2, Sum2, Count2}) ->
     {erlang:min(Min1, Min2), erlang:max(Max1, Max2), Sum1+Sum2, Count1+Count2}.
 
--spec initial_value(ot_meter:input_type()) -> undefined.
+-spec initial_value(ot_meter:input_type()) -> {infinity, number(), number(), 0}.
 initial_value(integer) ->
     {infinity, 0, 0, 0};
 initial_value(float) ->

--- a/src/ot_metric_aggregator_sum.erl
+++ b/src/ot_metric_aggregator_sum.erl
@@ -1,0 +1,85 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Sum aggregator for summing recorded counter values.
+%%
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_aggregator_sum).
+
+-behaviour(ot_metric_aggregator).
+
+-export([update/4,
+         checkpoint/2,
+         merge/2,
+         initial_value/1]).
+
+-include("ot_meter.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-spec update(ets:tab(), ot_meter:key(), ot_meter:input_type(), number()) -> boolean().
+update(Tab, Key, integer, Number) when is_integer(Number) ->
+    _ = ets:update_counter(Tab, Key, {#active_instrument.current, Number});
+update(Tab, Key, float, Number) ->
+    select_replace(Tab, Key, Number);
+update(_, _, _, _) ->
+    false.
+
+-spec checkpoint(ets:tab(), {ot_meter:name(), ot_meter:label_set()}) -> boolean().
+checkpoint(Tab, NameLabelSet) ->
+    MS = ets:fun2ms(fun(A=#active_instrument{key=Key,
+                                             aggregator=Aggregator,
+                                             instrument=#instrument{input_type=integer},
+                                             current=Current}) when Key =:= NameLabelSet ->
+                            A#active_instrument{checkpoint=Current,
+                                                current=0};
+                       (A=#active_instrument{key=Key,
+                                             aggregator=Aggregator,
+                                             instrument=#instrument{input_type=float},
+                                             current=Current}) when Key =:= NameLabelSet ->
+                            A#active_instrument{checkpoint=Current,
+                                                current=0.0}
+                    end),
+    case ets:select_replace(Tab, MS) of
+      0 ->
+          false;
+      _ ->
+          true
+    end.
+
+-spec merge(number(), number()) -> number().
+merge(Number1, Number2) ->
+    Number1 + Number2.
+
+-spec initial_value(ot_meter:input_type()) -> number().
+initial_value(integer) ->
+    0;
+initial_value(float) ->
+    0.0;
+initial_value(_) ->
+    0.
+
+%%
+
+select_replace(Tab, NameLabelSet, Number) ->
+    MS = ets:fun2ms(fun(A=#active_instrument{key=Key,
+                                             current=Current}) when Key =:= NameLabelSet ->
+                            A#active_instrument{current=Current+Number}
+                    end),
+    case ets:select_replace(Tab, MS) of
+        1 ->
+            true;
+        _ ->
+            false
+    end.

--- a/src/ot_metric_controller_push.erl
+++ b/src/ot_metric_controller_push.erl
@@ -1,0 +1,70 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%%
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_controller_push).
+
+-behaviour(gen_statem).
+
+-export([start_link/1]).
+
+-export([init/1,
+         callback_mode/0,
+         handle_event/4,
+         terminate/3]).
+
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
+
+-record(data, {interval :: integer()}).
+
+start_link(Opts) ->
+    gen_statem:start_link(?MODULE, Opts, []).
+
+init(Opts) ->
+    erlang:process_flag(trap_exit, true),
+    Interval = maps:get(pusher_interval, Opts, timer:seconds(1)),
+    {ok, ready, #data{interval=Interval}, [push_timer(Interval)]}.
+
+callback_mode() ->
+    handle_event_function.
+
+handle_event({timeout, push_timer}, push, ready, Data) ->
+    do_push(),
+    {keep_state_and_data, [push_timer(Data)]}.
+
+terminate(_, _, _) ->
+    %% one last push
+    do_push(),
+    ok.
+
+%%
+
+push_timer(#data{interval=Interval}) ->
+    push_timer(Interval);
+push_timer(Interval) ->
+    {{timeout, push_timer}, Interval, push}.
+
+do_push() ->
+    %% checkpoint all active instruments
+    ot_metric_accumulator:collect(),
+
+    %% merge active instruments and get as a map
+    Records = ot_metric_integrator:read(),
+
+    %% export the map of metrics
+    ot_metric_exporter:export(Records),
+    ok.

--- a/src/ot_metric_exporter.erl
+++ b/src/ot_metric_exporter.erl
@@ -1,0 +1,49 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%%
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_exporter).
+
+-behaviour(gen_server).
+
+-export([start_link/1,
+         export/1]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2]).
+
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
+
+-record(state, {exporter :: {module(), term()}}).
+
+start_link(Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Opts, []).
+
+export(Records) ->
+    {Module, Args} = gen_server:call(?MODULE, exporter),
+    erlang:apply(Module, export, [Records | Args]).
+
+init(Opts) ->
+    Exporter = proplists:get_value(metric_exporter, Opts, {ot_metric_exporter_stdout, []}),
+    {ok, #state{exporter=Exporter}}.
+
+handle_call(exporter, _From, State=#state{exporter=Exporter}) ->
+    {reply, Exporter, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.

--- a/src/ot_metric_exporter_stdout.erl
+++ b/src/ot_metric_exporter_stdout.erl
@@ -21,6 +21,6 @@
 -export([export/1]).
 
 export(Records) when map_size(Records) > 0 ->
-    io:format("Records ~p~n", [Records]);
+    io:format("*METRICS FOR DEBUG*~nRecords ~p~n", [Records]);
 export(_) ->
     ok.

--- a/src/ot_metric_exporter_stdout.erl
+++ b/src/ot_metric_exporter_stdout.erl
@@ -1,0 +1,26 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%%
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_exporter_stdout).
+
+-export([export/1]).
+
+export(Records) when map_size(Records) > 0 ->
+    io:format("Records ~p~n", [Records]);
+export(_) ->
+    ok.

--- a/src/ot_metric_integrator.erl
+++ b/src/ot_metric_integrator.erl
@@ -1,0 +1,74 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%%
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_integrator).
+
+-behaviour(gen_server).
+
+-export([start_link/1,
+         read/0]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2]).
+
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
+-include("ot_meter.hrl").
+
+-record(state, {}).
+
+start_link(Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Opts, []).
+
+read() ->
+    read(ot_metric_accumulator:active_table()).
+
+%% read all active instruments and merge any that end up with the same labelset
+%% after the filtering of the label sets has been done.
+%% returns a map of all metrics to be exported for this collection interval
+read(Tab) ->
+    ets:foldl(fun(#active_instrument{key={Name, LabelSet},
+                                     instrument=_Instrument=#instrument{label_keys=LabelKeys},
+                                     aggregator=Aggregator,
+                                     checkpoint=Value}, Acc) ->
+                      %% TODO: what to do here with label sets should be configurable
+                      FilteredLabelSet = filter_label_set(LabelKeys, LabelSet),
+                      NewKey = {Name, FilteredLabelSet},
+                      case maps:get(NewKey, Acc, undefined) of
+                          undefined ->
+                              Acc#{NewKey => Value};
+                          Existing ->
+                              NewValue = Aggregator:merge(Existing, Value),
+                              Acc#{NewKey => NewValue}
+                      end
+              end, #{}, Tab).
+
+init(_Opts) ->
+    {ok, #state{}}.
+
+handle_call(_Msg, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%%
+
+filter_label_set(Keys, Set) ->
+    %% TODO: should label sets be maps?
+    maps:to_list(maps:with(Keys, maps:from_list(Set))).

--- a/src/ot_metric_sup.erl
+++ b/src/ot_metric_sup.erl
@@ -1,0 +1,81 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Supervisor for processes belonging to the Metric SDK.
+%% @end
+%%%-------------------------------------------------------------------------
+-module(ot_metric_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/1]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link(Opts) ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, [Opts]).
+
+init([Opts]) ->
+    SupFlags = #{strategy => one_for_one,
+                 intensity => 1,
+                 period => 5},
+
+    MeterServer = #{id => ot_meter_server,
+                    start => {ot_meter_provider, start_link, [ot_meter_server, Opts]},
+                    restart => permanent,
+                    shutdown => 5000,
+                    type => worker,
+                    modules => [ot_meter_provider, ot_meter_server]},
+
+    Meter = #{id => ot_meter,
+              start => {ot_meter_default, start_link, [Opts]},
+              restart => permanent,
+              shutdown => 5000,
+              type => worker,
+              modules => [ot_meter]},
+
+    MetricAccumulator = #{id => ot_metric_accumulator,
+                          start => {ot_metric_accumulator, start_link, [Opts]},
+                          restart => permanent,
+                          shutdown => 5000,
+                          type => worker,
+                          modules => [ot_metric_accumulator]},
+
+    MetricIntegrator = #{id => ot_metric_integrator,
+                         start => {ot_metric_integrator, start_link, [Opts]},
+                         restart => permanent,
+                         shutdown => 5000,
+                         type => worker,
+                         modules => [ot_metric_integrator]},
+
+    MetricExporter = #{id => ot_metric_exporter,
+                       start => {ot_metric_exporter, start_link, [Opts]},
+                       restart => permanent,
+                       shutdown => 5000,
+                       type => worker,
+                       modules => [ot_metric_exporter]},
+
+    %% TODO: remove this, it should not be enabled by default
+    %% ControllerOpts = proplists:get_value(controller, Opts, #{}),
+    %% Controller = #{id => ot_metric_controller,
+    %%                start => {ot_metric_controller_push, start_link, [ControllerOpts]},
+    %%                restart => permanent,
+    %%                shutdown => 5000,
+    %%                type => worker,
+    %%                modules => [ot_metric_controller_push]},
+
+    ChildSpecs = [MeterServer, Meter, MetricExporter, MetricIntegrator, MetricAccumulator],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/src/ot_tracer_server.erl
+++ b/src/ot_tracer_server.erl
@@ -97,8 +97,7 @@ register_tracer(Name, Vsn, Modules, #state{shared_tracer=Tracer,
         true ->
             opentelemetry:set_tracer(Name, {ot_tracer_noop, []});
         false ->
-            InstrumentationLibrary = #instrumentation_library{name=to_binary(Name),
-                                                              version=to_binary(Vsn)},
+            InstrumentationLibrary = ot_utils:instrumentation_library(Name, Vsn),
             TracerTuple = {Tracer#tracer.module,
                            Tracer#tracer{instrumentation_library=InstrumentationLibrary}},
             [opentelemetry:set_tracer(M, TracerTuple) || M <- Modules]
@@ -111,8 +110,7 @@ register_tracer(Name, Vsn, #state{shared_tracer=Tracer,
         true ->
             opentelemetry:set_tracer(Name, {ot_tracer_noop, []});
         false ->
-            InstrumentationLibrary = #instrumentation_library{name=to_binary(Name),
-                                                              version=to_binary(Vsn)},
+            InstrumentationLibrary = ot_utils:instrumentation_library(Name, Vsn),
             TracerTuple = {Tracer#tracer.module,
                            Tracer#tracer{instrumentation_library=InstrumentationLibrary}},
             opentelemetry:set_tracer(Name, TracerTuple)
@@ -135,10 +133,3 @@ on_start(Processors) ->
 
 on_end(Processors) ->
     fun(Span) -> [P:on_end(Span, Config) || {P, Config} <- Processors] end.
-
-to_binary(T) when is_atom(T) ->
-    atom_to_binary(T, utf8);
-to_binary(T) when is_list(T) ->
-    list_to_binary(T);
-to_binary(T) when is_binary(T) ->
-    T.

--- a/src/ot_utils.erl
+++ b/src/ot_utils.erl
@@ -1,0 +1,29 @@
+-module(ot_utils).
+
+-export([instrumentation_library/2]).
+
+-include("ot_span.hrl").
+
+instrumentation_library(Name, Vsn) ->
+    #instrumentation_library{name=name_to_binary(Name),
+                             version=vsn_to_binary(Vsn)}.
+
+%% Vsn can't be an atom or anything but a list or binary
+%% so return `undefined' if it isn't a list or binary.
+vsn_to_binary(Vsn) when is_list(Vsn) ->
+    list_to_binary(Vsn);
+vsn_to_binary(Vsn) when is_binary(Vsn) ->
+    Vsn;
+vsn_to_binary(_) ->
+    undefined.
+
+%% name can be atom, list or binary. But atom `undefined'
+%% must stay as `undefined' atom.
+name_to_binary(undefined)->
+    undefined;
+name_to_binary(T) when is_atom(T) ->
+    atom_to_binary(T, utf8);
+name_to_binary(T) when is_list(T) ->
+    list_to_binary(T);
+name_to_binary(T) when is_binary(T) ->
+    T.

--- a/test/opentelemetry_SUITE.erl
+++ b/test/opentelemetry_SUITE.erl
@@ -32,6 +32,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
+    application:unload(opentelemetry),
     ok.
 
 init_per_group(Propagator, Config) when Propagator =:= w3c ;
@@ -67,6 +68,7 @@ init_per_testcase(_, Config) ->
     [{tid, Tid} | Config].
 
 end_per_testcase(_, _Config) ->
+    _ = application:stop(opentelemetry),
     ok.
 
 macros(Config) ->

--- a/test/ot_batch_processor_SUITE.erl
+++ b/test/ot_batch_processor_SUITE.erl
@@ -22,6 +22,7 @@ exporting_timeout_test(_Config) ->
 
     receive
         {'EXIT', Pid, _} ->
+            %% test is to ensure we don't hit this
             ct:fail(batch_processor_crash)
     after
         100 ->

--- a/test/ot_metric_SUITE.erl
+++ b/test/ot_metric_SUITE.erl
@@ -44,13 +44,21 @@ e2e_test(_Config) ->
                         kind => counter,
                         input_type => integer,
                         label_keys => ["a"]}]),
+    ?new_instruments([#{name => myfloat,
+                        kind => counter,
+                        input_type => float,
+                        label_keys => ["a"]}]),
     ?counter_add(mycounter, 4, []),
     ?counter_add(mycounter, 5, []),
+
+    ?counter_add(myfloat, 4.1, []),
+    ?counter_add(myfloat, 5.1, []),
 
     ot_metric_accumulator:collect(),
     Records = ot_metric_integrator:read(),
 
-    ?assertMatch(#{{mycounter, []} := 9}, Records),
+    ?assertMatch(#{{mycounter, []} := 9,
+                   {myfloat, []} := 9.2}, Records),
 
     ok.
 

--- a/test/ot_metric_SUITE.erl
+++ b/test/ot_metric_SUITE.erl
@@ -1,0 +1,103 @@
+-module(ot_metric_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
+-include("ot_test_utils.hrl").
+
+all() ->
+    [observer, counter, mmsc].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(opentelemetry),
+    Config.
+
+end_per_suite(_Config) ->
+    _ = application:stop(opentelemetry),
+    ok.
+
+observer(_Config) ->
+    ot_meter_default:new_instruments([], [#{name => myobserver,
+                                            kind => observer,
+                                            input_type => integer,
+                                            label_keys => ["a"]}]),
+
+    ot_meter_default:register_observer(meter, myobserver, fun(R) ->
+                                                                  ot_observer:observe(R, 3, [{"a", "b"}]),
+                                                                  ok
+                                                          end),
+
+    ot_metric_accumulator:collect(),
+    Records = ot_metric_integrator:read(),
+
+    ?assertMatch(#{{myobserver, [{"a", "b"}]} := {3, _}}, Records),
+
+    ot_meter_default:register_observer(meter, myobserver, fun(R) ->
+                                                                  ot_observer:observe(R, 5, []),
+                                                                  ok
+                                                          end),
+    ot_meter_default:register_observer(meter, myobserver, fun(R) ->
+                                                                  ot_observer:observe(R, 6, []),
+                                                                  ok
+                                                          end),
+
+    ot_metric_accumulator:collect(),
+    ?assertMatch(#{{myobserver, [{"a", "b"}]} := undefined,
+                   {myobserver, []} := {6, _}}, ot_metric_integrator:read()),
+
+    ok.
+
+counter(_Config) ->
+    ot_meter_default:new_instruments([], [#{name => c1,
+                                            kind => counter,
+                                            input_type => integer,
+                                            label_keys => [key1]}]),
+
+    %% a bad measurement should be ignored
+    ?assertEqual(ok, ot_meter_default:record(meter, m1, [{key1, value1}], undefined)),
+
+    ot_meter_default:record(meter, c1, [{key1, value1}], 2),
+    ot_meter_default:record(meter, c1, [{key1, value2}], 8),
+    ot_meter_default:record(meter, c1, [{key1, value1}], 5),
+
+    ot_metric_accumulator:collect(),
+    Records = ot_metric_integrator:read(),
+
+    %% check mmsc (min, max, sum, count) aggregation values
+    ?assertMatch(#{{c1, [{key1, value1}]} := 7,
+                   {c1, [{key1, value2}]} := 8}, Records),
+    ok.
+
+
+mmsc(_Config) ->
+    ot_meter_default:new_instruments([], [#{name => m1,
+                                            kind => measure,
+                                            input_type => integer,
+                                            label_keys => [key1]}]),
+
+    ot_meter_default:record(meter, m1, [{key1, value1}], 2),
+    ot_meter_default:record(meter, m1, [{key1, value2}], 8),
+    ot_meter_default:record(meter, m1, [{key1, value1}], 5),
+
+    ot_metric_accumulator:collect(),
+    Records = ot_metric_integrator:read(),
+
+    %% check mmsc (min, max, sum, count) aggregation values
+    ?assertMatch(#{{m1, [{key1, value1}]} := {2, 5, 7, 2},
+                   {m1, [{key1, value2}]} := {8, 8, 8, 1}}, Records),
+
+    ot_meter_default:record(meter, m1, [{key1, value1}], 2),
+    ot_meter_default:record(meter, m1, [{key1, value2}], 8),
+    ot_meter_default:record(meter, m1, [{key1, value1}], 5),
+
+    ot_metric_accumulator:collect(),
+    Records1 = ot_metric_integrator:read(),
+
+    %% check mmsc (min, max, sum, count) aggregation values
+    ?assertMatch(#{{m1, [{key1, value1}]} := {2, 5, 7, 2},
+                   {m1, [{key1, value2}]} := {8, 8, 8, 1}}, Records1),
+
+    ok.


### PR DESCRIPTION
aggregation is instrument type specific until views are added to the spec.

releasing bound metrics does nothing and won't until the active instrument
table tracks if updates have occured within the last collection interval
for each active instrument and deletes them after 2 intervals of no
updates. At that point binding and releasing will need to be tracked
along with if there have been updates so it is known if an active instrument
is actually inactive and should be removed from the table or not.