### PR TITLE
add simple span processor

### DIFF
--- a/apps/opentelemetry/src/opentelemetry_sup.erl
+++ b/apps/opentelemetry/src/opentelemetry_sup.erl
@@ -57,6 +57,14 @@ init([Opts]) ->
                        type => worker,
                        modules => [otel_batch_processor]},
 
+    SimpleProcessorOpts = proplists:get_value(otel_simple_processor, Processors, #{}),
+    SimpleProcessor = #{id => otel_simple_processor,
+                       start => {otel_simple_processor, start_link, [SimpleProcessorOpts]},
+                       restart => permanent,
+                       shutdown => 5000,
+                       type => worker,
+                       modules => [otel_simple_processor]},
+
     SpanSup = #{id => otel_span_sup,
                 start => {otel_span_sup, start_link, [Opts]},
                 type => supervisor,
@@ -67,6 +75,6 @@ init([Opts]) ->
     %% `TracerServer' *must* start before the `BatchProcessor'
     %% `BatchProcessor' relies on getting the `Resource' from
     %% the `TracerServer' process
-    ChildSpecs = [Detectors, TracerServer, BatchProcessor, SpanSup],
+    ChildSpecs = [Detectors, TracerServer, BatchProcessor, SimpleProcessor, SpanSup],
 
     {ok, {SupFlags, ChildSpecs}}.

--- a/apps/opentelemetry/src/otel_simple_processor.erl
+++ b/apps/opentelemetry/src/otel_simple_processor.erl
@@ -117,7 +117,7 @@ exporting(state_timeout, exporting_timeout, Data=#data{current_from=From,
     %% which deletes the exporting table, so create a new one and
     %% repeat the state to force another span exporting immediately
     Data1 = kill_runner(Data),
-    {repeat_state, Data1, [{reply, From, {error, timeout}}]};
+    {next_state, idle, Data1, [{reply, From, {error, timeout}}]};
 %% important to verify runner_pid and FromPid are the same in case it was sent
 %% after kill_runner was called but before it had done the unlink
 exporting(info, {'EXIT', FromPid, _}, Data=#data{runner_pid=FromPid}) ->

--- a/apps/opentelemetry/src/otel_span_processor.erl
+++ b/apps/opentelemetry/src/otel_span_processor.erl
@@ -12,7 +12,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc
+%% @doc Behaviour each Span Processor must implement.
 %% @end
 %%%-------------------------------------------------------------------------
 -module(otel_span_processor).

--- a/apps/opentelemetry/src/otel_utils.erl
+++ b/apps/opentelemetry/src/otel_utils.erl
@@ -1,0 +1,28 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2021, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%-----------------------------------------------------------------------
+-module(otel_utils).
+
+-export([format_exception/3]).
+
+-if(?OTP_RELEASE >= 24).
+format_exception(Kind, Reason, StackTrace) ->
+    erl_error:format_exception(Kind, Reason, StackTrace).
+-else.
+format_exception(Kind, Reason, StackTrace) ->
+    io_lib:format("~p:~p ~p", [Kind, Reason, StackTrace]).
+-endif.


### PR DESCRIPTION
The Simple Span Processor does a blocking call when ending a span
that returns after the span is exported.