### PR TITLE
Make span context (re)construction more ergonomic

### DIFF
--- a/apps/opentelemetry_api/src/otel_ctx.erl
+++ b/apps/opentelemetry_api/src/otel_ctx.erl
@@ -103,7 +103,7 @@ get_current() ->
             #{}
     end.
 
--spec attach(map()) -> token().
+-spec attach(map() | opentelemetry:span_ctx()) -> token().
 attach(Ctx) ->
     erlang:put(?CURRENT_CTX, Ctx).
 

--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -40,7 +40,12 @@
                         links => opentelemetry:links(),
                         is_recording => boolean(),
                         start_time => opentelemetry:timestamp(),
-                        kind => opentelemetry:span_kind()}.
+                        kind => opentelemetry:span_kind(),
+                        context => otel_ctx:t(),
+                        parent =>
+                            opentelemetry:span_ctx() |
+                            {opentelemetry:trace_id(),
+                             opentelemetry:span_id()}}.
 
 -export_type([start_opts/0]).
 


### PR DESCRIPTION
Hello and congratulations for your approach in this project.

#### TL;DR

This commit enables one to choose how to construct a new span, by defining both the context and the active span, using a trace id and a span id, in the same call (ie, in the `start_opts` of `start_span` and `with_span`).

#### Description

While working with this library's API, I found it hard to reconstruct the span context between processes while working in a fully asynchronous manner (eg, RabbitMQ and Broadway with lots of processes here and there and wishing to only share a trace id and a span id between them).

As such, this commit implements the ability to set the current span using a trace id and a span id, through a new implementation of `otel_tracer:set_current_span/2`.