### PR TITLE
support OS environment variables for setting tracer to OTLP

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -39,6 +39,7 @@ jobs:
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir }}
+      OTEL_TRACES_EXPORTER: "none"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -18,6 +18,7 @@ jobs:
         os: [ubuntu-latest]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
+      OTEL_TRACES_EXPORTER: "none"
     steps:
     - uses: actions/checkout@v2
     - name: Run Collector

--- a/apps/opentelemetry/src/opentelemetry_sup.erl
+++ b/apps/opentelemetry/src/opentelemetry_sup.erl
@@ -58,8 +58,14 @@ init([Opts]) ->
 
     Processors = proplists:get_value(processors, Opts, []),
     BatchProcessorOpts = proplists:get_value(otel_batch_processor, Processors, #{}),
+    BatchProcessorOpts1 = case proplists:get_value(traces_exporter, Opts) of
+                              undefined ->
+                                  BatchProcessorOpts;
+                              Exporter ->
+                                  BatchProcessorOpts#{exporter => Exporter}
+                          end,
     BatchProcessor = #{id => otel_batch_processor,
-                       start => {otel_batch_processor, start_link, [BatchProcessorOpts]},
+                       start => {otel_batch_processor, start_link, [BatchProcessorOpts1]},
                        restart => permanent,
                        shutdown => 5000,
                        type => worker,

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -16,7 +16,7 @@
 all() ->
     [empty_os_environment, sampler, sampler_parent_based, sampler_parent_based_zero,
      sampler_trace_id, sampler_trace_id_default, sampler_parent_based_one,
-     log_level, propagators].
+     log_level, propagators, otlp_exporter, jaeger_exporter, zipkin_exporter, none_exporter].
 
 init_per_testcase(empty_os_environment, Config) ->
     Vars = [],
@@ -34,41 +34,65 @@ init_per_testcase(propagators, Config) ->
 
     [{os_vars, Vars} | Config];
 init_per_testcase(sampler, Config) ->
-    Vars = [{"OTEL_TRACE_SAMPLER", "parentbased_always_off"}],
+    Vars = [{"OTEL_TRACES_SAMPLER", "parentbased_always_off"}],
 
     setup_env(Vars),
 
     [{os_vars, Vars} | Config];
 init_per_testcase(sampler_trace_id, Config) ->
-    Vars = [{"OTEL_TRACE_SAMPLER", "traceidratio"},
-            {"OTEL_TRACE_SAMPLER_ARG", "0.5"}],
+    Vars = [{"OTEL_TRACES_SAMPLER", "traceidratio"},
+            {"OTEL_TRACES_SAMPLER_ARG", "0.5"}],
 
     setup_env(Vars),
 
     [{os_vars, Vars} | Config];
 init_per_testcase(sampler_trace_id_default, Config) ->
-    Vars = [{"OTEL_TRACE_SAMPLER", "traceidratio"}],
+    Vars = [{"OTEL_TRACES_SAMPLER", "traceidratio"}],
 
     setup_env(Vars),
 
     [{os_vars, Vars} | Config];
 init_per_testcase(sampler_parent_based, Config) ->
-    Vars = [{"OTEL_TRACE_SAMPLER", "parentbased_traceidratio"},
-            {"OTEL_TRACE_SAMPLER_ARG", "0.5"}],
+    Vars = [{"OTEL_TRACES_SAMPLER", "parentbased_traceidratio"},
+            {"OTEL_TRACES_SAMPLER_ARG", "0.5"}],
 
     setup_env(Vars),
 
     [{os_vars, Vars} | Config];
 init_per_testcase(sampler_parent_based_one, Config) ->
-    Vars = [{"OTEL_TRACE_SAMPLER", "parentbased_traceidratio"},
-            {"OTEL_TRACE_SAMPLER_ARG", "1"}],
+    Vars = [{"OTEL_TRACES_SAMPLER", "parentbased_traceidratio"},
+            {"OTEL_TRACES_SAMPLER_ARG", "1"}],
 
     setup_env(Vars),
 
     [{os_vars, Vars} | Config];
 init_per_testcase(sampler_parent_based_zero, Config) ->
