### PR TITLE
fix default http propagators in .app.src to use key http_propagators

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [{wts, "~> 0.4"},
-        {opentelemetry_api,
-         {git, "https://github.com/open-telemetry/opentelemetry-erlang-api",
-          {branch, "master"}}}]}.
+        {opentelemetry_api, "~> 0.3"}]}.
 
 {shell, [{apps, [opentelemetry]},
          {config, "config/sys.config"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,8 @@
 {"1.1.0",
-[{<<"opentelemetry_api">>,
-  {git,"https://github.com/open-telemetry/opentelemetry-erlang-api",
-       {ref,"fcedcc428efa89c7cef3c9522c9abb03515f2461"}},
-  0},
+[{<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"0.3.0">>},0},
  {<<"wts">>,{pkg,<<"wts">>,<<"0.4.0">>},0}]}.
 [
 {pkg_hash,[
+ {<<"opentelemetry_api">>, <<"5D8F08C4F06C0B0EFF50514A57F0B530A25A6520F335AA05C9E39A3669D1DACC">>},
  {<<"wts">>, <<"62D9DC400AD29F0D233F0665B9C75C8F8EB0A8AF75EEC921056BA4A73B0605A2">>}]}
 ].

--- a/src/opentelemetry.app.src
+++ b/src/opentelemetry.app.src
@@ -10,8 +10,8 @@
     opentelemetry_api
    ]},
   {env, [{sampler, {always_on, #{}}},
-         {propagators, [fun ot_correlations:get_http_propagators/0,
-                        fun ot_tracer_default:w3c_propagators/0]},
+         {http_propagators, [fun ot_correlations:get_http_propagators/0,
+                             fun ot_tracer_default:w3c_propagators/0]},
 
          %% list of disabled tracers
          {deny_list, []},


### PR DESCRIPTION
Since `opentelemetry_app` uses: `Propagators = proplists:get_value(http_propagators, Opts, []),`