### PR TITLE
Permit keyword list start_opts in Tracer macros.

### DIFF
--- a/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
@@ -34,7 +34,7 @@ defmodule OpenTelemetry.Tracer do
   """
   defmacro start_span(name, opts \\ quote(do: %{})) do
     quote bind_quoted: [name: name, start_opts: opts] do
-      :otel_tracer.start_span(:opentelemetry.get_tracer(__MODULE__), name, start_opts)
+      :otel_tracer.start_span(:opentelemetry.get_tracer(__MODULE__), name, Map.new(start_opts))
     end
   end
 
@@ -45,7 +45,12 @@ defmodule OpenTelemetry.Tracer do
   """
   defmacro start_span(ctx, name, opts) do
     quote bind_quoted: [ctx: ctx, name: name, start_opts: opts] do
-      :otel_tracer.start_span(ctx, :opentelemetry.get_tracer(__MODULE__), name, start_opts)
+      :otel_tracer.start_span(
+        ctx,
+        :opentelemetry.get_tracer(__MODULE__),
+        name,
+        Map.new(start_opts)
+      )
     end
   end
 
@@ -76,7 +81,7 @@ defmodule OpenTelemetry.Tracer do
       :otel_tracer.with_span(
         :opentelemetry.get_tracer(__MODULE__),
         unquote(name),
-        unquote(start_opts),
+        Map.new(unquote(start_opts)),
         fn _ -> unquote(block) end
       )
     end
@@ -95,7 +100,7 @@ defmodule OpenTelemetry.Tracer do
         unquote(ctx),
         :opentelemetry.get_tracer(__MODULE__),
         unquote(name),
-        unquote(start_opts),
+        Map.new(unquote(start_opts)),
         fn _ -> unquote(block) end
       )
     end

--- a/apps/opentelemetry_api/test/open_telemetry_test.exs
+++ b/apps/opentelemetry_api/test/open_telemetry_test.exs
@@ -42,7 +42,7 @@ defmodule OpenTelemetryTest do
     assert [{"attr-1", "value-1"}] == a
   end
 
-  test "macro start_span" do
+  test "macro with_span" do
     Tracer.with_span "span-1" do
       Tracer.with_span "span-2" do
         Tracer.set_attribute("attr-1", "value-1")
@@ -52,6 +52,30 @@ defmodule OpenTelemetryTest do
 
         Tracer.add_events([event1, event2])
       end
+    end
+  end
+
+  test "macro with_span start_opts (map)" do
+    Tracer.with_span "span-1", %{
+      attributes: %{"thread.id" => inspect(self())},
+      is_recording: true,
+      kind: :internal,
+      links: [],
+      start_time: :opentelemetry.timestamp()
+      # sampler
+    } do
+      :ok
+    end
+  end
+
+  test "macro with_span start_opts (keyword list)" do
+    Tracer.with_span "span-1",
+      attributes: %{"thread.id" => inspect(self())},
+      is_recording: true,
+      kind: :internal,
+      links: [],
+      start_time: :opentelemetry.timestamp() do
+      :ok
     end
   end
 


### PR DESCRIPTION
Ergonomic for Elixir developers.

Also:

* Repair test name to reflect test code

* Provide tested examples of `with_span/3` with `start_opts` expressed as both a map and keyword list