### PR TITLE
url encode baggage keys and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ OpenTelemetry stats collection and distributed tracing framework for Erlang.
 
 Requires OTP 21.3 or above.
 
+## Contacting Us
+
+We hold regular meetings. See details at [community page](https://github.com/open-telemetry/community#special-interest-groups).
+
+We use [GitHub Discussions](https://github.com/open-telemetry/opentelemetry-erlang/discussions) for support or general questions. Feel free to drop us a line.
+
+We are also present in the #otel-erlang-elixir channel in the [CNCF slack](https://slack.cncf.io/). Please join us for more informal discussions.
+
 ## Design
 
 The [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification) defines a language library as having 2 components, the API and the SDK. The API must not only define the interfaces of any implementation in that language but also be able to function as a noop implementation of the tracer. The SDK is the default implementation of the API that must be optional.

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -215,7 +215,7 @@ propagation(Config) ->
     ?assertMatch(#span_ctx{is_recording=true}, ?current_span_ctx),
 
 
-    otel_baggage:set(<<"key-1">>, <<"value=1">>, []),
+    otel_baggage:set("key-1", <<"value=1">>, []),
     %% TODO: should the whole baggage entry be dropped if metadata is bad?
     %% drop bad metadata (the `1').
     otel_baggage:set(<<"key-2">>, <<"value-2">>, [<<"metadata">>, 1, {<<"md-k-1">>, <<"md-v-1">>}]),
@@ -234,7 +234,8 @@ propagation(Config) ->
     ?end_span(SpanCtx),
 
     ?assertEqual(#{<<"key-1">> => {<<"value=1">>, []},
-                   <<"key-2">> => {<<"value-2">>, [<<"metadata">>, {<<"md-k-1">>, <<"md-v-1">>}]}}, otel_baggage:get_all()),
+                   <<"key-2">> => {<<"value-2">>, [<<"metadata">>, {<<"md-k-1">>, <<"md-v-1">>}]}},
+                 otel_baggage:get_all()),
 
     %% ?end_span doesn't remove the span from the context
     ?assertEqual(SpanCtx, ?current_span_ctx),
@@ -250,7 +251,8 @@ propagation(Config) ->
     otel_propagator:text_map_extract(BinaryHeaders),
 
     ?assertEqual(#{<<"key-1">> => {<<"value=1">>, []},
-                   <<"key-2">> => {<<"value-2">>, [<<"metadata">>, {<<"md-k-1">>, <<"md-v-1">>}]}}, otel_baggage:get_all()),
+                   <<"key-2">> => {<<"value-2">>, [<<"metadata">>, {<<"md-k-1">>, <<"md-v-1">>}]}},
+                 otel_baggage:get_all()),
 
     %% extracted remote spans are set to the active span
     %% but with `is_recording' false

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -214,21 +214,21 @@ propagation(Config) ->
     ?assertMatch(#span_ctx{trace_flags=1}, ?current_span_ctx),
     ?assertMatch(#span_ctx{is_recording=true}, ?current_span_ctx),
 
-    otel_baggage:set("key-1", "value-1"),
-    otel_baggage:set("key-2", "value-2"),
+    otel_baggage:set(<<"key-1">>, <<"value=1">>),
+    otel_baggage:set(<<"key-2">>, <<"value-2">>),
     Headers = otel_propagator:text_map_inject([{<<"existing-header">>, <<"I exist">>}]),
 
     EncodedTraceId = io_lib:format("~32.16.0b", [TraceId]),
     EncodedSpanId = io_lib:format("~16.16.0b", [SpanId]),
 
-    ?assertListsEqual([{<<"baggage">>, "key-2=value-2,key-1=value-1"},
+    ?assertListsEqual([{<<"baggage">>, <<"key-2=value-2,key-1=value%3D1">>},
                        {<<"existing-header">>, <<"I exist">>} |
                        trace_context(Propagator, EncodedTraceId, EncodedSpanId)], Headers),
 
     ?end_span(SpanCtx),
 
-    ?assertEqual(#{"key-1" => "value-1",
-                   "key-2" => "value-2"}, otel_baggage:get_all()),
+    ?assertEqual(#{<<"key-1">> => <<"value=1">>,
+                   <<"key-2">> => <<"value-2">>}, otel_baggage:get_all()),
 
     %% ?end_span doesn't remove the span from the context
     ?assertEqual(SpanCtx, ?current_span_ctx),
@@ -243,8 +243,8 @@ propagation(Config) ->
     BinaryHeaders = [{string:uppercase(Key), iolist_to_binary(Value)} || {Key, Value} <- Headers],
     otel_propagator:text_map_extract(BinaryHeaders),
 
-    ?assertEqual(#{"key-1" => "value-1",
-                   "key-2" => "value-2"}, otel_baggage:get_all()),
+    ?assertEqual(#{<<"key-1">> => <<"value=1">>,
+                   <<"key-2">> => <<"value-2">>}, otel_baggage:get_all()),
 
     %% extracted remote spans are set to the active span
     %% but with `is_recording' false

--- a/apps/opentelemetry_api/lib/open_telemetry/baggage.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/baggage.ex
@@ -7,7 +7,8 @@ defmodule OpenTelemetry.Baggage do
 
   defdelegate set(keyvalues), to: :otel_baggage
   defdelegate set(ctx_or_key, keyvalues), to: :otel_baggage
-  defdelegate set(ctx, key, values), to: :otel_baggage
+  defdelegate set(ctx, key, value), to: :otel_baggage
+  defdelegate set(ctx, key, values, metadata), to: :otel_baggage
   defdelegate get_all(), to: :otel_baggage
   defdelegate get_all(ctx), to: :otel_baggage
   defdelegate clear(), to: :otel_baggage

--- a/apps/opentelemetry_api/lib/open_telemetry/baggage.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/baggage.ex
@@ -6,8 +6,11 @@ defmodule OpenTelemetry.Baggage do
   """
 
   defdelegate set(keyvalues), to: :otel_baggage
-  defdelegate set(key, values), to: :otel_baggage
+  defdelegate set(ctx_or_key, keyvalues), to: :otel_baggage
+  defdelegate set(ctx, key, values), to: :otel_baggage
   defdelegate get_all(), to: :otel_baggage
+  defdelegate get_all(ctx), to: :otel_baggage
   defdelegate clear(), to: :otel_baggage
+  defdelegate clear(ctx), to: :otel_baggage
   defdelegate get_text_map_propagators(), to: :otel_baggage
 end

--- a/apps/opentelemetry_api/src/otel_baggage.erl
+++ b/apps/opentelemetry_api/src/otel_baggage.erl
@@ -25,14 +25,20 @@
          clear/0,
          get_text_map_propagators/0]).
 
--type key() :: string().
--type value() :: string().
+%% keys and values are UTF-8 binaries
+-type key() :: unicode:unicode_binary().
+-type value() :: unicode:unicode_binary().
 
 -type t() :: #{key() => value()}.
 
 -export_type([t/0,
               key/0,
               value/0]).
+
+-define(DEC2HEX(X),
+        if ((X) >= 0) andalso ((X) =< 9) -> (X) + $0;
+           ((X) >= 10) andalso ((X) =< 15) -> (X) + $A - 10
+        end).
 
 -define(BAGGAGE_KEY, '$__otel_baggage_ctx_key').
 -define(BAGGAGE_HEADER, <<"baggage">>).
@@ -61,10 +67,10 @@ clear() ->
 get_text_map_propagators() ->
     ToText = fun(Baggage) when is_map(Baggage) ->
                      case maps:fold(fun(Key, Value, Acc) ->
-                                            [$,, [Key, "=", Value] | Acc]
+                                            [$,, [encode_key(Key), "=", encode_value(Value)] | Acc]
                                     end, [], Baggage) of
                          [$, | List] ->
-                             [{?BAGGAGE_HEADER, unicode:characters_to_list(List)}];
+                             [{?BAGGAGE_HEADER, unicode:characters_to_binary(List)}];
                          _ ->
                              []
                      end;
@@ -79,8 +85,8 @@ get_text_map_propagators() ->
                                Pairs = string:lexemes(String, [$,]),
                                lists:foldl(fun(Pair, Acc) ->
                                                    [Key, Value] = string:split(Pair, "="),
-                                                   Acc#{unicode:characters_to_list(Key) =>
-                                                            unicode:characters_to_list(Value)}
+                                                   Acc#{decode_key(Key) =>
+                                                            decode_value(Value)}
                                            end, CurrentBaggage, Pairs)
                        end
                end,
@@ -97,4 +103,95 @@ lookup(Header, [{H, Value} | Rest]) ->
             Value;
         false ->
             lookup(Header, Rest)
+    end.
+
+encode_key(Key) ->
+    form_urlencode(Key, [{encoding, utf8}]).
+
+encode_value(Value) ->
+    form_urlencode(Value, [{encoding, utf8}]).
+
+decode_key(Key) ->
+    uri_string:percent_decode(string:trim(unicode:characters_to_binary(Key))).
+
+decode_value(Value) ->
+    uri_string:percent_decode(string:trim(unicode:characters_to_binary(Value))).
+
+%% HTML 5.2 - 4.10.21.6 URL-encoded form data - WHATWG URL (10 Jan 2018) - UTF-8
+%% HTML 5.0 - 4.10.22.6 URL-encoded form data - encoding (non UTF-8)
+form_urlencode(Cs, [{encoding, latin1}]) when is_list(Cs) ->
+    B = convert_to_binary(Cs, utf8, utf8),
+    html5_byte_encode(base10_encode(B));
+form_urlencode(Cs, [{encoding, latin1}]) when is_binary(Cs) ->
+    html5_byte_encode(base10_encode(Cs));
+form_urlencode(Cs, [{encoding, Encoding}])
+  when is_list(Cs), Encoding =:= utf8; Encoding =:= unicode ->
+    B = convert_to_binary(Cs, utf8, Encoding),
+    html5_byte_encode(B);
+form_urlencode(Cs, [{encoding, Encoding}])
+  when is_binary(Cs), Encoding =:= utf8; Encoding =:= unicode ->
+    html5_byte_encode(Cs);
+form_urlencode(Cs, [{encoding, Encoding}]) when is_list(Cs); is_binary(Cs) ->
+    throw({error,invalid_encoding, Encoding});
+form_urlencode(Cs, _) ->
+    throw({error,invalid_input, Cs}).
+
+
+%% For each character in the entry's name and value that cannot be expressed using
+%% the selected character encoding, replace the character by a string consisting of
+%% a U+0026 AMPERSAND character (&), a "#" (U+0023) character, one or more ASCII
+%% digits representing the Unicode code point of the character in base ten, and
+%% finally a ";" (U+003B) character.
+base10_encode(Cs) ->
+    base10_encode(Cs, <<>>).
+%%
+base10_encode(<<>>, Acc) ->
+    Acc;
+base10_encode(<<H/utf8,T/binary>>, Acc) when H > 255 ->
+    Base10 = convert_to_binary(integer_to_list(H,10), utf8, utf8),
+    base10_encode(T, <<Acc/binary,"&#",Base10/binary,$;>>);
+base10_encode(<<H/utf8,T/binary>>, Acc) ->
+    base10_encode(T, <<Acc/binary,H>>).
+
+
+html5_byte_encode(B) ->
+    html5_byte_encode(B, <<>>).
+%%
+html5_byte_encode(<<>>, Acc) ->
+    Acc;
+html5_byte_encode(<<$ ,T/binary>>, Acc) ->
+    html5_byte_encode(T, <<Acc/binary,$+>>);
+html5_byte_encode(<<H,T/binary>>, Acc) ->
+    case is_url_char(H) of
+        true ->
+            html5_byte_encode(T, <<Acc/binary,H>>);
+        false ->
+            <<A:4,B:4>> = <<H>>,
+            html5_byte_encode(T, <<Acc/binary,$%,(?DEC2HEX(A)),(?DEC2HEX(B))>>)
+    end;
+html5_byte_encode(H, _Acc) ->
+    throw({error,invalid_input, H}).
+
+
+%% Return true if input char can appear in form-urlencoded string
+%% Allowed chararacters:
+%%   0x2A, 0x2D, 0x2E, 0x30 to 0x39, 0x41 to 0x5A,
+%%   0x5F, 0x61 to 0x7A
+is_url_char(C)
+  when C =:= 16#2A; C =:= 16#2D;
+       C =:= 16#2E; C =:= 16#5F;
+       16#30 =< C, C =< 16#39;
+       16#41 =< C, C =< 16#5A;
+       16#61 =< C, C =< 16#7A -> true;
+is_url_char(_) -> false.
+
+%% Convert to binary
+convert_to_binary(Binary, InEncoding, OutEncoding) ->
+    case unicode:characters_to_binary(Binary, InEncoding, OutEncoding) of
+        {error, _List, RestData} ->
+            throw({error, invalid_input, RestData});
+        {incomplete, _List, RestData} ->
+            throw({error, invalid_input, RestData});
+        Result ->
+            Result
     end.

--- a/apps/opentelemetry_api/src/otel_baggage.erl
+++ b/apps/opentelemetry_api/src/otel_baggage.erl
@@ -73,7 +73,7 @@ set(Ctx, KeyValues) when is_map(KeyValues) ->
     Baggage = otel_ctx:get_value(Ctx, ?BAGGAGE_KEY, #{}),
     otel_ctx:set_value(Ctx, ?BAGGAGE_KEY, maps:merge(Baggage, verify_baggage(KeyValues))).
 
--spec set(otel_ctx:t(), key(), value()) -> ok | otel_ctx:t().
+-spec set(otel_ctx:t() | key(), key() | value(), value() | list()) -> ok | otel_ctx:t().
 set(Key, Value, Metadata) when is_list(Key) ; is_binary(Key) ->
     Baggage = otel_ctx:get_value(?BAGGAGE_KEY, #{}),
     otel_ctx:set_value(?BAGGAGE_KEY, maps:merge(Baggage, verify_baggage(#{Key => {Value, Metadata}})));

--- a/apps/opentelemetry_api/src/otel_baggage.erl
+++ b/apps/opentelemetry_api/src/otel_baggage.erl
@@ -64,7 +64,7 @@ set(_) ->
     ok.
 
 %% Ctx will never be a list or binary so we can tell if a context is passed by checking that
--spec set(otel_ctx:t() | key(), #{key() => value()} | [{key(), value()}] | value()) -> otel_ctx:t().
+-spec set(otel_ctx:t() | key() | unicode:charlist(), #{key() => value()} | [{key(), value()}] | value()) -> otel_ctx:t().
 set(Key, Value) when is_list(Key) ; is_binary(Key) ->
     set(Key, Value, []);
 set(Ctx, KeyValues) when is_list(KeyValues) ->

--- a/apps/opentelemetry_api/src/otel_ctx.erl
+++ b/apps/opentelemetry_api/src/otel_ctx.erl
@@ -27,7 +27,9 @@
          get_value/2,
          get_value/3,
          remove/1,
+         remove/2,
          clear/0,
+         clear/1,
 
          attach/1,
          detach/1,
@@ -58,7 +60,8 @@ new() ->
 
 -spec set_value(term(), term()) -> ok.
 set_value(Key, Value) ->
-    erlang:put(?CURRENT_CTX, set_value(erlang:get(?CURRENT_CTX), Key, Value)).
+    erlang:put(?CURRENT_CTX, set_value(erlang:get(?CURRENT_CTX), Key, Value)),
+    ok.
 
 -spec set_value(t(), term(), term()) -> map().
 set_value(Ctx, Key, Value) when is_map(Ctx) ->
@@ -84,7 +87,12 @@ get_value(_, _, Default) ->
 
 -spec clear() -> ok.
 clear() ->
-    erlang:erase(?CURRENT_CTX).
+    erlang:erase(?CURRENT_CTX),
+    ok.
+
+-spec clear(t()) -> t().
+clear(_) ->
+    new().
 
 -spec remove(term()) -> ok.
 remove(Key) ->
@@ -95,6 +103,12 @@ remove(Key) ->
         _ ->
             ok
     end.
+
+-spec remove(t(), term()) -> t().
+remove(Ctx, Key) when is_map(Ctx) ->
+    maps:remove(Key, Ctx);
+remove(_, _) ->
+    new().
 
 -spec get_current() -> map().
 get_current() ->

--- a/apps/opentelemetry_api/test/open_telemetry_test.exs
+++ b/apps/opentelemetry_api/test/open_telemetry_test.exs
@@ -91,10 +91,10 @@ defmodule OpenTelemetryTest do
 
   test "baggage api from elixir" do
     Baggage.set(%{"a" => "b"})
-    assert %{"a" => "b"} = Baggage.get_all()
+    assert %{"a" => {"b", []}} = Baggage.get_all()
 
     Baggage.set(%{"a" => "c"})
-    assert %{"a" => "c"} = Baggage.get_all()
+    assert %{"a" => {"c", []}} = Baggage.get_all()
 
     Baggage.clear()
     assert 0 = :erlang.map_size(Baggage.get_all())
@@ -114,7 +114,7 @@ defmodule OpenTelemetryTest do
     ctx = Ctx.get_current()
 
     Baggage.set(%{"a" => "b"})
-    assert %{"a" => "b"} = Baggage.get_all()
+    assert %{"a" => {"b", []}} = Baggage.get_all()
 
     # attach the empty context
     # gets a token for the context
@@ -123,6 +123,6 @@ defmodule OpenTelemetryTest do
 
     # return to the context in the pdict before the attach
     Ctx.detach(token)
-    assert %{"a" => "b"} = Baggage.get_all()
+    assert %{"a" => {"b", []}} = Baggage.get_all()
   end
 end

--- a/apps/opentelemetry_api/test/otel_baggage_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_baggage_SUITE.erl
@@ -22,11 +22,13 @@ pdict_context(_Config) ->
     otel_baggage:set(<<"key-1">>, <<"value-1">>),
     otel_baggage:set([{<<"key-2">>, <<"value-2">>}]),
 
-    ?assertEqual(#{<<"key-1">> => <<"value-1">>,<<"key-2">> => <<"value-2">>}, otel_baggage:get_all()),
+    ?assertEqual(#{<<"key-1">> => {<<"value-1">>, []},
+                   <<"key-2">> => {<<"value-2">>, []}}, otel_baggage:get_all()),
 
     otel_baggage:set(#{<<"key-1">> => <<"value-3">>}),
 
-    ?assertEqual(#{<<"key-1">> => <<"value-3">>,<<"key-2">> => <<"value-2">>}, otel_baggage:get_all()),
+    ?assertEqual(#{<<"key-1">> => {<<"value-3">>, []},
+                   <<"key-2">> => {<<"value-2">>, []}}, otel_baggage:get_all()),
 
     otel_baggage:clear(),
     ?assert(maps:size(otel_baggage:get_all()) =:= 0),
@@ -37,9 +39,10 @@ explicit_context(_Config) ->
     Ctx = otel_ctx:new(),
 
     Ctx1 = otel_baggage:set(Ctx, <<"key-1">>, <<"value-1">>),
-    Ctx2 = otel_baggage:set(Ctx1, [{<<"key-2">>, <<"value-2">>}]),
+    Ctx2 = otel_baggage:set(Ctx1, [{"key-2", "value-2"}]),
 
-    ?assertEqual(#{<<"key-1">> => <<"value-1">>,<<"key-2">> => <<"value-2">>}, otel_baggage:get_all(Ctx2)),
+    ?assertEqual(#{<<"key-1">> => {<<"value-1">>, []},
+                   <<"key-2">> => {<<"value-2">>, []}}, otel_baggage:get_all(Ctx2)),
 
     Ctx3 = otel_baggage:clear(Ctx2),
     ?assert(maps:size(otel_baggage:get_all(Ctx3)) =:= 0),

--- a/apps/opentelemetry_api/test/otel_baggage_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_baggage_SUITE.erl
@@ -1,0 +1,48 @@
+-module(otel_baggage_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include("opentelemetry.hrl").
+-include("otel_tracer.hrl").
+
+all() ->
+    [pdict_context, explicit_context].
+
+init_per_suite(Config) ->
+    application:load(opentelemetry_api),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+pdict_context(_Config) ->
+    otel_baggage:set(<<"key-1">>, <<"value-1">>),
+    otel_baggage:set([{<<"key-2">>, <<"value-2">>}]),
+
+    ?assertEqual(#{<<"key-1">> => <<"value-1">>,<<"key-2">> => <<"value-2">>}, otel_baggage:get_all()),
+
+    otel_baggage:set(#{<<"key-1">> => <<"value-3">>}),
+
+    ?assertEqual(#{<<"key-1">> => <<"value-3">>,<<"key-2">> => <<"value-2">>}, otel_baggage:get_all()),
+
+    otel_baggage:clear(),
+    ?assert(maps:size(otel_baggage:get_all()) =:= 0),
+
+    ok.
+
+explicit_context(_Config) ->
+    Ctx = otel_ctx:new(),
+
+    Ctx1 = otel_baggage:set(Ctx, <<"key-1">>, <<"value-1">>),
+    Ctx2 = otel_baggage:set(Ctx1, [{<<"key-2">>, <<"value-2">>}]),
+
+    ?assertEqual(#{<<"key-1">> => <<"value-1">>,<<"key-2">> => <<"value-2">>}, otel_baggage:get_all(Ctx2)),
+
+    Ctx3 = otel_baggage:clear(Ctx2),
+    ?assert(maps:size(otel_baggage:get_all(Ctx3)) =:= 0),
+
+    ok.
+

--- a/apps/opentelemetry_exporter/README.md
+++ b/apps/opentelemetry_exporter/README.md
@@ -1,6 +1,6 @@
 # opentelemetry_exporter
 
-![Common Test](https://github.com/opentelemetry-beam/opentelemetry_exporter/workflows/Common%20Test/badge.svg) [![Gitter](https://badges.gitter.im/open-telemetry/opentelemetry-erlang.svg)](https://gitter.im/open-telemetry/opentelemetry-erlang?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+![Common Test](https://github.com/opentelemetry-beam/opentelemetry_exporter/workflows/Common%20Test/badge.svg) 
 
 The OpenTelemetry Protocol exporter for use with the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector).
 


### PR DESCRIPTION
Fix for #224 and #225 

This may not be completely ready yet but opening now for review.

Possible changes needed:

* Are keys supposed to be percent encoded
* How to handle metadata? It may just be part of the value and thus nothing to do (except that I don't think the `?` and `;` should be percent encoded if that is the case so even if it is just part of the value it may need updates to act properly.)

Baggage spec: https://w3c.github.io/baggage/