### PR TITLE
Update version in README for the api bump to 0.6.0

### DIFF
--- a/apps/opentelemetry_api/README.md
+++ b/apps/opentelemetry_api/README.md
@@ -25,7 +25,7 @@ Naming the `Tracers` provides additional metadata on spans and allows the user o
 ``` elixir
 def deps do
   [
-    {:opentelemetry_api, "~> 0.3.0"}
+    {:opentelemetry_api, "~> 0.6.0"}
   ]
 end
 ```


### PR DESCRIPTION
This update the lib version in the `opentelemetry_api` README to its latest version.