### PR TITLE
Better compliance with status spec

### DIFF
--- a/apps/opentelemetry_api/include/opentelemetry.hrl
+++ b/apps/opentelemetry_api/include/opentelemetry.hrl
@@ -30,6 +30,10 @@
 -define(SPAN_KIND_PRODUCER, producer).
 -define(SPAN_KIND_CONSUMER, consumer).
 
+-define(OTEL_STATUS_UNSET, unset).
+-define(OTEL_STATUS_OK, ok).
+-define(OTEL_STATUS_ERROR, error).
+
 -record(span_ctx, {
           %% 128 bit int trace id
           trace_id          :: opentelemetry:trace_id(),
@@ -70,11 +74,7 @@
          }).
 
 -record(status, {
-          code    :: atom() | integer(),
+          code = ?OTEL_STATUS_UNSET :: opentelemetry:status_code(),
           %% developer-facing error message
-          message :: unicode:unicode_binary()
+          message = <<"">>          :: unicode:unicode_binary()
          }).
-
--define(OTEL_STATUS_UNSET, unset).
--define(OTEL_STATUS_OK, ok).
--define(OTEL_STATUS_ERROR, error).

--- a/apps/opentelemetry_api/lib/open_telemetry.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry.ex
@@ -111,7 +111,10 @@ defmodule OpenTelemetry do
 
   @typedoc """
   An optional final status for this span. Semantically when Status
-  wasn't set it means span ended without errors and assume `ok`.
+  wasn't set it means span ended without errors and assume `unset`.
+
+  Application developers may set the status as `ok` when the operation
+  has been validated to have completed successfully.
   """
   @type status() :: :opentelemetry.status()
 
@@ -212,6 +215,6 @@ defmodule OpenTelemetry do
   @doc """
   Creates a Status.
   """
-  @spec status(atom(), String.t()) :: status()
+  @spec status(:opentelemetry.status_code(), String.t()) :: status()
   defdelegate status(code, message), to: :opentelemetry
 end

--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -126,7 +126,7 @@ defmodule OpenTelemetry.Span do
   @doc """
   Sets the Status of the currently active Span.
 
-  If used, this will override the default Span Status, which is `ok`.
+  If used, this will override the default Span Status, which is `:unset`.
   """
   @spec set_status(OpenTelemetry.span_ctx(), OpenTelemetry.status()) :: boolean()
   defdelegate set_status(span_ctx, status), to: :otel_span

--- a/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
@@ -173,7 +173,7 @@ defmodule OpenTelemetry.Tracer do
   @doc """
   Sets the Status of the currently active Span.
 
-  If used, this will override the default Span Status, which is `ok`.
+  If used, this will override the default Span Status, which is `:unset`.
   """
   @spec set_status(OpenTelemetry.status()) :: boolean()
   def set_status(status) do

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -298,10 +298,12 @@ events(List) ->
 -spec status(Code, Message) -> status() | undefined when
       Code :: status_code(),
       Message :: unicode:unicode_binary().
-status(Code, Message) when is_atom(Code),
-                           is_binary(Message) ->
-    #status{code=Code,
-            message=Message};
+status(?OTEL_STATUS_ERROR, Message) when is_binary(Message) ->
+    #status{code=?OTEL_STATUS_ERROR};
+status(ok, _Message) ->
+    #status{code=?OTEL_STATUS_OK};
+status(unset, _Message) ->
+    #status{code=?OTEL_STATUS_UNSET};
 status(_, _) ->
     undefined.
 

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -299,10 +299,10 @@ events(List) ->
       Code :: status_code(),
       Message :: unicode:unicode_binary().
 status(?OTEL_STATUS_ERROR, Message) when is_binary(Message) ->
-    #status{code=?OTEL_STATUS_ERROR};
-status(ok, _Message) ->
+    #status{code=?OTEL_STATUS_ERROR, message=Message};
+status(?OTEL_STATUS_OK, _Message) ->
     #status{code=?OTEL_STATUS_OK};
-status(unset, _Message) ->
+status(?OTEL_STATUS_UNSET, _Message) ->
     #status{code=?OTEL_STATUS_UNSET};
 status(_, _) ->
     undefined.

--- a/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
+++ b/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
@@ -120,7 +120,7 @@ update_span_data(_Config) ->
     Events = opentelemetry:events([{opentelemetry:timestamp(),
                                     <<"timed-event-name">>, []}]),
     Status = opentelemetry:status(?OTEL_STATUS_OK, <<"This is Ok">>),
-    ?assertMatch(#status{code = ?OTEL_STATUS_OK, message = <<"This is Ok">>}, Status),
+    ?assertMatch(#status{code = ?OTEL_STATUS_OK, message = <<"">>}, Status),
 
     otel_span:set_status(SpanCtx1, Status),
     otel_span:add_events(SpanCtx1, Events),

--- a/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
+++ b/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
@@ -119,6 +119,12 @@ update_span_data(_Config) ->
 
     Events = opentelemetry:events([{opentelemetry:timestamp(),
                                     <<"timed-event-name">>, []}]),
+    ErrorStatus = opentelemetry:status(?OTEL_STATUS_ERROR, <<"This is an error!">>),
+    ?assertMatch(#status{code = ?OTEL_STATUS_ERROR, message = <<"This is an error!">>}, ErrorStatus),
+
+    UnsetStatus = opentelemetry:status(?OTEL_STATUS_UNSET, <<"This is a message">>),
+    ?assertMatch(#status{code = ?OTEL_STATUS_UNSET, message = <<"">>}, UnsetStatus),
+
     Status = opentelemetry:status(?OTEL_STATUS_OK, <<"This is Ok">>),
     ?assertMatch(#status{code = ?OTEL_STATUS_OK, message = <<"">>}, Status),
 


### PR DESCRIPTION
Statuses are not allowed to be freeform and descriptions are only acceptable for errors. For the other statuses, descriptions are to be ignored.

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status