### PR TITLE
store resource attributes as binary strings

### DIFF
--- a/test/ot_resource_SUITE.erl
+++ b/test/ot_resource_SUITE.erl
@@ -23,11 +23,11 @@ startup(_Config) ->
     Resource = ot_tracer_provider:resource(),
     _ = application:stop(opentelemetry),
 
-    ?assertMatch({ot_resource, [{"service.name", "cttest"},
-                                {"service.version", "1.1.1"}]}, Resource),
+    ?assertMatch({ot_resource, [{<<"service.name">>, <<"cttest">>},
+                                {<<"service.version">>, <<"1.1.1">>}]}, Resource),
 
-    ?assertMatch({ot_resource, [{"service.name", "cttest"},
-                                {"service.version", "1.1.1"}]}, Tracer#tracer.resource),
+    ?assertMatch({ot_resource, [{<<"service.name">>, <<"cttest">>},
+                                {<<"service.version">>, <<"1.1.1">>}]}, Tracer#tracer.resource),
     ok.
 
 os_env_resource(_Config) ->
@@ -52,7 +52,7 @@ combining(_Config) ->
 
     Merged = ot_resource:merge(Resource1, Resource2),
 
-    Expected = {ot_resource, [{"service.name","other-name"},
-                              {"service.version","1.1.1"}]},
+    Expected = {ot_resource, [{<<"service.name">>, <<"other-name">>},
+                              {<<"service.version">>, <<"1.1.1">>}]},
     ?assertEqual(Expected, Merged),
     ok.


### PR DESCRIPTION
attributes will be getting support for arrays as values so
this will make things simpler.

I also removed the latin1 restriction for now because I can't
find it in the spec.