### PR TITLE
Format propagation header values to binary

### DIFF
--- a/src/ot_propagation_http_b3.erl
+++ b/src/ot_propagation_http_b3.erl
@@ -38,11 +38,11 @@ inject(_, #tracer_ctx{active=#span_ctx{trace_id=TraceId,
 inject(_, #tracer_ctx{active=#span_ctx{trace_id=TraceId,
                                        span_id=SpanId,
                                        trace_flags=TraceOptions}}) ->
-    Options = case TraceOptions band 1 of 1 -> "1"; _ -> "0" end,
+    Options = case TraceOptions band 1 of 1 -> <<"1">>; _ -> <<"0">> end,
     EncodedTraceId = io_lib:format("~32.16.0b", [TraceId]),
     EncodedSpanId = io_lib:format("~16.16.0b", [SpanId]),
-    [{?B3_TRACE_ID, EncodedTraceId},
-     {?B3_SPAN_ID, EncodedSpanId},
+    [{?B3_TRACE_ID, iolist_to_binary(EncodedTraceId)},
+     {?B3_SPAN_ID, iolist_to_binary(EncodedSpanId)},
      {?B3_SAMPLED, Options}];
 inject(_, undefined) ->
     [].

--- a/src/ot_propagation_http_w3c.erl
+++ b/src/ot_propagation_http_w3c.erl
@@ -52,14 +52,14 @@ inject(_, #tracer_ctx{active=SpanCtx=#span_ctx{},
 inject(_, undefined) ->
     [].
 
--spec encode(opentelemetry:span_ctx()) -> iolist().
+-spec encode(opentelemetry:span_ctx()) -> binary().
 encode(#span_ctx{trace_id=TraceId,
                  span_id=SpanId,
                  trace_flags=TraceOptions}) ->
     Options = case TraceOptions band 1 of 1 -> <<"01">>; _ -> <<"00">> end,
     EncodedTraceId = io_lib:format("~32.16.0b", [TraceId]),
     EncodedSpanId = io_lib:format("~16.16.0b", [SpanId]),
-    unicode:characters_to_binary([?VERSION, "-", EncodedTraceId, "-", EncodedSpanId, "-", Options]).
+    iolist_to_binary([?VERSION, "-", EncodedTraceId, "-", EncodedSpanId, "-", Options]).
 
 encode_tracestate(#span_ctx{tracestate=undefined}) ->
     [];

--- a/src/ot_propagation_http_w3c.erl
+++ b/src/ot_propagation_http_w3c.erl
@@ -59,7 +59,7 @@ encode(#span_ctx{trace_id=TraceId,
     Options = case TraceOptions band 1 of 1 -> <<"01">>; _ -> <<"00">> end,
     EncodedTraceId = io_lib:format("~32.16.0b", [TraceId]),
     EncodedSpanId = io_lib:format("~16.16.0b", [SpanId]),
-    [?VERSION, "-", EncodedTraceId, "-", EncodedSpanId, "-", Options].
+    unicode:characters_to_binary([?VERSION, "-", EncodedTraceId, "-", EncodedSpanId, "-", Options]).
 
 encode_tracestate(#span_ctx{tracestate=undefined}) ->
     [];

--- a/test/opentelemetry_SUITE.erl
+++ b/test/opentelemetry_SUITE.erl
@@ -182,17 +182,11 @@ update_span_data(Config) ->
                                               events=Events,
                                               _='_'})).
 
-propagation(Config) ->
-    Propagator = ?config(propagator, Config),
-    #span_ctx{trace_id=TraceId,
-              span_id=SpanId} = ?start_span(<<"span-1">>),
+propagation(_Config) ->
+    #span_ctx{trace_id=TraceId} = ?start_span(<<"span-1">>),
     Headers = ot_propagation:http_inject([{<<"existing-header">>, <<"I exist">>}]),
 
-    EncodedTraceId = io_lib:format("~32.16.0b", [TraceId]),
-    EncodedSpanId = io_lib:format("~16.16.0b", [SpanId]),
-
-    ?assertListsMatch([{<<"existing-header">>, <<"I exist">>} |
-                       trace_context(Propagator, EncodedTraceId, EncodedSpanId)], Headers),
+    [?assert(is_binary(Value)) || {_Key, Value} <- Headers],
 
     ?end_span(),
 


### PR DESCRIPTION
The `traceparent` header value is currently being returned as a mixed list vs a single binary value. This should be returned as a single binary.

Current behavior:

```elixir
[
  {"traceparent",
   ["00", '-', 'ef7ad0605733c5b943f4602eddac6adb', '-', '81fb003c23ab543b', '-',
    "01"]}
]
```

Expected behavior:

```elixir
[
  {"traceparent", "00-ef7ad0605733c5b943f4602eddac6adb-81fb003c23ab543b-01"}
]
```
