### PR TITLE
User defined ssl options in grpc endpoints

### DIFF
--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -152,8 +152,8 @@ shutdown(#state{channel_pid=Pid}) ->
 %%
 
 grpcbox_endpoints(Endpoints) ->
-    [{scheme(Scheme), Host, Port, SSLOptions} || 
-        #{scheme := Scheme, host := Host, port := Port, ssl_options := SSLOptions} <- Endpoints].
+    [{scheme(Scheme), Host, Port, maps:get(ssl_options, Endpoint, [])} || 
+        #{scheme := Scheme, host := Host, port := Port} = Endpoint <- Endpoints].
 
 headers_to_grpc_metadata(Headers) ->
     lists:foldl(fun({X, Y}, Acc) ->

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -187,8 +187,10 @@ endpoint(Endpoint) ->
             Parsed
     end.
 
-parse_endpoint({Scheme, Host, Port, SSLOptions}) ->
+parse_endpoint({Scheme, Host, Port, SSLOptions}) when is_list(SSLOptions) ->
     {true, #{scheme => atom_to_list(Scheme), host => Host, port => Port, path => [], ssl_options => SSLOptions}};
+parse_endpoint({Scheme, Host, Port, _}) ->
+    {true, #{scheme => atom_to_list(Scheme), host => Host, port => Port, path => []}};
 parse_endpoint(Endpoint=#{host := _Host, port := _Port, scheme := _Scheme, path := _Path}) ->
     {true, Endpoint};
 parse_endpoint(Endpoint=#{host := _Host, scheme := _Scheme, path := _Path}) ->

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -152,7 +152,8 @@ shutdown(#state{channel_pid=Pid}) ->
 %%
 
 grpcbox_endpoints(Endpoints) ->
-    [{scheme(Scheme), Host, Port, []} || #{scheme := Scheme, host := Host, port := Port} <- Endpoints].
+    [{scheme(Scheme), Host, Port, SSLOptions} || 
+        #{scheme := Scheme, host := Host, port := Port, ssl_options := SSLOptions} <- Endpoints].
 
 headers_to_grpc_metadata(Headers) ->
     lists:foldl(fun({X, Y}, Acc) ->
@@ -186,8 +187,8 @@ endpoint(Endpoint) ->
             Parsed
     end.
 
-parse_endpoint({Scheme, Host, Port, _}) ->
-    {true, #{scheme => atom_to_list(Scheme), host => Host, port => Port, path => []}};
+parse_endpoint({Scheme, Host, Port, SSLOptions}) ->
+    {true, #{scheme => atom_to_list(Scheme), host => Host, port => Port, path => [], ssl_options => SSLOptions}};
 parse_endpoint(Endpoint=#{host := _Host, port := _Port, scheme := _Scheme, path := _Path}) ->
     {true, Endpoint};
 parse_endpoint(Endpoint=#{host := _Host, scheme := _Scheme, path := _Path}) ->
@@ -243,8 +244,8 @@ endpoints_append_path(E) when is_list(E) ->
 endpoints_append_path(E) ->
     [append_path(E)].
 
-append_path({Scheme, Host, Port, _}) ->
-    #{scheme => atom_to_list(Scheme), host => Host, port => Port, path => "/v1/traces"};
+append_path({Scheme, Host, Port, SSLOptions}) ->
+    #{scheme => atom_to_list(Scheme), host => Host, port => Port, path => "/v1/traces", ssl_options => SSLOptions};
 append_path(Endpoint=#{path := Path}) ->
     Endpoint#{path => filename:join(Path, ?DEFAULT_TRACES_PATH)};
 append_path(EndpointString) when is_list(EndpointString) orelse is_binary(EndpointString) ->

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -42,8 +42,13 @@ configuration(_Config) ->
     try
         ?assertMatch(#{endpoints :=
                            [#{scheme := "http", host := "localhost",
-                              port := 9090, path := "/v1/traces"}]},
+                              port := 9090, path := "/v1/traces", ssl_options := []}]},
                      opentelemetry_exporter:merge_with_environment(#{endpoints => [{http, "localhost", 9090, []}]})),
+
+        ?assertMatch(#{endpoints :=
+                           [#{scheme := "http", host := "localhost",
+                              port := 9090, path := "/v1/traces", ssl_options := [{verify, verify_none}]}]},
+                     opentelemetry_exporter:merge_with_environment(#{endpoints => [{http, "localhost", 9090, [{verify, verify_none}]}]})),
 
         ?assertMatch([#{scheme := "http", host := "localhost", port := 443, path := []}],
                      opentelemetry_exporter:endpoints(["http://localhost:443"])),


### PR DESCRIPTION
Allow to set user defined ssl options for https grpc endpoints. Eg calling `:otel_batch_processor.set_exporter(:opentelemetry_exporter, config)`  where `config` is:

```
 %{
  endpoints: [
    {:https, 'api.honeycomb.io', 443,
     [
       verify: :verify_peer,
       cacertfile::certifi.cacertfile(),
       customize_hostname_check: [
         match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
       ]
     ]}
  ],
  headers: [
    {"x-honeycomb-team", "..."},
    {"x-honeycomb-dataset", "..."}
  ],
  protocol: :grpc
}
``` 



allows us to avoid ssl warnings in OTP 24 such as the one described in https://github.com/open-telemetry/opentelemetry-erlang/issues/259.

Fixes https://github.com/open-telemetry/opentelemetry-erlang/issues/259.