### PR TITLE
use new api function from_remote_span for propagated span context

### DIFF
--- a/apps/opentelemetry_api/include/opentelemetry.hrl
+++ b/apps/opentelemetry_api/include/opentelemetry.hrl
@@ -49,7 +49,8 @@
           %% TraceID and a non-zero SpanID.
           is_valid          :: boolean() | undefined,
           %% true if the span context came from a remote process
-          is_remote         :: boolean() | undefined,
+          %% defaults to false and the propagator must set to true when extracting
+          is_remote = false :: boolean(),
           %% this field is not propagated and is only here as an implementation optimization
           %% If true updates like adding events are done on the span. The same as if the
           %% trace flags lowest bit is 1 but simply not propagated.

--- a/apps/opentelemetry_api/src/otel_propagator_http_b3.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_http_b3.erl
@@ -53,9 +53,9 @@ extract(Headers, _) when is_list(Headers) ->
         TraceId = trace_id(Headers),
         SpanId = span_id(Headers),
         Sampled = lookup(?B3_SAMPLED, Headers),
-        otel_tracer:non_recording_span(string_to_integer(TraceId, 16),
-                                       string_to_integer(SpanId, 16),
-                                       case Sampled of True when ?B3_IS_SAMPLED(True) -> 1; _ -> 0 end)
+        otel_tracer:from_remote_span(string_to_integer(TraceId, 16),
+                                     string_to_integer(SpanId, 16),
+                                     case Sampled of True when ?B3_IS_SAMPLED(True) -> 1; _ -> 0 end)
     catch
         throw:invalid ->
             undefined;

--- a/apps/opentelemetry_api/src/otel_propagator_http_w3c.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_http_w3c.erl
@@ -135,9 +135,9 @@ to_span_ctx(Version, TraceId, SpanId, Opts) ->
     try
         %% verify version is hexadecimal
         _ = binary_to_integer(Version, 16),
-        otel_tracer:non_recording_span(binary_to_integer(TraceId, 16),
-                                       binary_to_integer(SpanId, 16),
-                                       case Opts of <<"01">> -> 1; <<"00">> -> 0; _ -> error(badarg) end)
+        otel_tracer:from_remote_span(binary_to_integer(TraceId, 16),
+                                     binary_to_integer(SpanId, 16),
+                                     case Opts of <<"01">> -> 1; <<"00">> -> 0; _ -> error(badarg) end)
     catch
         %% to integer from base 16 string failed
         error:badarg ->

--- a/apps/opentelemetry_api/src/otel_tracer.erl
+++ b/apps/opentelemetry_api/src/otel_tracer.erl
@@ -22,6 +22,7 @@
          with_span/4,
          with_span/5,
          non_recording_span/3,
+         from_remote_span/3,
          set_current_span/1,
          set_current_span/2,
          current_span_ctx/0,
@@ -80,6 +81,17 @@ non_recording_span(TraceId, SpanId, Traceflags) ->
     #span_ctx{trace_id=TraceId,
               span_id=SpanId,
               is_recording=false,
+              trace_flags=Traceflags}.
+
+%% @doc Returns a `span_ctx' record with `is_recording' set to `false' and `is_remote' set to `true'.
+%% This is mainly for use in propagators when they extract a Span to be used as a parent.
+-spec from_remote_span(opentelemetry:trace_id(), opentelemetry:span_id(), opentelemetry:trace_flags())
+                      -> opentelemetry:span_ctx().
+from_remote_span(TraceId, SpanId, Traceflags) ->
+    #span_ctx{trace_id=TraceId,
+              span_id=SpanId,
+              is_recording=false,
+              is_remote=true,
               trace_flags=Traceflags}.
 
 -spec set_current_span(opentelemetry:span_ctx() | undefined) -> ok.

--- a/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
@@ -96,13 +96,16 @@ nonrecording_no_sdk_propagation(_Config) ->
     %% is_recording will always be false in extracted `span_ctx'
     otel_propagator:text_map_extract(BinaryHeaders),
 
-    ?assertEqual(NonRecordingSpanCtx, otel_tracer:current_span_ctx()),
+    %% after being extracted `is_remote' will be set to `true'
+    RemoteSpanCtx = NonRecordingSpanCtx#span_ctx{is_remote=true},
+
+    ?assertEqual(RemoteSpanCtx, otel_tracer:current_span_ctx()),
     ?with_span(<<"span-1">>, #{}, fun(_) ->
                                           %% parent is non-recording so it should be returned
                                           %% as the "new" span
-                                          ?assertEqual(NonRecordingSpanCtx, otel_tracer:current_span_ctx())
+                                          ?assertEqual(RemoteSpanCtx, otel_tracer:current_span_ctx())
                                   end),
-    ?assertEqual(NonRecordingSpanCtx, otel_tracer:current_span_ctx()),
+    ?assertEqual(RemoteSpanCtx, otel_tracer:current_span_ctx()),
 
     BinaryHeaders = otel_propagator:text_map_inject([]),
     ?assertMatch(?EXPECTED_HEADERS, BinaryHeaders),


### PR DESCRIPTION
Thanks to @dvic for catching this issue. Long story of how it happened but put simply it is both the result of spec churn (how remote spans were defined/stored changed multiple times) and relying on unit tests.

Note that the unit test issue is not fixed in this PR, so a follow up is needed with additional integration tests that propagate a span context and then runs the remote/local parent based samplers after extracting.

I had only been testing the sampler against span contexts defined in the tests instead of ones created by propagation, this meant `is_remote` was set properly in the test `span_ctx` even though it wouldn't be in actual usage when a span came through the propagator.