### PR TITLE
use get_application_tracer in Elixir macros

### DIFF
--- a/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
@@ -31,7 +31,7 @@ defmodule OpenTelemetry.Tracer do
   """
   defmacro start_span(name, opts \\ quote(do: %{})) do
     quote bind_quoted: [name: name, start_opts: opts] do
-      :otel_tracer.start_span(:opentelemetry.get_tracer(__MODULE__), name, Map.new(start_opts))
+      :otel_tracer.start_span(:opentelemetry.get_application_tracer(__MODULE__), name, Map.new(start_opts))
     end
   end
 
@@ -44,7 +44,7 @@ defmodule OpenTelemetry.Tracer do
     quote bind_quoted: [ctx: ctx, name: name, start_opts: opts] do
       :otel_tracer.start_span(
         ctx,
-        :opentelemetry.get_tracer(__MODULE__),
+        :opentelemetry.get_application_tracer(__MODULE__),
         name,
         Map.new(start_opts)
       )
@@ -76,7 +76,7 @@ defmodule OpenTelemetry.Tracer do
   defmacro with_span(name, start_opts \\ quote(do: %{}), do: block) do
     quote do
       :otel_tracer.with_span(
-        :opentelemetry.get_tracer(__MODULE__),
+        :opentelemetry.get_application_tracer(__MODULE__),
         unquote(name),
         Map.new(unquote(start_opts)),
         fn _ -> unquote(block) end
@@ -95,7 +95,7 @@ defmodule OpenTelemetry.Tracer do
     quote do
       :otel_tracer.with_span(
         unquote(ctx),
-        :opentelemetry.get_tracer(__MODULE__),
+        :opentelemetry.get_application_tracer(__MODULE__),
         unquote(name),
         Map.new(unquote(start_opts)),
         fn _ -> unquote(block) end


### PR DESCRIPTION
The Erlang macros already properly use get_application_tracer.
The reason to use get_application_tracer is the macros lookup
the tracer for the particular application by module name.