### PR TITLE
Introduce otel_sampler:new/3 and fix behavior typespec

### DIFF
--- a/apps/opentelemetry/src/otel_sampler.erl
+++ b/apps/opentelemetry/src/otel_sampler.erl
@@ -37,17 +37,17 @@
 -type sampling_decision() :: ?DROP | ?RECORD_ONLY | ?RECORD_AND_SAMPLE.
 -type sampling_result() :: {sampling_decision(), opentelemetry:attributes(), opentelemetry:tracestate()}.
 -type description() :: unicode:unicode_binary().
--type decider() :: fun((otel_ctx:t(),
-                        opentelemetry:trace_id(),
-                        opentelemetry:links(),
-                        opentelemetry:span_name(),
-                        opentelemetry:span_kind(),
-                        opentelemetry:attributes(),
-                        term()) -> sampling_result()).
--type sampler() :: {decider(), description(), sampler_opts()}.
+-type sampler_fun() :: fun((otel_ctx:t(),
+                            opentelemetry:trace_id(),
+                            opentelemetry:links(),
+                            opentelemetry:span_name(),
+                            opentelemetry:span_kind(),
+                            opentelemetry:attributes(),
+                            term()) -> sampling_result()).
+-type sampler() :: {sampler_fun(), description(), sampler_opts()}.
 -type sampler_opts() :: term().
 -opaque t() :: sampler().
--export_type([decider/0,
+-export_type([sampler_fun/0,
               description/0,
               sampling_result/0,
               sampling_decision/0,
@@ -56,7 +56,7 @@
 
 -define(MAX_VALUE, 9223372036854775807). %% 2^63 - 1
 
--spec new(decider(), description(), sampler_opts()) -> t().
+-spec new(sampler_fun(), description(), sampler_opts()) -> t().
 new(DecisionFunction, Description, SamplerOpts) ->
     {DecisionFunction, Description, SamplerOpts}.
 

--- a/apps/opentelemetry/test/static_sampler.erl
+++ b/apps/opentelemetry/test/static_sampler.erl
@@ -6,6 +6,7 @@
 
 %% sampler returns the value from the Opts map based on the SpanName or `NOT_RECORD'
 setup(Opts) ->
-    {fun(_, _, _, SpanName, _, _, Opts1) ->
-             {maps:get(SpanName, Opts1, ?DROP), [], []}
-     end, <<"StaticSampler">>, Opts}.
+    otel_sampler:new(
+        fun(_, _, _, SpanName, _, _, Opts1) -> {maps:get(SpanName, Opts1, ?DROP), [], []} end, <<"StaticSamplerr">>,
+        Opts
+    ).

--- a/apps/opentelemetry/test/static_sampler.erl
+++ b/apps/opentelemetry/test/static_sampler.erl
@@ -7,6 +7,7 @@
 %% sampler returns the value from the Opts map based on the SpanName or `NOT_RECORD'
 setup(Opts) ->
     otel_sampler:new(
-        fun(_, _, _, SpanName, _, _, Opts1) -> {maps:get(SpanName, Opts1, ?DROP), [], []} end, <<"StaticSamplerr">>,
+        fun(_, _, _, SpanName, _, _, Opts1) -> {maps:get(SpanName, Opts1, ?DROP), [], []} end,
+        <<"StaticSampler">>,
         Opts
     ).


### PR DESCRIPTION
This PR contains the following changes

- added `otel_sampler:new/3`
  *because `otel_sampler.t()` is opaque, we need `new/3` to be able to create a sampler from the `setup/1` callback*

- introduced a type `sampler_opts` for the sampler options

- introduce a type `sampler_fun` for the sampler decision function

- fixed the otel_sampler `setup/2` callback to be `setup/1`
  *this callback accepts only the sampler options*