### PR TITLE
Add guard to register_tracer

### DIFF
--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -133,7 +133,7 @@ set_tracer(Name, Tracer) ->
 
 -spec register_tracer(atom(), string() | binary()) -> boolean().
 register_tracer(Name, Vsn) when is_atom(Name) and is_binary(Vsn) ->
-    otel_tracer_provider:register_tracer(Name, Vsn).
+    otel_tracer_provider:register_tracer(Name, Vsn);
 register_tracer(Name, Vsn) when is_atom(Name) and is_list(Vsn) ->
     otel_tracer_provider:register_tracer(Name, list_to_binary(Vsn)).
 

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -132,7 +132,7 @@ set_tracer(Name, Tracer) ->
     verify_and_set_term(Tracer, Name, otel_tracer).
 
 -spec register_tracer(atom(), string()) -> boolean().
-register_tracer(Name, Vsn) ->
+register_tracer(Name, Vsn) when is_atom(Name) and is_binary(Vsn) ->
     otel_tracer_provider:register_tracer(Name, Vsn).
 
 -spec register_application_tracer(atom()) -> boolean().

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -131,9 +131,11 @@ set_default_tracer(Tracer) ->
 set_tracer(Name, Tracer) ->
     verify_and_set_term(Tracer, Name, otel_tracer).
 
--spec register_tracer(atom(), string()) -> boolean().
+-spec register_tracer(atom(), string() | binary()) -> boolean().
 register_tracer(Name, Vsn) when is_atom(Name) and is_binary(Vsn) ->
     otel_tracer_provider:register_tracer(Name, Vsn).
+register_tracer(Name, Vsn) when is_atom(Name) and is_list(Vsn) ->
+    otel_tracer_provider:register_tracer(Name, list_to_binary(Vsn))
 
 -spec register_application_tracer(atom()) -> boolean().
 register_application_tracer(Name) ->

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -135,7 +135,7 @@ set_tracer(Name, Tracer) ->
 register_tracer(Name, Vsn) when is_atom(Name) and is_binary(Vsn) ->
     otel_tracer_provider:register_tracer(Name, Vsn).
 register_tracer(Name, Vsn) when is_atom(Name) and is_list(Vsn) ->
-    otel_tracer_provider:register_tracer(Name, list_to_binary(Vsn))
+    otel_tracer_provider:register_tracer(Name, list_to_binary(Vsn)).
 
 -spec register_application_tracer(atom()) -> boolean().
 register_application_tracer(Name) ->

--- a/apps/opentelemetry_api/src/otel_tracer_provider.erl
+++ b/apps/opentelemetry_api/src/otel_tracer_provider.erl
@@ -32,7 +32,7 @@
 -type cb_state() :: term().
 
 -callback init(term()) -> {ok, cb_state()}.
--callback register_tracer(atom(), string(), cb_state()) -> boolean().
+-callback register_tracer(atom(), binary(), cb_state()) -> boolean().
 -callback resource(cb_state()) -> term() | undefined.
 
 -record(state, {callback :: module(),
@@ -50,7 +50,7 @@ resource() ->
             undefined
     end.
 
--spec register_tracer(atom(), string()) -> boolean().
+-spec register_tracer(atom(), binary()) -> boolean().
 register_tracer(Name, Vsn) ->
     try
         gen_server:call(?MODULE, {register_tracer, Name, Vsn})


### PR DESCRIPTION
Without this, the exporter fails later if you send the second argument
as a float, for example.
