### PR TITLE
pass parent span context along when no sdk is used

### DIFF
--- a/apps/opentelemetry_api/include/opentelemetry.hrl
+++ b/apps/opentelemetry_api/include/opentelemetry.hrl
@@ -36,7 +36,7 @@
           %% 64 bit int span id
           span_id           :: opentelemetry:span_id(),
           %% 8-bit integer, lowest bit is if it is sampled
-          trace_flags = 1   :: integer() | undefined,
+          trace_flags = 0   :: integer() | undefined,
           %% Tracestate represents tracing-system specific context in a list of key-value pairs.
           %% Tracestate allows different vendors propagate additional information and
           %% inter-operate with their legacy Id formats.

--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -54,6 +54,16 @@ defmodule OpenTelemetry.Span do
   defdelegate end_span(span_ctx), to: :otel_span
 
   @doc """
+
+  """
+  defdelegate is_recording(span_ctx), to: :otel_span
+
+  @doc """
+
+  """
+  defdelegate is_valid(span_ctx), to: :otel_span
+
+  @doc """
   Set an attribute with key and value on the currently active Span.
   """
   @spec set_attribute(OpenTelemetry.span_ctx(), OpenTelemetry.attribute_key(), OpenTelemetry.attribute_value()) :: boolean()

--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -22,6 +22,7 @@
          span_id/1,
          tracestate/1,
          is_recording/1,
+         is_valid/1,
          set_attribute/3,
          set_attributes/2,
          add_event/3,
@@ -47,6 +48,15 @@
       SpanCtx :: opentelemetry:span_ctx().
 is_recording(SpanCtx) ->
     ?is_recording(SpanCtx).
+
+-spec is_valid(SpanCtx) -> boolean() when
+      SpanCtx :: opentelemetry:span_ctx().
+is_valid(#span_ctx{trace_id=TraceId,
+                   span_id=SpanId}) when TraceId =/= 0 ,
+                                         SpanId =/= 0 ->
+    true;
+is_valid(_) ->
+    false.
 
 %% accessors
 -spec trace_id(opentelemetry:span_ctx()) -> opentelemetry:trace_id().

--- a/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
@@ -4,21 +4,109 @@
 
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include("otel_tracer.hrl").
+-include("opentelemetry.hrl").
 
 -define(assertListsMatch(List1, List2), ?assertEqual(lists:sort(List1), lists:sort(List2))).
 
+%% Headers for: #span_ctx{trace_id=21267647932558653966460912964485513216,
+%%                        span_id=1152921504606846976,
+%%                        trace_flags=0}
+-define(EXPECTED_HEADERS, [{<<"traceparent">>,
+                            <<"00-10000000000000000000000000000000-1000000000000000-00">>}]).
+
 all() ->
-    [custom_propagator].
+    [{group, absence_of_an_installed_sdk}, custom_propagator].
+
+groups() ->
+    %% Tests of Behavior of the API in the absence of an installed SDK
+    %% https://github.com/open-telemetry/opentelemetry-specification/blob/82865fae64e7b30ee59906d7c4d25a48fe446563/specification/trace/api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk
+    [{absence_of_an_installed_sdk, [shuffle, parallel], [invalid_span_no_sdk_propagation,
+                                                         recording_no_sdk_propagation,
+                                                         nonrecording_no_sdk_propagation]}].
 
 init_per_suite(Config) ->
     application:load(opentelemetry_api),
-    {Extractors, Injectors} = custom_propagator:propagators(),
-    opentelemetry:set_text_map_extractors([Extractors]),
-    opentelemetry:set_text_map_injectors([Injectors]),
+    {Extractor, Injector} = custom_propagator:propagators(),
+    {W3CExtractor, W3CInjector} = otel_tracer_default:w3c_propagators(),
+    opentelemetry:set_text_map_extractors([Extractor, W3CExtractor]),
+    opentelemetry:set_text_map_injectors([Injector, W3CInjector]),
 
     Config.
 
 end_per_suite(_Config) ->
