### PR TITLE
Fix `set_current_span` spec

### DIFF
--- a/apps/opentelemetry_api/src/otel_tracer.erl
+++ b/apps/opentelemetry_api/src/otel_tracer.erl
@@ -82,11 +82,11 @@ non_recording_span(TraceId, SpanId, Traceflags) ->
               is_recording=false,
               trace_flags=Traceflags}.
 
--spec set_current_span(opentelemetry:span_ctx()) -> ok.
+-spec set_current_span(opentelemetry:span_ctx() | undefined) -> ok.
 set_current_span(SpanCtx) ->
     otel_ctx:set_value(?CURRENT_SPAN_CTX, SpanCtx).
 
--spec set_current_span(otel_ctx:t(), opentelemetry:span_ctx()) -> otel_ctx:t() | undefined.
+-spec set_current_span(otel_ctx:t(), opentelemetry:span_ctx() | undefined) -> otel_ctx:t() | undefined.
 set_current_span(Ctx, SpanCtx) ->
     otel_ctx:set_value(Ctx, ?CURRENT_SPAN_CTX, SpanCtx).
 


### PR DESCRIPTION
This function also accepts `undefined` as argument, as seen [on the test suite](https://github.com/open-telemetry/opentelemetry-erlang/blob/0cf62700c5b764b654d33d204d5292a20b7a600c/apps/opentelemetry/test/opentelemetry_SUITE.erl#L167)