### PR TITLE
fix tracer configuration merging

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-elixir@v1
@@ -35,7 +35,7 @@ jobs:
       matrix:
         otp_version: ['23.1', '22.3.4.2', '21.3.8.16']
         elixir: ['1.11.1']
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir }}
@@ -58,7 +58,7 @@ jobs:
       matrix:
         otp_version: ['23.1', '22.3.4.2', '21.3.8.16']
         elixir: ['1.11.1']
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir }}
@@ -98,7 +98,7 @@ jobs:
       matrix:
         otp_version: ['23.1']
         elixir: ['1.11.1']
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir }}

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ['23.0.2', '22.3.4.2', '21.3.8.16']
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       OTEL_TRACES_EXPORTER: "none"
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ['23.0.2', '22.3.4.2', '21.3.8.16']
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
     - uses: erlef/setup-elixir@v1

--- a/apps/opentelemetry/src/opentelemetry_sup.erl
+++ b/apps/opentelemetry/src/opentelemetry_sup.erl
@@ -50,14 +50,8 @@ init([Opts]) ->
 
     Processors = proplists:get_value(processors, Opts, []),
     BatchProcessorOpts = proplists:get_value(otel_batch_processor, Processors, #{}),
-    BatchProcessorOpts1 = case proplists:get_value(traces_exporter, Opts) of
-                              undefined ->
-                                  BatchProcessorOpts;
-                              Exporter ->
-                                  BatchProcessorOpts#{exporter => Exporter}
-                          end,
     BatchProcessor = #{id => otel_batch_processor,
-                       start => {otel_batch_processor, start_link, [BatchProcessorOpts1]},
+                       start => {otel_batch_processor, start_link, [BatchProcessorOpts]},
                        restart => permanent,
                        shutdown => 5000,
                        type => worker,

--- a/apps/opentelemetry/src/otel_batch_processor.erl
+++ b/apps/opentelemetry/src/otel_batch_processor.erl
@@ -233,10 +233,30 @@ new_export_table(Name) ->
 init_exporter(undefined) ->
     undefined;
 init_exporter({ExporterModule, Config}) when is_atom(ExporterModule) ->
-    case ExporterModule:init(Config) of
+    try ExporterModule:init(Config) of
         {ok, ExporterConfig} ->
             {ExporterModule, ExporterConfig};
         ignore ->
+            undefined
+    catch
+        error:badarg when ExporterModule =:= opentelemetry_exporter ->
+            case maps:get(protocol, Config, undefined) of
+                grpc ->
+                    ?LOG_WARNING("OTLP tracer, ~p, failed to initialize when using GRPC protocol. Verify you have the `grpcbox` dependency included.", [ExporterModule]),
+                    undefined;
+                _ ->
+                    %% leaving out config from the log since it might have secrets
+                    ?LOG_WARNING("Trace exporter module ~p threw exception when initializing: error:badarg", [ExporterModule])
+            end;
+        error:undef when ExporterModule =:= opentelemetry_exporter ->
+            ?LOG_WARNING("Trace exporter module ~p not found. Verify you have included the `opentelemetry_exporter` dependency.", [ExporterModule]),
+            undefined;
+        error:undef ->
+            ?LOG_WARNING("Trace exporter module ~p not found. Verify you have included the dependency that contains the exporter module.", [ExporterModule]),
+            undefined;
+        C:T ->
+            %% leaving out config from the log since it might have secrets
+            ?LOG_WARNING("Trace exporter module ~p threw exception when initializing: ~p:~p", [ExporterModule, C, T]),
             undefined
     end;
 init_exporter(ExporterModule) when is_atom(ExporterModule) ->

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -97,14 +97,14 @@ merge_with_environment(ConfigMappings, Opts) ->
 config_mappings(general_sdk) ->
     [{"OTEL_LOG_LEVEL", log_level, "info", existing_atom},
      {"OTEL_PROPAGATORS", propagators, "tracecontext,baggage", propagators},
-     {"OTEL_TRACES_EXPORTER", traces_exporter, undefined, exporter},
-     {"OTEL_METRICS_EXPORTER", metrics_exporter, "otlp", exporter}];
+     {"OTEL_TRACES_EXPORTER", traces_exporter, "otlp", exporter},
+     {"OTEL_METRICS_EXPORTER", metrics_exporter, undefined, exporter}];
 config_mappings(otel_batch_processor) ->
     [{"OTEL_BSP_SCHEDULE_DELAY_MILLIS", scheduled_delay_ms, 5000, integer},
      {"OTEL_BSP_EXPORT_TIMEOUT_MILLIS", exporting_timeout_ms, 30000, integer},
      {"OTEL_BSP_MAX_QUEUE_SIZE", max_queue_size, 2048, integer},
      %% a second usage of OTEL_TRACES_EXPORTER to set the exporter used by batch processor
-     {"OTEL_TRACES_EXPORTER", exporter, undefined, exporter}
+     {"OTEL_TRACES_EXPORTER", exporter, "otlp", exporter}
      %% the following are not supported yet
      %% {"OTEL_BSP_MAX_EXPORT_BATCH_SIZE", max_export_batch_size, 512}
     ].


### PR DESCRIPTION
Ran into this while working on some examples for docs.

This patch also makes the default exporter be undefined. I'm not sure what the best is here, when its defaulting to OTLP it crashes bad (confusing). So maybe it should instead be stdout or OTLP but handle the crash better to log a message to let the user it tried  using OTLP but something wasn't configured or available.