### PR TITLE
Update event name specs

### DIFF
--- a/apps/opentelemetry_api/lib/open_telemetry.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry.ex
@@ -107,6 +107,7 @@ defmodule OpenTelemetry do
   text description and key-value pairs.
   """
   @type event() :: :opentelemetry.event()
+  @type event_name() :: :opentelemetry.event_name()
 
   @typedoc """
   An optional final status for this span. Semantically when Status
@@ -192,13 +193,13 @@ defmodule OpenTelemetry do
   @doc """
   Creates a `t:event/0`.
   """
-  @spec event(String.t(), attributes()) :: event()
+  @spec event(event_name(), attributes()) :: event()
   defdelegate event(name, attributes), to: :opentelemetry
 
   @doc """
   Creates a `t:event/0`.
   """
-  @spec event(integer(), String.t(), attributes()) :: event()
+  @spec event(integer(), event_name(), attributes()) :: event()
   defdelegate event(timestamp, name, attributes), to: :opentelemetry
 
   @doc """

--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -76,7 +76,7 @@ defmodule OpenTelemetry.Span do
   @doc """
   Add an event to the currently active Span.
   """
-  @spec add_event(String.t(), OpenTelemetry.attributes()) :: boolean()
+  @spec add_event(OpenTelemetry.event_name(), OpenTelemetry.attributes()) :: boolean()
   defmacro add_event(event, attributes) do
     quote do
       tracer = :opentelemetry.get_tracer(__MODULE__)

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -77,6 +77,7 @@
               attributes/0,
               event/0,
               events/0,
+              event_name/0,
               tracestate/0,
               status/0,
               resource/0,
@@ -106,6 +107,7 @@
                               ?SPAN_KIND_CONSUMER.
 -type event()              :: #event{}.
 -type events()             :: [#event{}].
+-type event_name()         :: unicode:unicode_binary() | atom().
 -type link()               :: #link{}.
 -type links()              :: [#link{}].
 -type status()             :: #status{}.

--- a/apps/opentelemetry_api/src/ot_span.erl
+++ b/apps/opentelemetry_api/src/ot_span.erl
@@ -48,7 +48,7 @@
                         opentelemetry:attribute_key(),
                         opentelemetry:attribute_value()) -> boolean().
 -callback set_attributes(opentelemetry:span_ctx(), opentelemetry:attributes()) -> boolean().
--callback add_event(opentelemetry:span_ctx(), unicode:unicode_binary(), opentelemetry:attributes()) -> boolean().
+-callback add_event(opentelemetry:span_ctx(), opentelemetry:event_name(), opentelemetry:attributes()) -> boolean().
 -callback add_events(opentelemetry:span_ctx(), opentelemetry:events()) -> boolean().
 -callback set_status(opentelemetry:span_ctx(), opentelemetry:status()) -> boolean().
 -callback update_name(opentelemetry:span_ctx(), opentelemetry:span_name()) -> boolean().
@@ -93,7 +93,7 @@ set_attributes(_, _, _) ->
 
 -spec add_event(Tracer, SpanCtx, Name, Attributes) -> boolean() when
       Tracer :: opentelemetry:tracer(),
-      Name :: unicode:unicode_binary(),
+      Name :: opentelemetry:event_name(),
       Attributes :: opentelemetry:attributes(),
       SpanCtx :: opentelemetry:span_ctx().
 add_event(Tracer, SpanCtx, Name, Attributes) when ?is_recording(SpanCtx) ->


### PR DESCRIPTION
I had already added support for event names being atoms in the exporter but never got around to updating the specs for that.

https://github.com/opentelemetry-beam/opentelemetry_exporter/blob/master/src/opentelemetry_exporter.erl#L204