### PR TITLE
Remove the OTLP receiver legacy gRPC port(55680) references

### DIFF
--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -204,7 +204,7 @@ verify_export(Config) ->
     Protocol = ?config(protocol, Config),
     Port = case Protocol of
                grpc ->
-                   55680;
+                   4317;
                http_protobuf ->
                    55681
            end,

--- a/config/otel-collector-config.yaml
+++ b/config/otel-collector-config.yaml
@@ -3,7 +3,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: "0.0.0.0:55680"
+        endpoint: "0.0.0.0:4317"
       http:
         endpoint: "0.0.0.0:55681"
 processors:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   otel:
     image: otel/opentelemetry-collector-contrib-dev
@@ -6,7 +6,7 @@ services:
     privileged: true
     ports:
       - 55681:55681
-      - 55680:55680
+      - 4317:4317
     volumes:
       - ./config/otel-collector-config.yaml:/conf/otel-collector-config.yaml
     links:


### PR DESCRIPTION
**Description:**
The legacy gRPC port(55680) in OTLP Receiver will be disabled in OTel Collector before the collector GA.

This CR is to replace all gRPC port occurrences from `55680` to `4317`. Making the same changes to the rest of OTEL SDKs and website.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2565