### PR TITLE
add force_flush to tracer provider and span processors

### DIFF
--- a/apps/opentelemetry/src/otel_exporter.erl
+++ b/apps/opentelemetry/src/otel_exporter.erl
@@ -26,7 +26,7 @@
 %% Do whatever needs to be done to export each span here, the caller will block
 %% until it returns.
 -callback export(ets:tab(), otel_resource:t(), term()) -> ok |
-                                                        success |
-                                                        failed_not_retryable |
-                                                        failed_retryable.
+                                                          success |
+                                                          failed_not_retryable |
+                                                          failed_retryable.
 -callback shutdown(term()) -> ok.

--- a/apps/opentelemetry/src/otel_span_processor.erl
+++ b/apps/opentelemetry/src/otel_span_processor.erl
@@ -28,3 +28,5 @@
                                                               dropped |
                                                               {error, invalid_span} |
                                                               {error, no_export_buffer}.
+-callback force_flush(processor_config()) -> ok |
+                                             {error, term()}.

--- a/apps/opentelemetry_api/src/otel_tracer_provider.erl
+++ b/apps/opentelemetry_api/src/otel_tracer_provider.erl
@@ -26,7 +26,9 @@
          get_tracer/1,
          get_tracer/2,
          resource/0,
-         resource/1]).
+         resource/1,
+         force_flush/0,
+         force_flush/1]).
 
 -spec register_tracer(atom(), binary()) -> boolean().
 register_tracer(Name, Vsn) ->
@@ -65,4 +67,17 @@ resource(ServerRef) ->
     catch exit:{noproc, _} ->
             %% ignore because no SDK has been included and started
             undefined
+    end.
+
+-spec force_flush() -> ok | {error, term()} | timeout.
+force_flush() ->
+    force_flush(?MODULE).
+
+-spec force_flush(atom() | pid()) -> ok | {error, term()} | timeout.
+force_flush(ServerRef) ->
+    try
+        gen_server:call(?MODULE, force_flush)
+    catch exit:{noproc, _} ->
+            %% ignore because likely no SDK has been included and started
+            ok
     end.


### PR DESCRIPTION
I realized the tracer provider is overly complicated (it should not be a gen_server, but the implementation will be) but will be sending that in change in a separate PR to keep this focused.