### PR TITLE
replace parent sampler with parent_or_else

### DIFF
--- a/include/ot_sampler.hrl
+++ b/include/ot_sampler.hrl
@@ -18,4 +18,4 @@
 
 -define(NOT_RECORD, not_record).
 -define(RECORD, record).
--define(RECORD_AND_PROPAGATE, record_and_propagate).
+-define(RECORD_AND_SAMPLED, record_and_sampled).

--- a/src/ot_span_utils.erl
+++ b/src/ot_span_utils.erl
@@ -97,6 +97,6 @@ sample({Sampler, Opts}, TraceId, Parent, Links, SpanName, Kind, Attributes) ->
             {0, false, NewAttributes};
         ?RECORD ->
             {0, true, NewAttributes};
-        ?RECORD_AND_PROPAGATE ->
+        ?RECORD_AND_SAMPLED ->
             {1, true, NewAttributes}
     end.


### PR DESCRIPTION
0.4 Otel spec replaced the parent sampler with parent_or_else (https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#parentorelse).
parent_or_else is configured with a sampler to run if there is
no parent span (a root span). The default sampler, always_on,
is used if none is given.

Example configuring sampler to use parent_or_else:

{parent_or_else, #{delegate_sampler => {Sampler, SamplerOpts}}}