### PR TITLE
make trace/span id generation customizable

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -47,6 +47,13 @@ jobs:
       run: rebar3 eunit --cover
     - name: Common Test tests
       run: rebar3 ct --cover
+
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v2
+      if: always() # always run even if the previous step fails
+      with:
+        report_paths: '_build/test/logs/*/junit_report.xml'
+
     - name: XRef
       run: rebar3 xref
     - name: Covertool

--- a/apps/opentelemetry/src/otel_id_generator.erl
+++ b/apps/opentelemetry/src/otel_id_generator.erl
@@ -1,0 +1,54 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2021, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc This module provides the behaviour to implement for custom trace
+%% and span id generation and the default implementation of the
+%% generators which produces random 128 bit and 64 bit integers for the
+%% trace id and span id.
+%% @end
+%%%-----------------------------------------------------------------------
+-module(otel_id_generator).
+
+-export([generate_trace_id/0,
+         generate_trace_id/1,
+         generate_span_id/0,
+         generate_span_id/1]).
+
+-callback generate_trace_id() -> opentelemetry:trace_id().
+
+-callback generate_span_id() -> opentelemetry:span_id().
+
+-type t() :: module().
+
+-export_type([t/0]).
+
+%% @doc Calls a module implementing the `otel_id_generator' behaviour to generate a trace id
+-spec generate_trace_id(t()) -> opentelemetry:trace_id().
+generate_trace_id(Module) ->
+    Module:generate_trace_id().
+
+%% @doc Calls a module implementing the `otel_id_generator' behaviour to generate a span id
+-spec generate_span_id(t()) -> opentelemetry:span_id().
+generate_span_id(Module) ->
+    Module:generate_span_id().
+
+%% @doc Generates a 128 bit random integer to use as a trace id.
+-spec generate_trace_id() -> opentelemetry:trace_id().
+generate_trace_id() ->
+    rand:uniform(2 bsl 127 - 1). %% 2 shifted left by 127 == 2 ^ 128
+
+%% @doc Generates a 64 bit random integer to use as a span id.
+-spec generate_span_id() -> opentelemetry:span_id().
+generate_span_id() ->
+    rand:uniform(2 bsl 63 - 1). %% 2 shifted left by 63 == 2 ^ 64

--- a/apps/opentelemetry/src/otel_span_ets.erl
+++ b/apps/opentelemetry/src/otel_span_ets.erl
@@ -25,7 +25,7 @@
          handle_call/3,
          handle_cast/2]).
 
