### PR TITLE
Upgrade Elixir and OTP in GitHub Workflow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,6 +41,7 @@ jobs:
           - otp_version: '21.3.8.24'
             elixir_version: '1.11.4'
             rebar3_version: '3.15.2'
+            os: ubuntu-18.04
         exclude:
           - otp_version: '21.3.8.24'
             elixir: '1.12.1'
@@ -73,6 +74,7 @@ jobs:
           - otp_version: '21.3.8.24'
             elixir_version: '1.11.4'
             rebar3_version: '3.15.2'
+            os: ubuntu-18.04
         exclude:
           - otp_version: '21.3.8.24'
             elixir: '1.12.1'

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -33,16 +33,16 @@ jobs:
     name: Test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['24.0.2', '23.3.4.1', '22.3.4.19']
+        otp_version: ['24.0.2', '23.3.4.2', '22.3.4.20']
         elixir: ['1.12.1', '1.11.4']
         rebar3_version: ['3.16.1']
         os: [ubuntu-18.04]
         include:
-          - otp_version: '21.3.8.23'
+          - otp_version: '21.3.8.24'
             elixir_version: '1.11.4'
             rebar3_version: '3.15.2'
         exclude:
-          - otp_version: '21.3.8.23'
+          - otp_version: '21.3.8.24'
             elixir: '1.12.1'
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
@@ -65,16 +65,16 @@ jobs:
     name: Test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['24.0.2', '23.3.4.1', '22.3.4.19']
+        otp_version: ['24.0.2', '23.3.4.2', '22.3.4.20']
         elixir: ['1.12.1', '1.11.4']
         rebar3_version: ['3.16.1']
         os: [ubuntu-18.04]
         include:
-          - otp_version: '21.3.8.23'
+          - otp_version: '21.3.8.24'
             elixir_version: '1.11.4'
             rebar3_version: '3.15.2'
         exclude:
-          - otp_version: '21.3.8.23'
+          - otp_version: '21.3.8.24'
             elixir: '1.12.1'
     env:
       OTP_VERSION: ${{ matrix.otp_version }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: '24.0.1'
           elixir-version: '1.12.1'
@@ -33,9 +33,14 @@ jobs:
     name: Test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['24.0.1', '23.3.4.1', '22.3.4.19', '21.3.8.23']
+        otp_version: ['24.0.2', '23.3.4.1', '22.3.4.19']
         elixir: ['1.12.1', '1.11.4']
+        rebar3_version: ['3.16.1']
         os: [ubuntu-18.04]
+        include:
+          - otp_version: '21.3.8.23'
+            elixir_version: '1.11.4'
+            rebar3_version: '3.15.2'
         exclude:
           - otp_version: '21.3.8.23'
             elixir: '1.12.1'
@@ -45,10 +50,11 @@ jobs:
       OTEL_TRACES_EXPORTER: "none"
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp_version }}
           elixir-version: ${{ matrix.elixir }}
+          rebar3-version: ${{ matrix.rebar3_version }}
       - name: Compile
         run: rebar3 as test compile
       - name: ExUnit
@@ -59,9 +65,14 @@ jobs:
     name: Test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['24.0.1', '23.3.4.1', '22.3.4.19', '21.3.8.23']
+        otp_version: ['24.0.2', '23.3.4.1', '22.3.4.19']
         elixir: ['1.12.1', '1.11.4']
+        rebar3_version: ['3.16.1']
         os: [ubuntu-18.04]
+        include:
+          - otp_version: '21.3.8.23'
+            elixir_version: '1.11.4'
+            rebar3_version: '3.15.2'
         exclude:
           - otp_version: '21.3.8.23'
             elixir: '1.12.1'
@@ -73,10 +84,11 @@ jobs:
         working-directory: apps/opentelemetry_api/
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp_version }}
           elixir-version: ${{ matrix.elixir }}
+          rebar3-version: ${{ matrix.rebar3_version }}
       - uses: actions/cache@v2
         name: Cache
         with:
@@ -102,7 +114,7 @@ jobs:
     name: Dialyze on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['24.0.1']
+        otp_version: ['24.0.2']
         elixir: ['1.12.1']
         os: [ubuntu-18.04]
     env:
