### PR TITLE
Add B3 single propagation format support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
   inject and extract take an optional "set" and "get" function for working with
   a carrier.
 - Configuration of propagators is now a list of atoms representing either the
-  name of a builtin propagator (at this time those are, `trace_context`, `b3` and
-  `baggage`) or the name of a module implementing the propagator's behaviour.
+  name of a builtin propagator (at this time those are, `trace_context`, `b3`,
+  `b3multi` and `baggage`) or the name of a module implementing the
+  propagator's behaviour.
   - Default configuration: `{text_map_propagators, [trace_context, baggage]}`
 - Injectors and extractors can be configured separately instead of using the
   same list of propagators for both by configuring `text_map_injectors` and
@@ -20,7 +21,7 @@
   - For example you may want your service to support receiving `b3multi` headers
     but have no need for it including `b3multi` headers when it is propagating to
     other services:
-            
+
     ```
     {text_map_injectors, [trace_context, baggage]},
     {text_map_extractors, [b3multi, trace_context, baggage]}

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -178,9 +178,9 @@ transform(propagator, "baggage") ->
     baggage;
 transform(propagator, "b3multi") ->
     b3multi;
-%% TODO: support b3multi and jager propagator formats
-%% transform(propagator, "b3") ->
-%%     b3;
+transform(propagator, "b3") ->
+    b3;
+%% TODO: support jager propagator format
 %% transform(propagator, "jaeger") ->
 %%     jaeger;
 transform(propagator, Propagator) ->

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -82,20 +82,25 @@ registered_tracers(_Config) ->
 
 propagator_configuration(_Config) ->
     ?assertEqual({otel_propagator_text_map_composite,
-                  [otel_propagator_b3multi, otel_propagator_baggage]}, opentelemetry:get_text_map_extractor()),
+                  [{otel_propagator_b3, b3multi}, otel_propagator_baggage]}, opentelemetry:get_text_map_extractor()),
     ?assertEqual({otel_propagator_text_map_composite,
-                  [otel_propagator_b3multi, otel_propagator_baggage]}, opentelemetry:get_text_map_injector()),
+                  [{otel_propagator_b3, b3multi}, otel_propagator_baggage]}, opentelemetry:get_text_map_injector()),
 
     opentelemetry:set_text_map_extractor({otel_propagator_baggage, []}),
 
     ?assertEqual({otel_propagator_baggage, []}, opentelemetry:get_text_map_extractor()),
     ?assertEqual({otel_propagator_text_map_composite,
-                  [otel_propagator_b3multi, otel_propagator_baggage]}, opentelemetry:get_text_map_injector()),
+                  [{otel_propagator_b3, b3multi}, otel_propagator_baggage]}, opentelemetry:get_text_map_injector()),
 
-    opentelemetry:set_text_map_injector({otel_propagator_b3multi, []}),
+    opentelemetry:set_text_map_injector({{otel_propagator_b3, b3multi}, []}),
 
     ?assertEqual({otel_propagator_baggage, []}, opentelemetry:get_text_map_extractor()),
-    ?assertEqual({otel_propagator_b3multi, []}, opentelemetry:get_text_map_injector()),
+    ?assertEqual({{otel_propagator_b3, b3multi}, []}, opentelemetry:get_text_map_injector()),
+
+    opentelemetry:set_text_map_injector({{otel_propagator_b3, b3single}, []}),
+
+    ?assertEqual({otel_propagator_baggage, []}, opentelemetry:get_text_map_extractor()),
+    ?assertEqual({{otel_propagator_b3, b3single}, []}, opentelemetry:get_text_map_injector()),
 
     ok.
 
@@ -111,10 +116,15 @@ propagator_configuration_with_os_env(_Config) ->
     ?assertEqual({otel_propagator_text_map_composite,
                   [otel_propagator_trace_context]}, opentelemetry:get_text_map_injector()),
 
-    opentelemetry:set_text_map_injector({otel_propagator_b3multi, []}),
+    opentelemetry:set_text_map_injector({{otel_propagator_b3, b3multi}, []}),
 
     ?assertEqual({otel_propagator_baggage, []}, opentelemetry:get_text_map_extractor()),
-    ?assertEqual({otel_propagator_b3multi, []}, opentelemetry:get_text_map_injector()),
+    ?assertEqual({{otel_propagator_b3, b3multi}, []}, opentelemetry:get_text_map_injector()),
+
+    opentelemetry:set_text_map_injector({{otel_propagator_b3, b3single}, []}),
+
+    ?assertEqual({otel_propagator_baggage, []}, opentelemetry:get_text_map_extractor()),
+    ?assertEqual({{otel_propagator_b3, b3single}, []}, opentelemetry:get_text_map_injector()),
 
     ok.
 

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -16,8 +16,8 @@
 all() ->
     [empty_os_environment, sampler, sampler_parent_based, sampler_parent_based_zero,
      sampler_trace_id, sampler_trace_id_default, sampler_parent_based_one,
-     log_level, propagators, propagators_b3multi, otlp_exporter, jaeger_exporter,
-     zipkin_exporter, none_exporter].
+     log_level, propagators, propagators_b3, propagators_b3multi, otlp_exporter,
+     jaeger_exporter, zipkin_exporter, none_exporter].
 
 init_per_testcase(empty_os_environment, Config) ->
     Vars = [],
@@ -30,6 +30,12 @@ init_per_testcase(log_level, Config) ->
     [{os_vars, Vars} | Config];
 init_per_testcase(propagators, Config) ->
     Vars = [{"OTEL_PROPAGATORS", "baggage,afakeone"}],
+
+    setup_env(Vars),
+
+    [{os_vars, Vars} | Config];
+init_per_testcase(propagators_b3, Config) ->
+    Vars = [{"OTEL_PROPAGATORS", "b3"}],
 
     setup_env(Vars),
 
@@ -170,6 +176,13 @@ propagators(_Config) ->
     %% TODO: can make this a better error message when it fails with a custom assert macro
     ?assertIsSubset([{log_level, error},
                      {text_map_propagators, [baggage]}],
+                    otel_configuration:merge_with_os([{log_level, error}])),
+
+    ok.
+
+propagators_b3(_Config) ->
+    ?assertIsSubset([{log_level, error},
+                     {text_map_propagators, [b3]}],
                     otel_configuration:merge_with_os([{log_level, error}])),
 
     ok.

--- a/apps/opentelemetry_api/src/otel_propagator.erl
+++ b/apps/opentelemetry_api/src/otel_propagator.erl
@@ -45,7 +45,7 @@
 
 %% trace_context and tracecontext are the same. tracecontext is the term
 %% in Otel specs and trace_context is the more idiomatic Erlang spelling
--type builtin() :: trace_context | tracecontext | b3multi | baggage. %% b3 | jaeger
+-type builtin() :: trace_context | tracecontext | b3 | b3multi | baggage. %% jaeger
 
 %% a carrier can be any type
 -type carrier() :: term().
@@ -67,13 +67,13 @@ builtin_to_module(tracecontext) ->
     otel_propagator_trace_context;
 builtin_to_module(trace_context) ->
     otel_propagator_trace_context;
+builtin_to_module(b3) ->
+    {otel_propagator_b3, b3single};
 builtin_to_module(b3multi) ->
-    otel_propagator_b3multi;
+    {otel_propagator_b3, b3multi};
 builtin_to_module(baggage) ->
     otel_propagator_baggage;
-%% TODO: add multib3 and jaeger as builtin propagators
-%% builtin_to_module(multib3) ->
-%%     otel_propagator_multib3;
+%% TODO: add jaeger as builtin propagator
 %% builtin_to_module(jaeger) ->
 %%     otel_propagator_jaeger;
 builtin_to_module(Module) when is_atom(Module) ->

--- a/apps/opentelemetry_api/src/otel_propagator_b3.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_b3.erl
@@ -1,0 +1,111 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2019, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc An implementation of {@link otel_propagator_text_map} that injects and
+%% extracts trace context using the B3 specification from Zipkin.
+%%
+%% Since `trace_context' and `baggage' are the two default propagators the
+%% global TextMap Propagators must be configured if B3 is to be used for
+%% propagation:
+%%
+%% ```
+%% {text_map_propagators, [b3, baggage]},
+%% '''
+%%
+%% To use B3 multi-header format use:
+%%
+%% ```
+%% {text_map_propagators, [b3multi, baggage]},
+%% '''
+%%
+%% ```
+%% CompositePropagator = otel_propagator_text_map_composite:create([b3, baggage]),
+%% opentelemetry:set_text_map_propagator(CompositePropagator).
+%% '''
+%%
+%% It is also possible to set a separate list of injectors or extractors.
+%% For example, if the service should extract B3 encoded context but you
+%% only want to inject context encoded with the W3C TraceContext format
+%% (maybe you have some services only supporting B3 that are making requests
+%% to your server but you have no reason to continue propagating in both
+%% formats when communicating to other services further down the stack).
+%% In that case you would instead set configuration like:
+%%
+%%
+%% ```
+%% {text_map_extractors, [b3, trace_context, baggage]},
+%% {text_map_injectors, [trace_context, baggage]},
+%% '''
+%%
+%% Or using calls to {@link opentelemetry} at runtime:
+%%
+%% ```
+%% B3CompositePropagator = otel_propagator_text_map_composite:create([b3, trace_context, baggage]),
+%% CompositePropagator = otel_propagator_text_map_composite:create([trace_context, baggage]),
+%% opentelemetry:set_text_map_extractor(B3CompositePropagator),
+%% opentelemetry:set_text_map_injector(CompositePropagator).
+%% '''
+%% @end
+%%%-----------------------------------------------------------------------
+-module(otel_propagator_b3).
+
+-behaviour(otel_propagator_text_map).
+
+-export([fields/1,
+         inject/4,
+         extract/5]).
+
+-include("opentelemetry.hrl").
+
+-define(B3_CONTEXT_KEY, <<"b3">>).
+
+%% Returns all the keys the propagator sets with `inject'
+fields(b3single) ->
+    otel_propagator_b3single:fields(b3single);
+fields(b3multi) ->
+    otel_propagator_b3multi:fields(b3multi);
+fields(_) ->
+    [].
+
+-spec inject(Context, Carrier, CarrierSetFun, Options) -> Carrier
+              when Context :: otel_ctx:t(),
+                   Carrier :: otel_propagator:carrier(),
+                   CarrierSetFun :: otel_propagator_text_map:carrier_set(),
+                   Options :: b3multi | b3single.
+inject(Ctx, Carrier, CarrierSet, Options=b3single) ->
+    otel_propagator_b3single:inject(Ctx, Carrier, CarrierSet, Options);
+inject(Ctx, Carrier, CarrierSet, Options=b3multi) ->
+    otel_propagator_b3multi:inject(Ctx, Carrier, CarrierSet, Options);
+inject(_Ctx, Carrier, _CarrierSet, _Options) ->
+    Carrier.
+
+% Extract trace context from the supplied carrier. The b3 single header takes
+% precedence over the multi-header format.
+%
+% If extraction fails, the original context will be returned.
+-spec extract(Context, Carrier, CarrierKeysFun, CarrierGetFun, Options) -> Context
+              when Context :: otel_ctx:t(),
+                   Carrier :: otel_propagator:carrier(),
+                   CarrierKeysFun :: otel_propagator_text_map:carrier_keys(),
+                   CarrierGetFun :: otel_propagator_text_map:carrier_get(),
+                   Options :: otel_propagator_text_map:propagator_options().
+extract(Ctx, Carrier, CarrierKeysFun, CarrierGet, Options) ->
+    case otel_propagator_b3single:extract(Ctx, Carrier, CarrierKeysFun, CarrierGet, Options) of
+        Result when Result =/= undefined -> Result;
+        _ ->
+            case otel_propagator_b3multi:extract(Ctx, Carrier, CarrierKeysFun, CarrierGet, Options) of
+                Result when Result =/= undefined -> Result;
+                _ -> Ctx
+            end
+    end.

--- a/apps/opentelemetry_api/test/otel_propagator_b3_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_propagator_b3_SUITE.erl
@@ -1,0 +1,241 @@
+-module(otel_propagator_b3_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include("otel_tracer.hrl").
+-include("opentelemetry.hrl").
+
+-define(assertListsEqual(List1, List2), ?assertEqual(lists:sort(List1), lists:sort(List2))).
+
+all() ->
+    [{group, b3},
+     {group, b3multi}].
+
+groups() ->
+    ExtractTests = [extract, extract_sampling, extract_invalid_trace_id, extract_invalid_span_id],
+
+    [{b3, [], [inject_single | ExtractTests]},
+     {b3multi, [], [inject_multi | ExtractTests]}].
+
+init_per_suite(Config) ->
+    application:load(opentelemetry_api),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(Propagator, Config) ->
+    CompositePropagator = otel_propagator_text_map_composite:create([Propagator]),
+    opentelemetry:set_text_map_propagator(CompositePropagator),
+    [{propagator, CompositePropagator} | Config].
+
+end_per_group(_, _Config) ->
+    ok.
+
+extract(_Config) ->
+    % Single: Common B3 format
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38e-1">>}]),
+    ?assertMatch(#span_ctx{trace_id=11111111111111111111111111111111,
+                           span_id=2222222222222222,
+                           trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    % Single: B3 format with 16 character trace ID
+    run_extract([{<<"b3">>, <<"0007e5196e2ae38e-0007e5196e2ae38e-1">>}]),
+    ?assertMatch(#span_ctx{trace_id=2222222222222222,
+                           span_id=2222222222222222,
+                           trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    % Single: B3 format with parent span id
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38e-1-0101010101010101">>}]),
+    ?assertMatch(#span_ctx{trace_id=11111111111111111111111111111111,
+                           span_id=2222222222222222,
+                           trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    % Single: B3 format without trace flags
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38e">>}]),
+    ?assertMatch(#span_ctx{trace_id=11111111111111111111111111111111,
+                           span_id=2222222222222222,
+                           trace_flags=0}, otel_tracer:current_span_ctx()),
+
+    % Multi: B3 format with 32 character trace ID
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>},
+                 {<<"X-B3-Sampled">>, <<"1">>}]),
+    ?assertMatch(#span_ctx{trace_id=11111111111111111111111111111111,
+                           span_id=2222222222222222,
+                           trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    % Multi: B3 format with 16 character trace ID
+    run_extract([{<<"X-B3-TraceId">>, <<"0007e5196e2ae38e">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>},
+                 {<<"X-B3-Sampled">>, <<"1">>}]),
+    ?assertMatch(#span_ctx{trace_id=2222222222222222,
+                           span_id=2222222222222222,
+                           trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    % Multi: B3 format without Sampled header
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>}]),
+    ?assertMatch(#span_ctx{trace_id=11111111111111111111111111111111,
+                           span_id=2222222222222222,
+                           trace_flags=0}, otel_tracer:current_span_ctx()),
+
+    % Combined: Single header format is preferred when both are present
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38e-1">>},
+                 {<<"X-B3-TraceId">>, <<"75694700a50b5df51a28412ea368a592">>},
+                 {<<"X-B3-SpanId">>, <<"b6431ccfe6d2ea8f">>},
+                 {<<"X-B3-Sampled">>, <<"0">>}]),
+    ?assertMatch(#span_ctx{trace_id=11111111111111111111111111111111,
+                           span_id=2222222222222222,
+                           trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    ok.
+
+extract_sampling(_Config) ->
+    % Single: Sampling is set to 1
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38e-1">>}]),
+    ?assertMatch(#span_ctx{trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    % Single: Sampling is set to debug
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38e-d">>}]),
+    ?assertMatch(#span_ctx{trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    % Single: Sampling is set to 0
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38e-0">>}]),
+    ?assertMatch(#span_ctx{trace_flags=0}, otel_tracer:current_span_ctx()),
+
+    % Single: Sampling is set to invalid value
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38e-x">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Single: B3 format with only sampling decision (even though this is
+    % supported according to Zipkin docs, this is tricky to implement and other
+    % OTEL tracers don't seem to support it either).
+    run_extract([{<<"b3">>, <<"0">>}]),
+    ?assertMatch(undefined, otel_tracer:current_span_ctx()),
+
+    % Multi: Sampling is set to 1
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>},
+                 {<<"X-B3-Sampled">>, <<"1">>}]),
+    ?assertMatch(#span_ctx{trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    % Multi: Sampling is set to true
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>},
+                 {<<"X-B3-Sampled">>, <<"true">>}]),
+    ?assertMatch(#span_ctx{trace_flags=1}, otel_tracer:current_span_ctx()),
+
+    % Multi: Sampling is set to 0
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>},
+                 {<<"X-B3-Sampled">>, <<"0">>}]),
+    ?assertMatch(#span_ctx{trace_flags=0}, otel_tracer:current_span_ctx()),
+
+    % Multi: Sampling is set to false
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>},
+                 {<<"X-B3-Sampled">>, <<"false">>}]),
+    ?assertMatch(#span_ctx{trace_flags=0}, otel_tracer:current_span_ctx()),
+
+    % Multi: Sampling is set to invalid value
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>},
+                 {<<"X-B3-Sampled">>, <<"invalid">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Multi: B3 format with only sampling decision (even though this is
+    % supported according to Zipkin docs, this is tricky to implement and other
+    % OTEL tracers don't seem to support it either).
+    run_extract([{<<"X-B3-Sampled">>, <<"0">>}]),
+    ?assertMatch(undefined, otel_tracer:current_span_ctx()),
+
+    ok.
+
+extract_invalid_trace_id(_Config) ->
+    % Single: Shorter trace ID than expected
+    run_extract([{<<"b3">>, <<"01-0007e5196e2ae38e-1">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Single: Longer trace ID than expected
+    run_extract([{<<"b3">>, <<"0123456789012345678901234567890123456789-0007e5196e2ae38e-1">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Single: Non-hex trace ID
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71cyyyy-0007e5196e2ae38e-1">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Multi: Shorter trace ID than expected
+    run_extract([{<<"X-B3-TraceId">>, <<"01">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Multi: Longer trace ID than expected
+    run_extract([{<<"X-B3-TraceId">>, <<"0123456789012345678901234567890123456789">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Multi: Non-hex trace ID
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71cyyyy">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    ok.
+
+extract_invalid_span_id(_Config) ->
+    % Single: Shorter span ID than expected
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007-1">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Single: Longer span ID than expected
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38eaa-1">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Single: Non-hex span ID
+    run_extract([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ayyyy-1">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Multi: Shorter span ID than expected
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Multi: Longer span ID than expected
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38eaa">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    % Multi: Non-hex span ID
+    run_extract([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                 {<<"X-B3-SpanId">>, <<"0007e5196e2ae38eyyyy">>}]),
+    ?assertEqual(undefined, otel_tracer:current_span_ctx()),
+
+    ok.
+
+inject_single(_Config) ->
+    otel_tracer:set_current_span(#span_ctx{trace_id=11111111111111111111111111111111,
+                                           span_id=2222222222222222,
+                                           trace_flags=1}),
+    Headers = otel_propagator_text_map:inject([]),
+
+    ?assertListsEqual([{<<"b3">>, <<"0000008c3defb1edb984fe2ac71c71c7-0007e5196e2ae38e-1">>}], Headers),
+
+    ok.
+
+inject_multi(_Config) ->
+    % Span with all fields
+    otel_tracer:set_current_span(#span_ctx{trace_id=11111111111111111111111111111111,
+                                           span_id=2222222222222222,
+                                           trace_flags=1}),
+    Headers = otel_propagator_text_map:inject([]),
+    ?assertListsEqual([{<<"X-B3-TraceId">>, <<"0000008c3defb1edb984fe2ac71c71c7">>},
+                       {<<"X-B3-SpanId">>, <<"0007e5196e2ae38e">>},
+                       {<<"X-B3-Sampled">>, <<"1">>}], Headers),
+
+    ok.
+
+run_extract(HeaderKeyValuePairs) ->
+    otel_ctx:clear(),
+    otel_propagator_text_map:extract(HeaderKeyValuePairs).


### PR DESCRIPTION
[B3 single format][1] looks like this: `b3={TraceId}-{SpanId}-{SamplingState}-{ParentSpanId}`,
where the last two fields are optional.

[OpenTelemetry B3 requirements][2]:

B3 has both single and multi-header encodings. It also has semantics
that do not map directly to OpenTelemetry such as a debug trace flag,
and allowing spans from both sides of request to share the same id. To
maximize compatibility between OpenTelemetry and Zipkin implementations,
the following guidelines have been established for B3 context
propagation.

When extracting B3, propagators:
* MUST attempt to extract B3 encoded using single and multi-header formats. The single-header variant takes precedence over the multi-header version. :green_circle: 
* MUST preserve a debug trace flag, if received, and propagate it with subsequent requests. Additionally, an OpenTelemetry implementation MUST set the sampled trace flag when the debug flag is set. :yellow_circle: We do not preserve the debug flag at the moment. We didn't do this before and not doing this in this PR either. We however do set sampling to 1 if that flag is present.
* MUST NOT reuse X-B3-SpanId as the id for the server-side span. :green_circle: 

When injecting B3, propagators:
* MUST default to injecting B3 using the single-header format :green_circle: 
* MUST provide configuration to change the default injection format to B3 multi-header :green_circle: 
* MUST NOT propagate X-B3-ParentSpanId as OpenTelemetry does not support reusing the same id for both sides of a request. :green_circle: 

[1]: https://github.com/openzipkin/b3-propagation#single-header
[2]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#b3-requirements