### PR TITLE
move propagators to the api

### DIFF
--- a/apps/opentelemetry_api/src/otel_propagator_http_b3.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_http_b3.erl
@@ -22,8 +22,7 @@
 -export([inject/1,
          extract/2]).
 
--include_lib("opentelemetry_api/include/opentelemetry.hrl").
--include("otel_tracer.hrl").
+-include("opentelemetry.hrl").
 
 -define(B3_TRACE_ID, <<"X-B3-TraceId">>).
 -define(B3_SPAN_ID, <<"X-B3-SpanId">>).

--- a/apps/opentelemetry_api/src/otel_propagator_http_w3c.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_http_w3c.erl
@@ -24,8 +24,7 @@
          extract/2,
          decode/1]).
 
--include_lib("opentelemetry_api/include/opentelemetry.hrl").
--include("otel_tracer.hrl").
+-include("opentelemetry.hrl").
 
 -define(VERSION, <<"00">>).
 
@@ -66,7 +65,7 @@ encode_tracestate(#span_ctx{tracestate=Entries}) ->
     StateHeaderValue = lists:join($,, [[Key, $=, Value] || {Key, Value} <- Entries]),
     [{?STATE_HEADER_KEY, unicode:characters_to_binary(StateHeaderValue)}].
 
--spec extract(otel_propagator:http_headers(), term()) -> opentelemetry:span_ctx()| undefined.
+-spec extract(otel_propagator:text_map(), term()) -> opentelemetry:span_ctx()| undefined.
 extract(Headers, _) when is_list(Headers) ->
     case header_take(?HEADER_KEY, Headers) of
         [{_, Value} | RestHeaders] ->


### PR DESCRIPTION
It is now in the api spec and usable without the SDK: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md#textmap-propagator