### PR TITLE
expand Elixir trace API

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -30,9 +30,9 @@ jobs:
       with:
         path: |
           _build
-        key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ hashFiles(format('rebar.lock')) }}
+        key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ hashFiles(format('rebar.lock')) }}-1
         restore-keys: |
-          ${{ runner.os }}-build-${{ matrix.otp_version }}-
+          ${{ runner.os }}-build-${{ matrix.otp_version }}-1-
     - name: Compile
       run: rebar3 compile
     - name: EUnit tests
@@ -79,9 +79,9 @@ jobs:
       with:
         path: |
           _build
-        key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ hashFiles('rebar.lock') }}
+        key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ hashFiles('rebar.lock') }}-1
         restore-keys: |
-          ${{ runner.os }}-dialyzer-${{ matrix.otp_version }}-
+          ${{ runner.os }}-dialyzer-${{ matrix.otp_version }}-1-
     - name: Compile
       run: rebar3 compile
     - name: Dialyzer

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -106,7 +106,7 @@ with_span(Config) ->
     otel_tracer:set_current_span(SpanCtx1),
 
     Result = some_result,
-    ?assertMatch(Result, otel_tracer:with_span(Tracer, <<"with-span-2">>,
+    ?assertMatch(Result, otel_tracer:with_span(Tracer, <<"with-span-2">>, #{},
                                                fun(SpanCtx2) ->
                                                        ?assertNotEqual(SpanCtx1, SpanCtx2),
                                                        ?assertEqual(SpanCtx2, ?current_span_ctx),
@@ -288,9 +288,10 @@ tracer_previous_ctx(Config) ->
     ?assertMatch(SpanCtx1, ?current_span_ctx),
 
     %% create a span that is not on the current context and with no parent
-    {SpanCtx2, Ctx} = otel_tracer:start_span(otel_ctx:new(), Tracer, <<"span-2">>, #{}),
-    %% start a new active span with SpanCtx2 as the parent
-    {SpanCtx3, _Ctx1} = otel_tracer:start_span(Ctx, Tracer, <<"span-3">>, #{}),
+    SpanCtx2 = otel_tracer:start_span(Tracer, <<"span-2">>, #{}),
+    Ctx = otel_tracer:set_current_span(otel_ctx:new(), SpanCtx2),
+    %% start a new span with SpanCtx2 as the parent
+    SpanCtx3 = otel_tracer:start_span(Ctx, Tracer, <<"span-3">>, #{}),
 
     %% end SpanCtx3, even though it isn't the parent SpanCtx1
     otel_span:end_span(SpanCtx3),
@@ -316,7 +317,7 @@ attach_ctx(Config) ->
     ?assertMatch(SpanCtx1, ?current_span_ctx),
 
     %% create a span that is not set to active and with no parent
-    {SpanCtx2, _Ctx} = otel_tracer:start_span(otel_ctx:new(), Tracer, <<"span-2">>, #{}),
+    SpanCtx2 = otel_tracer:start_span(otel_ctx:new(), Tracer, <<"span-2">>, #{}),
     Ctx = otel_ctx:get_current(),
 
     erlang:spawn(fun() ->

--- a/apps/opentelemetry_api/test/open_telemetry_test.exs
+++ b/apps/opentelemetry_api/test/open_telemetry_test.exs
@@ -14,13 +14,13 @@ defmodule OpenTelemetryTest do
   Record.defrecordp(:link, @fields)
 
   test "current_span tracks last set_span" do
-    ctx1 = Tracer.start_span("span-1")
+    span_ctx1 = Tracer.start_span("span-1")
     assert :undefined == Tracer.current_span_ctx()
-    Tracer.set_current_span(ctx1)
-    ctx2 = Tracer.start_span("span-2")
-    Tracer.set_current_span(ctx2)
+    Tracer.set_current_span(span_ctx1)
+    span_ctx2 = Tracer.start_span("span-2")
+    Tracer.set_current_span(span_ctx2)
 
-    assert ctx2 == Tracer.current_span_ctx()
+    assert span_ctx2 == Tracer.current_span_ctx()
   end
 
   test "link creation" do

--- a/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
+++ b/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
@@ -137,5 +137,5 @@ noop_with_span(_Config) ->
     ?assertMatch({otel_tracer_noop, _}, Tracer),
 
     Result = some_result,
-    ?assertEqual(Result, otel_tracer:with_span(Tracer, <<"span1">>, fun(_) -> Result end)),
+    ?assertEqual(Result, otel_tracer:with_span(Tracer, <<"span1">>, #{}, fun(_) -> Result end)),
     ok.

--- a/test/otel_tests.exs
+++ b/test/otel_tests.exs
@@ -3,6 +3,7 @@ defmodule OtelTests do
 
   require OpenTelemetry.Tracer, as: Tracer
   require OpenTelemetry.Span, as: Span
+  require OpenTelemetry.Ctx, as: Ctx
 
   require Record
   @fields Record.extract(:span, from_lib: "opentelemetry/include/otel_span.hrl")
@@ -10,7 +11,7 @@ defmodule OtelTests do
   @fields Record.extract(:span_ctx, from_lib: "opentelemetry_api/include/opentelemetry.hrl")
   Record.defrecordp(:span_ctx, @fields)
 
-  test "use Tracer to set attributes" do
+  test "use Tracer to set current active Span's attributes" do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
     OpenTelemetry.register_tracer(:test_tracer, "0.1.0")
 
@@ -22,6 +23,34 @@ defmodule OtelTests do
     assert_receive {:span,
                     span(
                       name: "span-1",
+                      attributes: [{"attr-1", "value-1"}, {"attr-2", "value-2"}]
+                    )}
+  end
+
+  test "use Tracer to start a Span as currently active with an explicit parent" do
+    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
+    OpenTelemetry.register_tracer(:test_tracer, "0.1.0")
+
+    s1 = Tracer.start_span("span-1")
+    ctx = Tracer.set_current_span(Ctx.new(), s1)
+
+    Tracer.with_span ctx, "span-2", %{} do
+      Tracer.set_attribute("attr-1", "value-1")
+      Tracer.set_attributes([{"attr-2", "value-2"}])
+    end
+
+    span_ctx(span_id: parent_span_id) = Span.end_span(s1)
+
+    assert_receive {:span,
+                    span(
+                      name: "span-1",
+                      attributes: []
+                    )}
+
+    assert_receive {:span,
+                    span(
+                      name: "span-2",
+                      parent_span_id: ^parent_span_id,
                       attributes: [{"attr-1", "value-1"}, {"attr-2", "value-2"}]
                     )}
   end
@@ -39,6 +68,46 @@ defmodule OtelTests do
                     span(
                       name: "span-2",
                       attributes: [{"attr-1", "value-1"}, {"attr-2", "value-2"}]
+                    )}
+  end
+
+  test "use explicit Context for parent of started Span" do
+    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
+
+    s1 = Tracer.start_span("span-1")
+    ctx = Tracer.set_current_span(Ctx.new(), s1)
+
+    # span-2 will have s1 as the parent since s1 is the current span in `ctx`
+    s2 = Tracer.start_span(ctx, "span-2", %{})
+
+    # span-3 will have no parent because it uses the current context
+    s3 = Tracer.start_span("span-3")
+
+    Span.set_attribute(s1, "attr-1", "value-1")
+    Span.set_attributes(s1, [{"attr-2", "value-2"}])
+
+    span_ctx(span_id: s1_span_id) = Span.end_span(s1)
+
+    assert span_ctx() = Span.end_span(s2)
+    assert span_ctx() = Span.end_span(s3)
+
+    assert_receive {:span,
+                    span(
+                      name: "span-1",
+                      parent_span_id: :undefined,
+                      attributes: [{"attr-1", "value-1"}, {"attr-2", "value-2"}]
+                    )}
+
+    assert_receive {:span,
+                    span(
+                      name: "span-2",
+                      parent_span_id: ^s1_span_id
+                    )}
+
+    assert_receive {:span,
+                    span(
+                      name: "span-3",
+                      parent_span_id: :undefined
                     )}
   end
 end


### PR DESCRIPTION
start_span, no matter the arity, always returns only a span_ctx now

the Tracer module includes macros that accept Context variables
instead of reading the context from the pdict, allowing explicit
parent spans to be used again.