+    ok.
+
+invalid_span_no_sdk_propagation(_Config) ->
+    ct:comment("Test that a start_span called with an invalid span parent "
+               "and no SDK results in the same invalid span as the child"),
+    otel_ctx:clear(),
+
+    InvalidSpanCtx = #span_ctx{trace_id=0,
+                               span_id=0,
+                               trace_flags=0,
+                               tracestate=[],
+                               is_valid=false,
+                               is_recording=false},
+    otel_tracer:set_current_span(InvalidSpanCtx),
+    ?assertEqual(InvalidSpanCtx, otel_tracer:current_span_ctx()),
+    ?with_span(<<"span-1">>, #{}, fun(_) ->
+                                          %% parent is recording so a new span_id should be used
+                                          ?assertEqual(InvalidSpanCtx, otel_tracer:current_span_ctx())
+                                  end),
+    ?assertEqual(InvalidSpanCtx, otel_tracer:current_span_ctx()),
+
+    BinaryHeaders = otel_propagator:text_map_inject([]),
+    %% invalid span contexts are skipped when injecting
+    ?assertMatch([], BinaryHeaders),
+
+    ok.
+
+recording_no_sdk_propagation(_Config) ->
+    ct:comment("Test that a start_span called with an valid recording span parent "
+               "and no SDK results in a new span_id for the child"),
+    otel_ctx:clear(),
+
+    RecordingSpanCtx = #span_ctx{trace_id=21267647932558653966460912964485513216,
+                                 span_id=1152921504606846976,
+                                 is_recording=true},
+    otel_tracer:set_current_span(RecordingSpanCtx),
+    ?assertEqual(RecordingSpanCtx, otel_tracer:current_span_ctx()),
+    ?with_span(<<"span-1">>, #{}, fun(_) ->
+                                          %% parent is recording so a new span_id should be used
+                                          ?assertNotEqual(RecordingSpanCtx, otel_tracer:current_span_ctx())
+                                  end),
+    ?assertEqual(RecordingSpanCtx, otel_tracer:current_span_ctx()),
+    BinaryHeaders = otel_propagator:text_map_inject([]),
+    ?assertMatch(?EXPECTED_HEADERS, BinaryHeaders),
+
+    ok.
+
+nonrecording_no_sdk_propagation(_Config) ->
+    ct:comment("Test that a start_span called with an valid non-recording span parent "
+               "and no SDK results in the same span_ctx as the child"),
+
+    otel_ctx:clear(),
+
+    NonRecordingSpanCtx = #span_ctx{trace_id=21267647932558653966460912964485513216,
+                                    span_id=1152921504606846976,
+                                    is_recording=false},
+    ?set_current_span(NonRecordingSpanCtx),
+    BinaryHeaders = otel_propagator:text_map_inject([]),
+    %% is_recording will always be false in extracted `span_ctx'
+    otel_propagator:text_map_extract(BinaryHeaders),
+
+    ?assertEqual(NonRecordingSpanCtx, otel_tracer:current_span_ctx()),
+    ?with_span(<<"span-1">>, #{}, fun(_) ->
+                                          %% parent is non-recording so it should be returned
+                                          %% as the "new" span
+                                          ?assertEqual(NonRecordingSpanCtx, otel_tracer:current_span_ctx())
+                                  end),
+    ?assertEqual(NonRecordingSpanCtx, otel_tracer:current_span_ctx()),
+
+    BinaryHeaders = otel_propagator:text_map_inject([]),
+    ?assertMatch(?EXPECTED_HEADERS, BinaryHeaders),
+
     ok.
 
 custom_propagator(_Config) ->


### PR DESCRIPTION
This PR updates the API to follow the spec around behaviour without an SDK: https://github.com/open-telemetry/opentelemetry-specification/blob/82865fae64e7b30ee59906d7c4d25a48fe446563/specification/trace/api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk

Basically it says that if there is a parent span and `start_span` is called on the no-op tracer then either return the same span context (the parent) or create a new non-recording span context (nothing is stored in ets, its just a context).