### PR TITLE
Remove unused header in otel_span_ets

### DIFF
--- a/apps/opentelemetry/src/otel_span_ets.erl
+++ b/apps/opentelemetry/src/otel_span_ets.erl
@@ -37,7 +37,6 @@
          update_name/2]).
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
--include("otel_tracer.hrl").
 -include("otel_span.hrl").
 -include("otel_span_ets.hrl").
 


### PR DESCRIPTION
The warning detected by erlang_ls that `otel_tracer.hrl` is unused in
otel_span_ets module. This change remove this include.