### PR TITLE
add configuration module to merge OS env with app env

### DIFF
--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -24,7 +24,8 @@
          stop/1]).
 
 start(_StartType, _StartArgs) ->
-    Opts = application:get_all_env(opentelemetry),
+    Opts = otel_configuration:merge_with_os(
+             application:get_all_env(opentelemetry)),
 
     %% set the global propagators for HTTP based on the application env
     setup_text_map_propagators(Opts),

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -1,0 +1,176 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2021, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Merges environment variable configuration values with application
+%% configuration. The OS environment variables take precedence over the
+%% application environment.
+%% @end
+%%%-------------------------------------------------------------------------
+-module(otel_configuration).
+
+-export([merge_with_os/1]).
+
+-include_lib("kernel/include/logger.hrl").
+
+-spec merge_with_os(list()) -> list().
+merge_with_os(Opts) ->
+    general(
+      sampler(
+        processors(Opts))).
+
+general(Opts) ->
+    merge_list_with_environment(config_mappings(general_sdk), Opts).
+
+processors(AppEnvOpts) ->
+    Processors = proplists:get_value(processors, AppEnvOpts, [{otel_batch_processor, #{}}]),
+
+    Config = lists:map(fun({Name, Opts}) ->
+                               {Name, merge_with_environment(config_mappings(Name), Opts)}
+                       end, Processors),
+
+    lists:keystore(processors, 1, AppEnvOpts, {processors, Config}).
+
+%% sampler configuration is unique since it has the _ARG that is a sort of
+%% sub-configuration of the sampler config, and isn't a list.
+sampler(AppEnvOpts) ->
+    Sampler = proplists:get_value(sampler, AppEnvOpts, {parent_based, #{root => {always_on, #{}}}}),
+
+    Sampler1 = case os:getenv("OTEL_TRACE_SAMPLER") of
+                   false ->
+                       Sampler;
+                   OSEnvSampler->
+                       transform(sampler, {OSEnvSampler, os:getenv("OTEL_TRACE_SAMPLER_ARG")})
+               end,
+
+    lists:keystore(sampler, 1, AppEnvOpts, {sampler, Sampler1}).
+
+-spec merge_list_with_environment([{OSVar, Key, Default, Transform}], list()) -> list()
+              when OSVar :: string(),
+                   Key :: atom(),
+                   Default :: term(),
+                   Transform :: atom().
+merge_list_with_environment(ConfigMappings, Opts) ->
+    lists:foldl(fun({OSVar, Key, Default, Transform}, Acc) ->
+                        case os:getenv(OSVar) of
+                            false ->
+                                case lists:keyfind(Key, 1, Opts) of
+                                    false ->
+                                        %% set to Default if it doesn't exist
+                                        [{Key, transform(Transform, Default)} | Acc];
+                                    _ ->
+                                        Acc
+                                end;
+                            Value ->
+                                lists:keystore(Key, 1, Acc, {Key, transform(Transform, Value)})
+                        end
+                end, Opts, ConfigMappings).
+
+-spec merge_with_environment([{OSVar, Key, Default, Transform}], map()) -> map()
+              when OSVar :: string(),
+                   Key :: atom(),
+                   Default :: term(),
+                   Transform :: atom().
+merge_with_environment(ConfigMappings, Opts) ->
+    lists:foldl(fun({OSVar, Key, Default, Transform}, Acc) ->
+                        case os:getenv(OSVar) of
+                            false ->
+                                %% set to Default if it doesn't exist
+                                maps:update_with(Key, fun(X) -> X end,
+                                                 Default, Acc);
+                            Value ->
+                                maps:put(Key, transform(Transform, Value), Acc)
+                        end
+                end, Opts, ConfigMappings).
+
+config_mappings(general_sdk) ->
+    [{"OTEL_LOG_LEVEL", log_level, "info", existing_atom},
+     {"OTEL_PROPAGATORS", propagators, "tracecontext,baggage", propagators}];
+config_mappings(otel_batch_processor) ->
+    [{"OTEL_BSP_SCHEDULE_DELAY_MILLIS", scheduled_delay_ms, 5000, integer},
+     {"OTEL_BSP_EXPORT_TIMEOUT_MILLIS", exporting_timeout_ms, 30000, integer},
+     {"OTEL_BSP_MAX_QUEUE_SIZE", max_queue_size, 2048, integer}
+     %% the following are not supported yet
+     %% {"OTEL_BSP_MAX_EXPORT_BATCH_SIZE", max_export_batch_size, 512}
+    ].
+
+%% span limit not supported
+%% config_mappings(span_limits) ->
+%%     [{"OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", attribute_count_limit, 1000, integer},
+%%      {"OTEL_SPAN_EVENT_COUNT_LIMIT", event_count_limit, 1000, integer},
+%%      {"OTEL_SPAN_LINK_COUNT_LIMIT", link_count_limit 1000, integer}];
+%% config_mappings(_) ->
+%%     [].
+
+transform(integer, Value) when is_list(Value) ->
+    list_to_integer(Value);
+transform(existing_atom, Value) when is_list(Value) ->
+    list_to_existing_atom(Value);
+%% convert sampler string to usable configuration term
+transform(sampler, {"parentbased_always_on", _}) ->
+    {parent_based, #{root => {always_on, #{}}}};
+transform(sampler, {"parentbased_always_off", _}) ->
+    {parent_based, #{root => {always_off, #{}}}};
+transform(sampler, {"always_on", _}) ->
+    {always_on, #{}};
+transform(sampler, {"always_off", _}) ->
+    {always_off, #{}};
+transform(sampler, {"traceidratio", false}) ->
+    {trace_id_ratio_based, 1.0};
+transform(sampler, {"traceidratio", Probability}) ->
+    {trace_id_ratio_based, probability_string_to_float(Probability)};
+transform(sampler, {"parentbased_traceidratio", false}) ->
+    {parentbased_traceidratio, 1.0};
+transform(sampler, {"parentbased_traceidratio", Probability}) ->
+    {parent_based,
+     #{root => {trace_id_ratio_based, probability_string_to_float(Probability)}}};
+transform(sampler, Value) ->
+    Value;
+
+transform(propagators, PropagatorsString) when is_list(PropagatorsString) ->
+    Propagators = string:split(PropagatorsString, ",", all),
+    lists:filtermap(fun(Propagator) when is_list(Propagator) ->
+                          case transform(propagator, string:trim(Propagator)) of
+                              undefined ->
+                                  false;
+                              Value ->
+                                  {true, Value}
+                          end
+                  end, Propagators);
+
+transform(propagator, "tracecontext") ->
+    fun otel_tracer_default:w3c_propagators/0;
+transform(propagator, "baggage") ->
+    fun otel_baggage:get_text_map_propagators/0;
+transform(propagator, Propagator) ->
+    ?LOG_WARNING("Ignoring uknown propagator ~ts in OS environment variable $OTEL_PROPAGATORS",
+                 [Propagator]),
+    undefined;
+
+
+transform(string, Value) ->
+    Value.
+
+probability_string_to_float(Probability) ->
+    try list_to_float(Probability) of
+        Float ->
+            Float
+    catch
+        error:badarg when Probability =:= "1" ->
+            1.0;
+         error:badarg when Probability =:= "0" ->
+            0.0;
+        error:badarg ->
+            ?LOG_WARNING("Unable to convert $OTEL_TRACE_SAMPLER_ARG string value ~ts to float, using 1.0"),
+            1.0
+    end.

--- a/apps/opentelemetry/src/otel_sampler.erl
+++ b/apps/opentelemetry/src/otel_sampler.erl
@@ -19,7 +19,7 @@
 %%%-------------------------------------------------------------------------
 -module(otel_sampler).
 
--export([setup/2,
+-export([setup/1,
          get_description/1,
          always_on/7,
          always_off/7,
@@ -50,7 +50,12 @@
 
 -define(MAX_VALUE, 9223372036854775807). %% 2^63 - 1
 
--spec setup(atom() | module(), map()) -> t().
+-spec setup(atom() | {atom() | module(), term()}) -> t().
+setup({Sampler, Opts}) ->
+    setup(Sampler, Opts);
+setup(Sampler) when is_atom(Sampler) ->
+    setup(Sampler, #{}).
+
 setup(always_on, Opts) ->
     {fun ?MODULE:always_on/7, description(always_on, Opts), []};
 setup(always_off, Opts) ->

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -54,8 +54,8 @@
 init(Opts) ->
     Resource = otel_resource_detector:get_resource(),
 
-    {Sampler, SamplerOpts} = proplists:get_value(sampler, Opts, {parent_based, #{root => {always_on, #{}}}}),
-    SamplerFun = otel_sampler:setup(Sampler, SamplerOpts),
+    SamplerAndOpts = proplists:get_value(sampler, Opts, {parent_based, #{root => always_on}}),
+    SamplerFun = otel_sampler:setup(SamplerAndOpts),
     Processors = proplists:get_value(processors, Opts, []),
     DenyList = proplists:get_value(deny_list, Opts, []),
 

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -428,8 +428,8 @@ record_but_not_sample(Config) ->
                "as a valid recorded span but is not sent to the exporter."),
     Tid = ?config(tid, Config),
 
-    Sampler = otel_sampler:setup(static_sampler, #{<<"span-record-and-sample">> => ?RECORD_AND_SAMPLE,
-                                                   <<"span-record">> => ?RECORD_ONLY}),
+    Sampler = otel_sampler:setup({static_sampler, #{<<"span-record-and-sample">> => ?RECORD_AND_SAMPLE,
+                                                    <<"span-record">> => ?RECORD_ONLY}}),
 
     Tracer = opentelemetry:get_tracer(),
 

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -1,0 +1,150 @@
+-module(otel_configuration_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(assertIsSubset(X, Y),
+        lists:foreach(fun({K, V}) ->
+                              V1 = proplists:get_value(K, Y, undefined),
+                              %% include the key in the assert so it is there
+                              %% in the error message if it fails
+                              ?assertEqual({K, V}, {K, V1})
+                      end, X)).
+
+all() ->
+    [empty_os_environment, sampler, sampler_parent_based, sampler_parent_based_zero,
+     sampler_trace_id, sampler_trace_id_default, sampler_parent_based_one,
+     log_level, propagators].
+
+init_per_testcase(empty_os_environment, Config) ->
+    Vars = [],
+    [{os_vars, Vars} | Config];
+init_per_testcase(log_level, Config) ->
+    Vars = [{"OTEL_LOG_LEVEL", "error"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(propagators, Config) ->
+    Vars = [{"OTEL_PROPAGATORS", "baggage,afakeone"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(sampler, Config) ->
+    Vars = [{"OTEL_TRACE_SAMPLER", "parentbased_always_off"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(sampler_trace_id, Config) ->
+    Vars = [{"OTEL_TRACE_SAMPLER", "traceidratio"},
+            {"OTEL_TRACE_SAMPLER_ARG", "0.5"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(sampler_trace_id_default, Config) ->
+    Vars = [{"OTEL_TRACE_SAMPLER", "traceidratio"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(sampler_parent_based, Config) ->
+    Vars = [{"OTEL_TRACE_SAMPLER", "parentbased_traceidratio"},
+            {"OTEL_TRACE_SAMPLER_ARG", "0.5"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(sampler_parent_based_one, Config) ->
+    Vars = [{"OTEL_TRACE_SAMPLER", "parentbased_traceidratio"},
+            {"OTEL_TRACE_SAMPLER_ARG", "1"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(sampler_parent_based_zero, Config) ->
+    Vars = [{"OTEL_TRACE_SAMPLER", "parentbased_traceidratio"},
+            {"OTEL_TRACE_SAMPLER_ARG", "0"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config].
+
+end_per_testcase(_, Config) ->
+    Vars = ?config(os_vars, Config),
+
+    [os:unsetenv(Name) || {Name, _} <- Vars],
+
+    ok.
+
+empty_os_environment(_Config) ->
+    ?assertIsSubset([{log_level,info},
+                     {propagators,[fun otel_tracer_default:w3c_propagators/0,
+                                     fun otel_baggage:get_text_map_propagators/0]},
+                     {sampler,{parent_based,#{root => {always_on,#{}}}}}],
+                    otel_configuration:merge_with_os([])),
+
+    ?assertIsSubset([{log_level, error}], otel_configuration:merge_with_os([{log_level, error}])),
+
+    ok.
+
+sampler(_Config) ->
+    ?assertMatch({sampler, {parent_based, #{root := {always_off, #{}}}}},
+                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+
+    ok.
+
+sampler_parent_based(_Config) ->
+    ?assertMatch({sampler, {parent_based, #{root := {trace_id_ratio_based, 0.5}}}},
+                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+
+    ok.
+
+sampler_trace_id(_Config) ->
+    ?assertMatch({sampler, {trace_id_ratio_based, 0.5}},
+                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+
+    ok.
+
+sampler_trace_id_default(_Config) ->
+    ?assertMatch({sampler, {trace_id_ratio_based, 1.0}},
+                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+
+    ok.
+
+sampler_parent_based_one(_Config) ->
+    ?assertMatch({sampler, {parent_based, #{root := {trace_id_ratio_based, 1.0}}}},
+                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+
+    ok.
+
+sampler_parent_based_zero(_Config) ->
+    ?assertMatch({sampler, {parent_based, #{root := {trace_id_ratio_based, 0.0}}}},
+                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+
+    ok.
+
+log_level(_Config) ->
+    %% TODO: can make this a better error message when it fails with a custom assert macro
+    ?assertIsSubset([{log_level, error}], otel_configuration:merge_with_os([])),
+
+    ?assertIsSubset([{log_level, error}], otel_configuration:merge_with_os([{log_level, info}])),
+
+    ok.
+
+propagators(_Config) ->
+    %% TODO: can make this a better error message when it fails with a custom assert macro
+    ?assertIsSubset([{log_level, error},
+                     {propagators, [fun otel_baggage:get_text_map_propagators/0]}],
+                    otel_configuration:merge_with_os([{log_level, error}])),
+
+    ok.
+
+%%
+
+setup_env(Vars) ->
+    [os:putenv(Name, Value) || {Name, Value} <- Vars].

--- a/apps/opentelemetry/test/otel_samplers_SUITE.erl
+++ b/apps/opentelemetry/test/otel_samplers_SUITE.erl
@@ -28,11 +28,11 @@ end_per_testcase(_, _Config) ->
 
 get_description(_Config) ->
     Probability = 0.5,
-    Sampler = otel_sampler:setup(trace_id_ratio_based, Probability),
+    Sampler = otel_sampler:setup({trace_id_ratio_based, Probability}),
 
     ?assertEqual(<<"TraceIdRatioBased{0.500000}">>, otel_sampler:get_description(Sampler)),
 
-    ParentBasedSampler = otel_sampler:setup(parent_based, #{root => {trace_id_ratio_based, Probability}}),
+    ParentBasedSampler = otel_sampler:setup({parent_based, #{root => {trace_id_ratio_based, Probability}}}),
     ?assertEqual(<<"ParentBased{root:TraceIdRatioBased{0.500000},remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}">>,
                  otel_sampler:get_description(ParentBasedSampler)),
 
@@ -47,7 +47,7 @@ trace_id_ratio_based(_Config) ->
     Ctx = otel_ctx:new(),
 
     %% sampler that runs on all spans
-    {Sampler, _, Opts} = otel_sampler:setup(trace_id_ratio_based, Probability),
+    {Sampler, _, Opts} = otel_sampler:setup({trace_id_ratio_based, Probability}),
 
     %% checks the trace id is under the upper bound
     ?assertMatch({?RECORD_AND_SAMPLE, [], []},
@@ -87,8 +87,8 @@ parent_based(_Config) ->
 
     Ctx = otel_ctx:new(),
 
-    {Sampler, _, Opts} = otel_sampler:setup(parent_based,
-                                            #{root => {trace_id_ratio_based, Probability}}),
+    {Sampler, _, Opts} = otel_sampler:setup({parent_based,
+                                             #{root => {trace_id_ratio_based, Probability}}}),
 
     %% with no parent it will run the probability sampler
     ?assertMatch({?RECORD_AND_SAMPLE, [], []},
@@ -109,7 +109,7 @@ parent_based(_Config) ->
                          DoNotSample, [], SpanName, undefined, [], Opts)),
 
     %% with no root sampler in setup opts the default sampler always_on is used
-    {DefaultParentOrElse, _, Opts1} = otel_sampler:setup(parent_based, #{}),
+    {DefaultParentOrElse, _, Opts1} = otel_sampler:setup({parent_based, #{}}),
 
     ?assertMatch({?RECORD_AND_SAMPLE, [], []},
                  DefaultParentOrElse(otel_tracer:set_current_span(Ctx,  undefined),
@@ -130,7 +130,7 @@ parent_based(_Config) ->
 
 custom_sampler_module(_Config) ->
     SpanName = <<"span-name">>,
-    {Sampler, _, Opts} = otel_sampler:setup(static_sampler, #{SpanName => ?DROP}),
+    {Sampler, _, Opts} = otel_sampler:setup({static_sampler, #{SpanName => ?DROP}}),
     ?assertMatch({?DROP, [], []},
                  Sampler(otel_ctx:new(), opentelemetry:generate_trace_id(), [],
                          SpanName, undefined, [], Opts)),


### PR DESCRIPTION
This adds support for OS variables to define propagators, samplers and log level.

Note that log level doesn't do anything yet. I *think* it should be used to set `logger:set_application_level`, but it likely needs to also expose itself through `otel_configuration` so that other opentelemetry libs, like third party exporters can utilize it as well.