@@ -113,7 +125,7 @@ jobs:
         working-directory: apps/opentelemetry_api/
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp_version }}
           elixir-version: ${{ matrix.elixir }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-elixir@v1
         with:
-          otp-version: '23.1'
-          elixir-version: '1.11.1'
+          otp-version: '24.0.1'
+          elixir-version: '1.12.1'
       - uses: actions/cache@v2
         name: Cache
         with:
@@ -33,9 +33,12 @@ jobs:
     name: Test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['23.1', '22.3.4.2', '21.3.8.16']
-        elixir: ['1.11.1']
+        otp_version: ['24.0.1', '23.3.4.1', '22.3.4.19', '21.3.8.23']
+        elixir: ['1.12.1', '1.11.4']
         os: [ubuntu-18.04]
+        exclude:
+          - otp_version: '21.3.8.23'
+            elixir: '1.12.1'
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir }}
@@ -56,9 +59,12 @@ jobs:
     name: Test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['23.1', '22.3.4.2', '21.3.8.16']
-        elixir: ['1.11.1']
+        otp_version: ['24.0.1', '23.3.4.1', '22.3.4.19', '21.3.8.23']
+        elixir: ['1.12.1', '1.11.4']
         os: [ubuntu-18.04]
+        exclude:
+          - otp_version: '21.3.8.23'
+            elixir: '1.12.1'
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir }}
@@ -96,8 +102,8 @@ jobs:
     name: Dialyze on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['23.1']
-        elixir: ['1.11.1']
+        otp_version: ['24.0.1']
+        elixir: ['1.12.1']
         os: [ubuntu-18.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -14,8 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['24.0.1', '23.3.4.1', '22.3.4.19', '21.3.8.23']
+        otp_version: ['24.0.2', '23.3.4.1', '22.3.4.19']
+        rebar3_version: ['3.16.1']
         os: [ubuntu-18.04]
+        include:
+          - otp_version: '21.3.8.23'
+            rebar3_version: '3.15.2'
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       OTEL_TRACES_EXPORTER: "none"
@@ -23,9 +27,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run Collector
       run: docker-compose up -d
-    - uses: erlef/setup-elixir@v1
+    - uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ matrix.otp_version }}
+        rebar3-version: ${{ matrix.rebar3_version }}
         elixir-version: '1.11.1'
     - uses: actions/cache@v2
       name: Cache
@@ -69,14 +74,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['24.0.1', '23.3.4.1', '22.3.4.19', '21.3.8.23']
+        otp_version: ['24.0.2', '23.3.4.1', '22.3.4.19']
+        rebar3_version: ['3.16.1']
         os: [ubuntu-18.04]
+        include:
+          - otp_version: '21.3.8.23'
+            rebar3_version: '3.15.2'
     steps:
     - uses: actions/checkout@v2
-    - uses: erlef/setup-elixir@v1
+    - uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ matrix.otp_version }}
-        elixir-version: '1.11.1'
+        rebar3-version: ${{ matrix.rebar3_version }}
+        elixir-version: '1.12.1'
     - uses: actions/cache@v2
       name: Cache
       with:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -20,6 +20,7 @@ jobs:
         include:
           - otp_version: '21.3.8.24'
             rebar3_version: '3.15.2'
+            os: ubuntu-18.04
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       OTEL_TRACES_EXPORTER: "none"
@@ -80,6 +81,7 @@ jobs:
         include:
           - otp_version: '21.3.8.24'
             rebar3_version: '3.15.2'
+            os: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - uses: erlef/setup-beam@v1

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['23.0.2', '22.3.4.2', '21.3.8.16']
+        otp_version: ['24.0.1', '23.3.4.1', '22.3.4.19', '21.3.8.23']
         os: [ubuntu-18.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
@@ -69,7 +69,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['23.0.2', '22.3.4.2', '21.3.8.16']
+        otp_version: ['24.0.1', '23.3.4.1', '22.3.4.19', '21.3.8.23']
         os: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['24.0.2', '23.3.4.1', '22.3.4.19']
+        otp_version: ['24.0.2', '23.3.4.2', '22.3.4.20']
         rebar3_version: ['3.16.1']
         os: [ubuntu-18.04]
         include:
-          - otp_version: '21.3.8.23'
+          - otp_version: '21.3.8.24'
             rebar3_version: '3.15.2'
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
@@ -74,11 +74,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ['24.0.2', '23.3.4.1', '22.3.4.19']
+        otp_version: ['24.0.2', '23.3.4.2', '22.3.4.20']
         rebar3_version: ['3.16.1']
         os: [ubuntu-18.04]
         include:
-          - otp_version: '21.3.8.23'
+          - otp_version: '21.3.8.24'
             rebar3_version: '3.15.2'
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This change do:

* Add Elixir 1.12.1 and upgrade 1.11 to latest release.
* Add OTP 24.0.1 and upgrade major OTP release to latest release.
* Use rebar3 v1.15.2 for OTP 21. And v1.16.1 for OTP 22+.