### PR TITLE
OTEL_RESOURCE_(LABELS -> ATTRIBUTES)

### DIFF
--- a/apps/opentelemetry/src/otel_resource_env_var.erl
+++ b/apps/opentelemetry/src/otel_resource_env_var.erl
@@ -21,7 +21,7 @@
 -export([get_resource/0,
          parse/1]).
 
--define(OS_ENV, "OTEL_RESOURCE_LABELS").
+-define(OS_ENV, "OTEL_RESOURCE_ATTRIBUTES").
 -define(LABEL_LIST_SPLITTER, ",").
 -define(LABEL_KEY_VALUE_SPLITTER, "=").
 

--- a/apps/opentelemetry/test/otel_resource_SUITE.erl
+++ b/apps/opentelemetry/test/otel_resource_SUITE.erl
@@ -16,7 +16,7 @@ all() ->
     [startup, os_env_resource, app_env_resource, combining].
 
 startup(_Config) ->
-    os:putenv("OTEL_RESOURCE_LABELS", "service.name=cttest,service.version=1.1.1"),
+    os:putenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=cttest,service.version=1.1.1"),
 
     {ok, _} = application:ensure_all_started(opentelemetry),
     {_, Tracer} = opentelemetry:get_tracer(),

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -130,7 +130,7 @@ span_round_trip(_Config) ->
 
 %% insert a couple spans and export to locally running otel collector
 verify_export(Config) ->
-    os:putenv("OTEL_RESOURCE_LABELS", "service.name=my-test-service,service.version=98da75ea6d38724743bf42b45565049238d86b3f"),
+    os:putenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=my-test-service,service.version=98da75ea6d38724743bf42b45565049238d86b3f"),
     Protocol = ?config(protocol, Config),
     Port = case Protocol of
                grpc ->


### PR DESCRIPTION
Ran into an issue getting Lightstep running locally, and realized it was
due to a name change on the `OTEL_RESOURCE_LABELS` env variable. It
recently changed in the spec.

https://github.com/open-telemetry/opentelemetry-specification/pull/758
https://github.com/open-telemetry/opentelemetry-specification/blob/c9eeaaec21a3afa421546dd9c92221ba537dde82/specification/sdk-environment-variables.md