### PR TITLE
remove unneeded current span functions from otel_tracer

### DIFF
--- a/apps/opentelemetry_api/include/otel_tracer.hrl
+++ b/apps/opentelemetry_api/include/otel_tracer.hrl
@@ -19,10 +19,10 @@
 -define(set_current_span(SpanCtx),
         otel_tracer:set_current_span(SpanCtx)).
 
-%% use tracer call to ensure the current span is overwritten with
-%% an ended (`is_recording' set to `false') is put in the context
+%% updates the current context with the updated span context that
+%% has `is_recording' set to `false'
 -define(end_span(),
-        otel_tracer:end_span()).
+        otel_tracer:set_current_span(otel_span:end_span(?current_span_ctx))).
 
 -define(end_span(SpanCtx),
         otel_span:end_span(SpanCtx)).

--- a/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
@@ -127,7 +127,9 @@ defmodule OpenTelemetry.Tracer do
   The Span in the current Context has its `is_recording` set to `false`.
   """
   def end_span() do
-    :otel_tracer.end_span()
+    non_recording_span = :otel_span.end_span(:otel_tracer.current_span_ctx())
+    _ = :otel_tracer.set_current_span(non_recording_span)
+    non_recording_span
   end
 
   @doc """

--- a/apps/opentelemetry_api/src/otel_tracer.erl
+++ b/apps/opentelemetry_api/src/otel_tracer.erl
@@ -26,14 +26,7 @@
          set_current_span/1,
          set_current_span/2,
          current_span_ctx/0,
-         current_span_ctx/1,
-         end_span/0,
-         set_attribute/2,
-         set_attributes/1,
-         add_event/2,
-         add_events/1,
-         set_status/1,
-         update_name/1]).
+         current_span_ctx/1]).
 
 -include("opentelemetry.hrl").
 
@@ -94,9 +87,10 @@ from_remote_span(TraceId, SpanId, Traceflags) ->
               is_remote=true,
               trace_flags=Traceflags}.
 
--spec set_current_span(opentelemetry:span_ctx() | undefined) -> ok.
+-spec set_current_span(opentelemetry:span_ctx() | undefined) -> opentelemetry:span_ctx() | undefined.
 set_current_span(SpanCtx) ->
-    otel_ctx:set_value(?CURRENT_SPAN_CTX, SpanCtx).
+    _ = otel_ctx:set_value(?CURRENT_SPAN_CTX, SpanCtx),
+    SpanCtx.
 
 -spec set_current_span(otel_ctx:t(), opentelemetry:span_ctx() | undefined) -> otel_ctx:t() | undefined.
 set_current_span(Ctx, SpanCtx) ->
@@ -109,50 +103,3 @@ current_span_ctx() ->
 -spec current_span_ctx(otel_ctx:t()) -> opentelemetry:span_ctx() | undefined.
 current_span_ctx(Ctx) ->
     otel_ctx:get_value(Ctx, ?CURRENT_SPAN_CTX, undefined).
-
-%% Span operations
-
--spec end_span() -> opentelemetry:span_ctx().
-end_span() ->
-    EndedSpanCtx = otel_span:end_span(current_span_ctx()),
-    %% this is done to set `is_recording' to `false' after ending
-    _ = set_current_span(EndedSpanCtx),
-    EndedSpanCtx.
-
--spec set_attribute(Key, Value) -> boolean() when
-      Key :: opentelemetry:attribute_key(),
-      Value :: opentelemetry:attribute_value().
-set_attribute(Key, Value) ->
-    otel_span:set_attribute(current_span_ctx(), Key, Value).
-
--spec set_attributes(Attributes) -> boolean() when
-      Attributes :: opentelemetry:attributes().
-set_attributes(Attributes) when is_list(Attributes) ->
-    otel_span:set_attributes(current_span_ctx(), Attributes);
-set_attributes(_) ->
-    false.
-
--spec add_event(Name, Attributes) -> boolean() when
-      Name :: opentelemetry:event_name(),
-      Attributes :: opentelemetry:attributes().
-add_event(Name, Attributes) when is_list(Attributes) ->
-    otel_span:add_event(current_span_ctx(), Name, Attributes);
-add_event(_, _) ->
-    false.
-
--spec add_events(Events) -> boolean() when
-      Events :: opentelemetry:events().
-add_events(Events) when is_list(Events)  ->
-    otel_span:add_events(current_span_ctx(), Events);
-add_events(_) ->
-    false.
-
--spec set_status(Status) -> boolean() when
-      Status :: opentelemetry:status().
-set_status(Status) ->
-    otel_span:set_status(current_span_ctx(), Status).
-
--spec update_name(Name) -> boolean() when
-      Name :: opentelemetry:span_name().
-update_name(SpanName) ->
-    otel_span:update_name(current_span_ctx(), SpanName).


### PR DESCRIPTION
`?end_span` is updated to work update the current context through
calling `otel_tracer:set_current_span`. In order to still return
the new `SpanCtx` this function was also changed to return the
`SpanCtx` that was passed to it.