--export([start_span/6,
+-export([start_span/7,
          end_span/1,
          end_span/2,
          get_ctx/1,
@@ -46,10 +46,11 @@ start_link(Opts) ->
     gen_server:start_link(?MODULE, Opts, []).
 
 %% @doc Start a span and insert into the active span ets table.
--spec start_span(otel_ctx:t(), opentelemetry:span_name(), otel_sampler:t(), otel_span:start_opts(),
-                 fun(), otel_tracer_server:instrumentation_library()) -> opentelemetry:span_ctx().
-start_span(Ctx, Name, Sampler, Opts, Processors, InstrumentationLibrary) ->
-    case otel_span_utils:start_span(Ctx, Name, Sampler, Opts) of
+-spec start_span(otel_ctx:t(), opentelemetry:span_name(), otel_sampler:t(), otel_id_generator:t(),
+                 otel_span:start_opts(), fun(), otel_tracer_server:instrumentation_library())
+                -> opentelemetry:span_ctx().
+start_span(Ctx, Name, Sampler, IdGeneratorModule, Opts, Processors, InstrumentationLibrary) ->
+    case otel_span_utils:start_span(Ctx, Name, Sampler, IdGeneratorModule, Opts) of
         {SpanCtx=#span_ctx{is_recording=true}, Span=#span{}} ->
             Span1 = Span#span{instrumentation_library=InstrumentationLibrary},
             Span2 = Processors(Ctx, Span1),

--- a/apps/opentelemetry/src/otel_tracer.hrl
+++ b/apps/opentelemetry/src/otel_tracer.hrl
@@ -9,6 +9,7 @@
          on_start_processors     :: fun((otel_ctx:t(), opentelemetry:span()) -> opentelemetry:span()),
          on_end_processors       :: fun((opentelemetry:span()) -> boolean() | {error, term()}),
          sampler                 :: otel_sampler:t(),
+         id_generator            :: otel_id_generator:t(),
          instrumentation_library :: otel_tracer_server:instrumentation_library() | undefined,
          telemetry_library       :: otel_tracer_server:telemetry_library() | undefined,
          resource                :: otel_resource:t() | undefined

--- a/apps/opentelemetry/src/otel_tracer_default.erl
+++ b/apps/opentelemetry/src/otel_tracer_default.erl
@@ -33,8 +33,9 @@
 start_span(Ctx, {_, #tracer{on_start_processors=Processors,
                             on_end_processors=OnEndProcessors,
                             sampler=Sampler,
+                            id_generator=IdGeneratorModule,
                             instrumentation_library=InstrumentationLibrary}}, Name, Opts) ->
-    SpanCtx = otel_span_ets:start_span(Ctx, Name, Sampler, Opts, Processors, InstrumentationLibrary),
+    SpanCtx = otel_span_ets:start_span(Ctx, Name, Sampler, IdGeneratorModule, Opts, Processors, InstrumentationLibrary),
     SpanCtx#span_ctx{span_sdk={otel_span_ets, OnEndProcessors}}.
 
 -spec with_span(otel_ctx:t(), opentelemetry:tracer(), opentelemetry:span_name(),

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -62,6 +62,8 @@ start_link(Opts) ->
 init(Opts) ->
     Resource = otel_resource_detector:get_resource(),
 
+    IdGeneratorModule = proplists:get_value(id_generator, Opts, otel_id_generator),
+
     SamplerSpec = proplists:get_value(
         sampler, Opts, {parent_based, #{root => always_on}}
     ),
@@ -80,6 +82,7 @@ init(Opts) ->
                      sampler=Sampler,
                      on_start_processors=on_start(Processors),
                      on_end_processors=on_end(Processors),
+                     id_generator=IdGeneratorModule,
                      resource=Resource,
                      telemetry_library=TelemetryLibrary},
     opentelemetry:set_default_tracer({otel_tracer_default, Tracer}),

--- a/apps/opentelemetry/test/otel_samplers_SUITE.erl
+++ b/apps/opentelemetry/test/otel_samplers_SUITE.erl
@@ -271,7 +271,7 @@ custom_sampler_module(_Config) ->
         {?DROP, [], []},
         Sampler:should_sample(
             otel_ctx:new(),
-            opentelemetry:generate_trace_id(),
+            otel_id_generator:generate_trace_id(),
             [],
             SpanName,
             undefined,
@@ -288,7 +288,7 @@ should_sample(_Config) ->
         otel_samplers:should_sample(
             Sampler,
             otel_ctx:new(),
-            opentelemetry:generate_trace_id(),
+            otel_id_generator:generate_trace_id(),
             [],
             <<"span-name">>,
             undefined,

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -52,9 +52,7 @@
          event/3,
          events/1,
          status/2,
-         verify_and_set_term/3,
-         generate_trace_id/0,
-         generate_span_id/0]).
+         verify_and_set_term/3]).
 
 -include("opentelemetry.hrl").
 -include_lib("kernel/include/logger.hrl").
@@ -348,27 +346,6 @@ status(?OTEL_STATUS_UNSET, _Message) ->
     #status{code=?OTEL_STATUS_UNSET};
 status(_, _) ->
     undefined.
-
-%%--------------------------------------------------------------------
-%% @doc
-%% Generates a 128 bit random integer to use as a trace id.
-%% @end
-%%--------------------------------------------------------------------
--spec generate_trace_id() -> trace_id().
-generate_trace_id() ->
-    uniform(2 bsl 127 - 1). %% 2 shifted left by 127 == 2 ^ 128
-
-%%--------------------------------------------------------------------
-%% @doc
-%% Generates a 64 bit random integer to use as a span id.
-%% @end
-%%--------------------------------------------------------------------
--spec generate_span_id() -> span_id().
-generate_span_id() ->
-    uniform(2 bsl 63 - 1). %% 2 shifted left by 63 == 2 ^ 64
-
-uniform(X) ->
-    rand:uniform(X).
 
 %% internal functions
 

--- a/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
@@ -22,7 +22,6 @@ groups() ->
     %% Tests of Behavior of the API in the absence of an installed SDK
     %% https://github.com/open-telemetry/opentelemetry-specification/blob/82865fae64e7b30ee59906d7c4d25a48fe446563/specification/trace/api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk
     [{absence_of_an_installed_sdk, [shuffle, parallel], [invalid_span_no_sdk_propagation,
-                                                         recording_no_sdk_propagation,
                                                          nonrecording_no_sdk_propagation]}].
 
 init_per_suite(Config) ->
@@ -97,26 +96,6 @@ invalid_span_no_sdk_propagation(_Config) ->
     BinaryHeaders = otel_propagator_text_map:inject([]),
     %% invalid span contexts are skipped when injecting
     ?assertMatch([], BinaryHeaders),
-
-    ok.
-
-recording_no_sdk_propagation(_Config) ->
-    ct:comment("Test that a start_span called with an valid recording span parent "
-               "and no SDK results in a new span_id for the child"),
-    otel_ctx:clear(),
-
-    RecordingSpanCtx = #span_ctx{trace_id=21267647932558653966460912964485513216,
-                                 span_id=1152921504606846976,
-                                 is_recording=true},
-    otel_tracer:set_current_span(RecordingSpanCtx),
-    ?assertEqual(RecordingSpanCtx, otel_tracer:current_span_ctx()),
-    ?with_span(<<"span-1">>, #{}, fun(_) ->
-                                          %% parent is recording so a new span_id should be used
-                                          ?assertNotEqual(RecordingSpanCtx, otel_tracer:current_span_ctx())
-                                  end),
-    ?assertEqual(RecordingSpanCtx, otel_tracer:current_span_ctx()),
-    BinaryHeaders = otel_propagator_text_map:inject([]),
-    ?assertMatch(?EXPECTED_HEADERS, BinaryHeaders),
 
     ok.
 

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -114,8 +114,8 @@ configuration(_Config) ->
 ets_instrumentation_info(_Config) ->
     Tid = ets:new(span_tab, [duplicate_bag, {keypos, #span.instrumentation_library}]),
 
-    TraceId = opentelemetry:generate_trace_id(),
-    SpanId = opentelemetry:generate_span_id(),
+    TraceId = otel_id_generator:generate_trace_id(),
+    SpanId = otel_id_generator:generate_span_id(),
 
     ParentSpan =
         #span{name = <<"span-1">>,
@@ -137,7 +137,7 @@ ets_instrumentation_info(_Config) ->
 
     ChildSpan = #span{name = <<"span-2">>,
                       trace_id = TraceId,
-                      span_id = opentelemetry:generate_span_id(),
+                      span_id = otel_id_generator:generate_span_id(),
                       parent_span_id = SpanId,
                       kind = ?SPAN_KIND_SERVER,
                       start_time = opentelemetry:timestamp(),
@@ -165,8 +165,8 @@ ets_instrumentation_info(_Config) ->
     ok.
 
 span_round_trip(_Config) ->
-    TraceId = opentelemetry:generate_trace_id(),
-    SpanId = opentelemetry:generate_span_id(),
+    TraceId = otel_id_generator:generate_trace_id(),
+    SpanId = otel_id_generator:generate_span_id(),
 
     Span =
         #span{name = <<"span-1">>,
@@ -219,8 +219,8 @@ verify_export(Config) ->
 
     ?assertMatch(ok, opentelemetry_exporter:export(Tid, otel_resource:create([]), State)),
 
-    TraceId = opentelemetry:generate_trace_id(),
-    SpanId = opentelemetry:generate_span_id(),
+    TraceId = otel_id_generator:generate_trace_id(),
+    SpanId = otel_id_generator:generate_span_id(),
 
     ParentSpan =
         #span{name = <<"span-1">>,
@@ -242,7 +242,7 @@ verify_export(Config) ->
 
     ChildSpan = #span{name = <<"span-2">>,
                       trace_id = TraceId,
-                      span_id = opentelemetry:generate_span_id(),
+                      span_id = otel_id_generator:generate_span_id(),
                       parent_span_id = SpanId,
                       kind = ?SPAN_KIND_SERVER,
                       start_time = opentelemetry:timestamp(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   otel:
-    image: otel/opentelemetry-collector-contrib-dev
+    image: otel/opentelemetry-collector-contrib-dev:954d0bbc8e80c88380a801443940c7c91779f928
     command: ["--config=/conf/otel-collector-config.yaml"]
     privileged: true
     ports:


### PR DESCRIPTION
A behaviour, otel_id_generator, is added which has callbacks for
generating trace and span ids, along with the default versions
of those functions.

The implementation to use is kept in the tracer record.