-    Vars = [{"OTEL_TRACE_SAMPLER", "parentbased_traceidratio"},
-            {"OTEL_TRACE_SAMPLER_ARG", "0"}],
+    Vars = [{"OTEL_TRACES_SAMPLER", "parentbased_traceidratio"},
+            {"OTEL_TRACES_SAMPLER_ARG", "0"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(otlp_exporter, Config) ->
+    Vars = [{"OTEL_TRACES_EXPORTER", "otlp"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(zipkin_exporter, Config) ->
+    Vars = [{"OTEL_TRACES_EXPORTER", "zipkin"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(jaeger_exporter, Config) ->
+    Vars = [{"OTEL_TRACES_EXPORTER", "jaeger"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(none_exporter, Config) ->
+    Vars = [{"OTEL_TRACES_EXPORTER", "none"}],
 
     setup_env(Vars),
 
@@ -142,6 +166,27 @@ propagators(_Config) ->
                      {propagators, [fun otel_baggage:get_text_map_propagators/0]}],
                     otel_configuration:merge_with_os([{log_level, error}])),
 
+    ok.
+
+otlp_exporter(_Config) ->
+    ?assertMatch({traces_exporter, {opentelemetry_exporter, #{}}},
+                 lists:keyfind(traces_exporter, 1, otel_configuration:merge_with_os([]))),
+
+    ok.
+
+jaeger_exporter(_Config) ->
+    ?assertMatch({traces_exporter, undefined},
+                 lists:keyfind(traces_exporter, 1, otel_configuration:merge_with_os([]))),
+    ok.
+
+zipkin_exporter(_Config) ->
+    ?assertMatch({traces_exporter, undefined},
+                 lists:keyfind(traces_exporter, 1, otel_configuration:merge_with_os([]))),
+    ok.
+
+none_exporter(_Config) ->
+    ?assertMatch({traces_exporter, undefined},
+                 lists:keyfind(traces_exporter, 1, otel_configuration:merge_with_os([]))),
     ok.
 
 %%

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,8 @@ defmodule OtelElixirTests.MixProject do
   def deps do
     [
       {:opentelemetry, path: "apps/opentelemetry", only: :test},
-      {:opentelemetry_api, path: "apps/opentelemetry_api", only: :test, override: true}
+      {:opentelemetry_api, path: "apps/opentelemetry_api", only: :test, override: true},
+      {:opentelemetry_exporter, path: "apps/opentelemetry_exporter", only: :test}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -12,8 +12,7 @@ defmodule OtelElixirTests.MixProject do
   def deps do
     [
       {:opentelemetry, path: "apps/opentelemetry", only: :test},
-      {:opentelemetry_api, path: "apps/opentelemetry_api", only: :test, override: true},
-      {:opentelemetry_exporter, path: "apps/opentelemetry_exporter", only: :test}
+      {:opentelemetry_api, path: "apps/opentelemetry_api", only: :test, override: true}
     ]
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,6 +5,7 @@ Application.put_env(:opentelemetry, :processors, [
   {:otel_batch_processor, %{scheduled_delay_ms: 1}}
 ])
 
+Application.load(:opentelemetry_exporter)
 Application.ensure_all_started(:opentelemetry)
 
 ExUnit.start()


### PR DESCRIPTION
Right now we have to throw out jaeger and zipkin exporters. I suppose we could do the same as is being done here for `otlp`, simply set the module to what it should be, like `opentelemetry_zipkin` and the user is expected to have included the application...? 

Starting to wonder if the exporter shouldn't just be a part of the SDK. I think it would be an easy call on OTP-24 since it'll support optional dependencies in `.app` but it currently would force inclusion of `grpcbox` and `inets` into every release.