### PR TITLE
Expose trace IDs in hex format

### DIFF
--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -40,6 +40,18 @@ defmodule OpenTelemetry.Span do
   defdelegate trace_id(span), to: :otel_span
 
   @doc """
+  Get the lowercase hex encoded span ID.
+  """
+  @spec hex_span_id(OpenTelemetry.span_ctx()) :: binary()
+  defdelegate hex_span_id(span), to: :otel_span
+
+  @doc """
+  Get the lowercase hex encoded trace ID.
+  """
+  @spec hex_trace_id(OpenTelemetry.span_ctx()) :: binary()
+  defdelegate hex_trace_id(span), to: :otel_span
+
+  @doc """
   Get the Tracestate of a Span.
   """
   @spec tracestate(OpenTelemetry.span_ctx()) :: OpenTelemetry.tracestate()

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -60,6 +60,8 @@
 -export_type([tracer/0,
               trace_id/0,
               span_id/0,
+              hex_trace_id/0,
+              hex_span_id/0,
               trace_flags/0,
               timestamp/0,
               span_name/0,
@@ -84,6 +86,9 @@
 
 -type trace_id()           :: non_neg_integer().
 -type span_id()            :: non_neg_integer().
+
+-type hex_trace_id()       :: binary().
+-type hex_span_id()        :: binary().
 
 -type trace_flags()        :: non_neg_integer().
 

--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -20,6 +20,8 @@
 
 -export([trace_id/1,
          span_id/1,
+         hex_trace_id/1,
+         hex_span_id/1,
          tracestate/1,
          is_recording/1,
          is_valid/1,
@@ -68,6 +70,14 @@ trace_id(#span_ctx{trace_id=TraceId }) ->
 -spec span_id(opentelemetry:span_ctx()) -> opentelemetry:span_id().
 span_id(#span_ctx{span_id=SpanId }) ->
     SpanId.
+
+-spec hex_trace_id(opentelemetry:span_ctx()) -> opentelemetry:hex_trace_id().
+hex_trace_id(#span_ctx{trace_id=TraceId}) ->
+    iolist_to_binary(io_lib:format("~32.16.0b", [TraceId])).
+
+-spec hex_span_id(opentelemetry:span_ctx()) -> opentelemetry:hex_span_id().
+hex_span_id(#span_ctx{span_id=SpanId}) ->
+    iolist_to_binary(io_lib:format("~16.16.0b", [SpanId])).
 
 -spec tracestate(opentelemetry:span_ctx() | undefined) -> opentelemetry:tracestate().
 tracestate(#span_ctx{tracestate=undefined}) ->

--- a/apps/opentelemetry_api/test/open_telemetry_test.exs
+++ b/apps/opentelemetry_api/test/open_telemetry_test.exs
@@ -89,6 +89,15 @@ defmodule OpenTelemetryTest do
     end
   end
 
+  test "hex trace identifiers" do
+    Tracer.with_span "span-1" do
+      span = Tracer.current_span_ctx()
+
+      assert Span.hex_trace_id(span) == "00000000000000000000000000000000"
+      assert Span.hex_span_id(span) == "0000000000000000"
+    end
+  end
+
   test "baggage api from elixir" do
     Baggage.set(%{"a" => "b"})
     assert %{"a" => {"b", []}} = Baggage.get_all()

--- a/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
+++ b/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
@@ -11,7 +11,7 @@
 -include("otel_tracer.hrl").
 
 all() ->
-    [noop_tracer, update_span_data, noop_with_span, can_create_link_from_span].
+    [noop_tracer, update_span_data, noop_with_span, can_create_link_from_span, hex_trace_ids].
 
 init_per_suite(Config) ->
     application:load(opentelemetry_api),
@@ -144,4 +144,10 @@ noop_with_span(_Config) ->
 
     Result = some_result,
     ?assertEqual(Result, otel_tracer:with_span(Tracer, <<"span1">>, #{}, fun(_) -> Result end)),
+    ok.
+
+hex_trace_ids(_Config) ->
+    SpanCtx=#span_ctx{trace_id=41394, span_id=50132},
+    ?assertEqual(<<"0000000000000000000000000000a1b2">>, otel_span:hex_trace_id(SpanCtx)),
+    ?assertEqual(<<"000000000000c3d4">>, otel_span:hex_span_id(SpanCtx)),
     ok.


### PR DESCRIPTION
According to the [spec][1]
> The API MUST allow retrieving the TraceId and SpanId in the following forms:
>
>  *  Hex - returns the lowercase hex-encoded TraceId (result MUST be a 32-hex-character lowercase string) or SpanId (result MUST be a 16-hex-character lowercase string).
>  *  Binary - returns the binary representation of the TraceId (result MUST be a 16-byte array) or SpanId (result MUST be an 8-byte array).
>
> The API SHOULD NOT expose details about how they are internally stored.

This commit takes care of the Hex part.

[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#retrieving-the-traceid-and-spanid)