### PR TITLE
Configuration improvements and span limit settings

### DIFF
--- a/apps/opentelemetry/include/otel_span.hrl
+++ b/apps/opentelemetry/include/otel_span.hrl
@@ -67,3 +67,12 @@
 
           instrumentation_library :: opentelemetry:instrumentation_library() | undefined
          }).
+
+-record(span_limits, {
+          attribute_count_limit = 128             :: integer(), %% Maximum allowed attribute count per span;
+          attribute_value_length_limit = infinity :: integer() | infinity,  %% Maximum allowed attribute value length
+          event_count_limit = 128                 :: integer(), %% Maximum allowed span event count
+          link_count_limit = 128                  :: integer(), %% Maximum allowed span link count
+          attribute_per_event_limit = 128         :: integer(), %% Maximum allowed attribute per span event count
+          attribute_per_link_limit = 128          :: integer() %% Maximum allowed attribute per span link count
+       }).

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -27,6 +27,9 @@ start(_StartType, _StartArgs) ->
     Opts = otel_configuration:merge_with_os(
              application:get_all_env(opentelemetry)),
 
+    %% set global span limits record based on configuration
+    otel_span_limits:set(Opts),
+
     %% set the global propagators for HTTP based on the application env
     setup_text_map_propagators(Opts),
 

--- a/apps/opentelemetry/src/opentelemetry_sup.erl
+++ b/apps/opentelemetry/src/opentelemetry_sup.erl
@@ -48,7 +48,7 @@ init([Opts]) ->
                      type => worker,
                      modules => [otel_tracer_provider, otel_tracer_server]},
 
-    Processors = proplists:get_value(processors, Opts, []),
+    Processors = maps:get(processors, Opts),
     BatchProcessorOpts = proplists:get_value(otel_batch_processor, Processors, #{}),
     BatchProcessor = #{id => otel_batch_processor,
                        start => {otel_batch_processor, start_link, [BatchProcessorOpts]},

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -20,46 +20,106 @@
 -module(otel_configuration).
 
 -export([merge_with_os/1,
-         merge_list_with_environment/2,
+         merge_list_with_environment/3,
          report_cb/1]).
 
 -include_lib("kernel/include/logger.hrl").
 
--spec merge_with_os(list()) -> list().
-merge_with_os(Opts) ->
-    span_limits(
-      general(
-        sampler(
-          processors(Opts)))).
+%% required configuration
+%% using a map instead of a record because there can be more values
+-type t() :: #{log_level := atom(),
+               register_loaded_applications := boolean(),
+               text_map_propagators := [atom()],
+               traces_exporter := {atom(), term()},
+               processors := list(),
+               attribute_count_limit := integer(),
+               attribute_value_length_limit := integer() | infinity,
+               event_count_limit := integer(),
+               link_count_limit := integer(),
+               attribute_per_event_limit := integer(),
+               attribute_per_link_limit := integer()}.
 
-span_limits(Opts) ->
-    merge_list_with_environment(config_mappings(span_limits), Opts).
+new() ->
+    #{log_level => info,
+      register_loaded_applications => true,
+      text_map_propagators => [trace_context, baggage],
+      traces_exporter => {opentelemetry_exporter, #{}},
+      processors => [{otel_batch_processor, #{scheduled_delay_ms => 5000,
+                                              exporting_timeout_ms => 30000,
+                                              max_queue_size => 2048,
+                                              exporter => {opentelemetry_exporter, #{}}}}],
+      sampler => {parent_based, #{root => always_on}},
+      attribute_count_limit => 128,
+      attribute_value_length_limit => infinity,
+      event_count_limit => 128,
+      link_count_limit => 128,
+      attribute_per_event_limit => 128,
+      attribute_per_link_limit => 128}.
 
-general(Opts) ->
-    merge_list_with_environment(config_mappings(general_sdk), Opts).
+-spec merge_with_os(list()) -> t().
+merge_with_os(AppEnv) ->
+    ConfigMap = new(),
 
-processors(AppEnvOpts) ->
-    Processors = proplists:get_value(processors, AppEnvOpts, [{otel_batch_processor, #{}}]),
+    lists:foldl(fun(F, Acc) ->
+                        F(AppEnv, Acc)
+                end, ConfigMap, [fun span_limits/2,
+                                 fun general/2,
+                                 fun sampler/2,
+                                 fun processors/2]).
 
-    Config = lists:map(fun({Name, Opts}) ->
-                               {Name, merge_with_environment(config_mappings(Name), Opts)}
-                       end, Processors),
+-spec span_limits(list(), t()) -> t().
+span_limits(AppEnv, ConfigMap) ->
+    merge_list_with_environment(config_mappings(span_limits), AppEnv, ConfigMap).
 
-    lists:keystore(processors, 1, AppEnvOpts, {processors, Config}).
+-spec general(list(), t()) -> t().
+general(AppEnv, ConfigMap) ->
+    merge_list_with_environment(config_mappings(general_sdk), AppEnv, ConfigMap).
+
+-spec processors(list(), t()) -> t().
+processors(AppEnv, ConfigMap) ->
+    %% builtin processors have OS environment configuration per type of processor
+    %% so we must do an environment merge even with the default processor from
+    %% the ConfigMap to ensure we get all the user's configuration
+    Processors = proplists:get_value(processors, AppEnv, maps:get(processors, ConfigMap)),
+
+    ProcessorsConfig = lists:map(fun({Name, Opts}) ->
+                                         {Name, merge_with_environment(config_mappings(Name), Opts)}
+                                 end, Processors),
+
+    ConfigMap#{processors := ProcessorsConfig}.
 
 %% sampler configuration is unique since it has the _ARG that is a sort of
 %% sub-configuration of the sampler config, and isn't a list.
-sampler(AppEnvOpts) ->
-    Sampler = proplists:get_value(sampler, AppEnvOpts, {parent_based, #{root => always_on}}),
-
+-spec sampler(list(), t()) -> t().
+sampler(AppEnv, ConfigMap) ->
     case os:getenv("OTEL_TRACES_SAMPLER") of
         false ->
-            lists:keystore(sampler, 1, AppEnvOpts, {sampler, Sampler});
+            case proplists:get_value(sampler, AppEnv) of
+                undefined ->
+                    ConfigMap;
+                Sampler ->
+                    try transform(sampler, Sampler) of
+                        TransformedSampler ->
+                            ConfigMap#{sampler := TransformedSampler}
+                    catch
+                        Kind:Reason:StackTrace ->
+                            ?LOG_INFO(#{source => transform,
+                                        kind => Kind,
+                                        reason => Reason,
+                                        os_var => "OTEL_TRACES_SAMPLER",
+                                        key => sampler,
+                                        transform => sampler,
+                                        value => Sampler,
+                                        stacktrace => StackTrace},
+                                      #{report_cb => fun ?MODULE:report_cb/1}),
+                            ConfigMap
+                    end
+            end;
         OSEnvSampler->
             SamplerTuple = {OSEnvSampler, os:getenv("OTEL_TRACES_SAMPLER_ARG")},
             try transform(sampler, SamplerTuple) of
                 TransformedSampler ->
-                    lists:keystore(sampler, 1, AppEnvOpts, {sampler, TransformedSampler})
+                    ConfigMap#{sampler := TransformedSampler}
             catch
                 Kind:Reason:StackTrace ->
                     ?LOG_INFO(#{source => transform,
@@ -71,25 +131,28 @@ sampler(AppEnvOpts) ->
                                 value => SamplerTuple,
                                 stacktrace => StackTrace},
                               #{report_cb => fun ?MODULE:report_cb/1}),
-                    AppEnvOpts
+                    ConfigMap
             end
     end.
 
--spec merge_list_with_environment([{OSVar, Key, Default, Transform}], list()) -> list()
+-spec merge_list_with_environment([{OSVar, Key, Transform}], list(), t()) -> t()
               when OSVar :: string(),
                    Key :: atom(),
-                   Default :: term(),
                    Transform :: atom().
-merge_list_with_environment(ConfigMappings, Opts) ->
-    lists:foldl(fun({OSVar, Key, Default, Transform}, Acc) ->
+merge_list_with_environment(ConfigMappings, AppEnv, ConfigMap) ->
+    lists:foldl(fun({OSVar, Key, Transform}, Acc) ->
                         case os:getenv(OSVar) of
                             false ->
-                                case lists:keyfind(Key, 1, Opts) of
+                                case lists:keyfind(Key, 1, AppEnv) of
                                     false ->
-                                        %% set to Default if it doesn't exist
-                                        try transform(Transform, Default) of
-                                            Value ->
-                                                [{Key, Value} | Acc]
+                                        Acc;
+                                    {_, Value} ->
+                                        %% transform even the value from the
+                                        %% application environment to ensure it
+                                        %% is of the right type/format
+                                        try transform(Transform, Value) of
+                                            TransformedValue ->
+                                                Acc#{Key := TransformedValue}
                                         catch
                                             Kind:Reason:StackTrace ->
                                                 ?LOG_INFO(#{source => transform,
@@ -98,19 +161,16 @@ merge_list_with_environment(ConfigMappings, Opts) ->
                                                             os_var => OSVar,
                                                             key => Key,
                                                             transform => Transform,
-                                                            value => Default,
+                                                            value => Value,
                                                             stacktrace => StackTrace},
                                                           #{report_cb => fun ?MODULE:report_cb/1}),
                                                 Acc
-                                        end;
-                                    _ ->
-                                        %% already set, do nothing
-                                        Acc
+                                        end
                                 end;
                             OSVal ->
                                 try transform(Transform, OSVal) of
-                                    Value ->
-                                        lists:keystore(Key, 1, Acc, {Key, Value})
+                                    TransformedValue ->
+                                        Acc#{Key := TransformedValue}
                                 catch
                                     Kind:Reason:StackTrace ->
                                         ?LOG_INFO(#{source => transform,
@@ -119,43 +179,44 @@ merge_list_with_environment(ConfigMappings, Opts) ->
                                                     os_var => OSVar,
                                                     key => Key,
                                                     transform => Transform,
-                                                    value => Default,
+                                                    value => OSVal,
                                                     stacktrace => StackTrace},
                                                   #{report_cb => fun ?MODULE:report_cb/1}),
                                         Acc
                                 end
                         end
-                end, Opts, ConfigMappings).
+                end, ConfigMap, ConfigMappings).
 
--spec merge_with_environment([{OSVar, Key, Default, Transform}], map()) -> map()
+-spec merge_with_environment([{OSVar, Key, Transform}], map()) -> map()
               when OSVar :: string(),
                    Key :: atom(),
-                   Default :: term(),
                    Transform :: atom().
 merge_with_environment(ConfigMappings, Opts) ->
-    lists:foldl(fun({OSVar, Key, Default, Transform}, Acc) ->
-                        Value = case os:getenv(OSVar) of
-                                    false ->
-                                        %% set to Default if it doesn't exist
-                                        Default;
-                                    OSVal ->
-                                        OSVal
-                                end,
-                        try transform(Transform, Value) of
-                            Transformed ->
-                                maps:update_with(Key, fun(X) -> X end, Transformed, Acc)
-                        catch
-                            Kind:Reason:StackTrace ->
-                                ?LOG_INFO(#{source => transform,
-                                            kind => Kind,
-                                            reason => Reason,
-                                            os_var => OSVar,
-                                            key => Key,
-                                            transform => Transform,
-                                            value => Value,
-                                            stacktrace => StackTrace},
-                                          #{report_cb => fun ?MODULE:report_cb/1}),
-                                Acc
+    lists:foldl(fun({OSVar, Key, Transform}, Acc) ->
+                        case os:getenv(OSVar) of
+                            false ->
+                                Acc;
+                            OSVal ->
+                                try transform(Transform, OSVal) of
+                                    Transformed ->
+                                        %% unlike the top level config `t()' not every config
+                                        %% key is guaranteed to exist here because it could
+                                        %% have been read from the application environment.
+                                        %% so use `=>' and not `:='
+                                        Acc#{Key => Transformed}
+                                catch
+                                    Kind:Reason:StackTrace ->
+                                        ?LOG_INFO(#{source => transform,
+                                                    kind => Kind,
+                                                    reason => Reason,
+                                                    os_var => OSVar,
+                                                    key => Key,
+                                                    transform => Transform,
+                                                    value => OSVal,
+                                                    stacktrace => StackTrace},
+                                                  #{report_cb => fun ?MODULE:report_cb/1}),
+                                        Acc
+                                end
                         end
                 end, Opts, ConfigMappings).
 
@@ -171,26 +232,27 @@ report_cb(#{source := transform,
      [OSVar, Key, Transform, Value, otel_utils:format_exception(Kind, Reason, StackTrace)]}.
 
 config_mappings(general_sdk) ->
-    [{"OTEL_LOG_LEVEL", log_level, "info", existing_atom},
-     {"OTEL_PROPAGATORS", text_map_propagators, "tracecontext,baggage", propagators},
-     {"OTEL_TRACES_EXPORTER", traces_exporter, "otlp", exporter},
-     {"OTEL_METRICS_EXPORTER", metrics_exporter, undefined, exporter}];
+    [{"OTEL_LOG_LEVEL", log_level, existing_atom},
+     {"OTEL_REGISTER_LOADED_APPLICATIONS", register_loaded_applications, boolean},
+     {"OTEL_PROPAGATORS", text_map_propagators, propagators},
+     {"OTEL_TRACES_EXPORTER", traces_exporter, exporter},
+     {"OTEL_METRICS_EXPORTER", metrics_exporter, exporter}];
 config_mappings(otel_batch_processor) ->
-    [{"OTEL_BSP_SCHEDULE_DELAY_MILLIS", scheduled_delay_ms, 5000, integer},
-     {"OTEL_BSP_EXPORT_TIMEOUT_MILLIS", exporting_timeout_ms, 30000, integer},
-     {"OTEL_BSP_MAX_QUEUE_SIZE", max_queue_size, 2048, integer},
+    [{"OTEL_BSP_SCHEDULE_DELAY_MILLIS", scheduled_delay_ms, integer}, %% 5000,
+     {"OTEL_BSP_EXPORT_TIMEOUT_MILLIS", exporting_timeout_ms, integer}, %% 30000,
+     {"OTEL_BSP_MAX_QUEUE_SIZE", max_queue_size, integer}, %% 2048,
      %% a second usage of OTEL_TRACES_EXPORTER to set the exporter used by batch processor
-     {"OTEL_TRACES_EXPORTER", exporter, "otlp", exporter}
+     {"OTEL_TRACES_EXPORTER", exporter, exporter} %% "otlp",
      %% the following are not supported yet
      %% {"OTEL_BSP_MAX_EXPORT_BATCH_SIZE", max_export_batch_size, 512}
     ];
 config_mappings(span_limits) ->
-    [{"OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", attribute_count_limit, 128, integer},
-     {"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", attribute_value_length_limit, infinity, integer_infinity},
-     {"OTEL_SPAN_EVENT_COUNT_LIMIT", event_count_limit, 128, integer},
-     {"OTEL_SPAN_LINK_COUNT_LIMIT", link_count_limit, 128, integer},
-     {"OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT", attribute_per_event_limit, 128, integer},
-     {"OTEL_LINK_ATTRIBUTE_COUNT_LIMIT", attribute_per_link_limit, 128, integer}%% ,
+    [{"OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", attribute_count_limit, integer},
+     {"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", attribute_value_length_limit, integer_infinity},
+     {"OTEL_SPAN_EVENT_COUNT_LIMIT", event_count_limit, integer},
+     {"OTEL_SPAN_LINK_COUNT_LIMIT", link_count_limit, integer},
+     {"OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT", attribute_per_event_limit, integer},
+     {"OTEL_LINK_ATTRIBUTE_COUNT_LIMIT", attribute_per_link_limit, integer}%% ,
      %% {"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", attribute_value_length_limit, 128, integer},
      %% {"OTEL_ATTRIBUTE_COUNT_LIMIT", attribute_per_link_limit, 128, integer}
     ];
@@ -209,11 +271,12 @@ transform(exporter, "zipkin") ->
     undefined;
 transform(exporter, "none") ->
     undefined;
-transform(exporter, "prometheus") ->
-    prometheus;
-transform(exporter, UnknownExporter) ->
+transform(exporter, Value={Term, _}) when is_atom(Term) ->
+    Value;
+transform(exporter, UnknownExporter) when is_list(UnknownExporter) ->
     ?LOG_WARNING("unknown exporter ~p. falling back to default otlp", [UnknownExporter]),
     {opentelemetry_exporter, #{}};
+
 transform(integer_infinity, infinity) ->
     infinity;
 transform(integer_infinity, Value) ->
@@ -222,8 +285,18 @@ transform(integer, Value) when is_integer(Value) ->
     Value;
 transform(integer, Value) when is_list(Value) ->
     list_to_integer(Value);
+transform(existing_atom, Value) when is_atom(Value) ->
+    Value;
 transform(existing_atom, Value) when is_list(Value) ->
     list_to_existing_atom(Value);
+transform(boolean, Value) when is_boolean(Value) ->
+    Value;
+transform(boolean, "true") ->
+    true;
+transform(boolean, "false") ->
+    false;
+transform(url, Value=#{}) ->
+    Value;
 transform(url, Value) ->
     uri_string:parse(Value);
 %% convert sampler string to usable configuration term
@@ -245,7 +318,31 @@ transform(sampler, {"parentbased_traceidratio", Probability}) ->
     {parent_based, #{root => {trace_id_ratio_based, probability_string_to_float(Probability)}}};
 transform(sampler, Value) ->
     Value;
-
+transform(key_value_list, Value) when is_list(Value) ->
+    case io_lib:printable_list(Value) of
+        true ->
+            Pairs = string:split(Value, ",", all),
+            lists:filtermap(fun(Pair) ->
+                                    case string:split(Pair, "=", all) of
+                                        [K, V] ->
+                                            V1 = re:replace(string:trim(V), "^\"|\"$", "", [global, {return, list}]),
+                                            {true, {string:trim(K), V1}};
+                                        _ ->
+                                            false
+                                    end
+                            end, Pairs);
+        false ->
+            Value
+    end;
+transform(propagators, [P | _]=Propagators) when is_atom(P) ->
+    lists:filtermap(fun(Propagator) ->
+                            case transform(propagator, Propagator) of
+                                undefined ->
+                                    false;
+                                Value ->
+                                    {true, Value}
+                            end
+                    end, Propagators);
 transform(propagators, PropagatorsString) when is_list(PropagatorsString) ->
     Propagators = string:split(PropagatorsString, ",", all),
     lists:filtermap(fun(Propagator) when is_list(Propagator) ->
@@ -257,13 +354,18 @@ transform(propagators, PropagatorsString) when is_list(PropagatorsString) ->
                           end
                   end, Propagators);
 
-transform(propagator, "tracecontext") ->
+transform(propagator, Value) when Value =:= "tracecontext" ;
+                                  Value =:= tracecontext ;
+                                  Value =:= trace_context ->
     trace_context;
-transform(propagator, "baggage") ->
+transform(propagator, Value) when Value =:= "baggage" ;
+                                  Value =:= baggage ->
     baggage;
-transform(propagator, "b3multi") ->
+transform(propagator, Value) when Value =:= "b3multi" ;
+                                  Value =:= b3multi ->
     b3multi;
-transform(propagator, "b3") ->
+transform(propagator, Value) when Value =:= "b3" ;
+                                  Value =:= b3 ->
     b3;
 %% TODO: support jager propagator format
 %% transform(propagator, "jaeger") ->
@@ -271,21 +373,7 @@ transform(propagator, "b3") ->
 transform(propagator, Propagator) ->
     ?LOG_WARNING("Ignoring unknown propagator ~ts in OS environment variable $OTEL_PROPAGATORS",
                  [Propagator]),
-    undefined;
-transform(key_value_list, Value) when is_list(Value) ->
-    Pairs = string:split(Value, ",", all),
-    lists:filtermap(fun(Pair) ->
-                            case string:split(Pair, "=", all) of
-                                [K, V] ->
-                                    V1 = re:replace(string:trim(V), "^\"|\"$", "", [global, {return, list}]),
-                                    {true, {string:trim(K), V1}};
-                                _ ->
-                                    false
-                            end
-                    end, Pairs);
-
-transform(string, Value) ->
-    Value.
+    undefined.
 
 probability_string_to_float(Probability) ->
     try list_to_float(Probability) of

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -135,7 +135,7 @@ sampler(AppEnv, ConfigMap) ->
             end
     end.
 
--spec merge_list_with_environment([{OSVar, Key, Transform}], list(), t()) -> t()
+-spec merge_list_with_environment([{OSVar, Key, Transform}], list(), map()) -> map()
               when OSVar :: string(),
                    Key :: atom(),
                    Transform :: atom().

--- a/apps/opentelemetry/src/otel_resource_detector.erl
+++ b/apps/opentelemetry/src/otel_resource_detector.erl
@@ -66,11 +66,11 @@ get_resource(Timeout) ->
             otel_resource:create([])
     end.
 
-init([Opts]) ->
+init([_Opts]) ->
     process_flag(trap_exit, true),
 
-    Detectors = proplists:get_value(resource_detectors, Opts, []),
-    DetectorTimeout = proplists:get_value(resource_detectors_timeout, Opts, 5000),
+    Detectors = application:get_env(opentelemetry, resource_detectors, []),
+    DetectorTimeout = application:get_env(opentelemetry, resource_detectors_timeout, 5000),
 
     {ok, collecting, #data{resource=otel_resource:create([]),
                            detectors=Detectors,

--- a/apps/opentelemetry/src/otel_span_limits.erl
+++ b/apps/opentelemetry/src/otel_span_limits.erl
@@ -1,0 +1,55 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2021, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Module for setting the global limits for the number of attributes,
+%% events and links on a Span.
+%% @end
+%%%-------------------------------------------------------------------------
+-module(otel_span_limits).
+
+-export([get/0,
+         set/1]).
+
+-include("otel_span.hrl").
+
+-define(SPAN_LIMITS_KEY, {?MODULE, span_limits}).
+
+-spec get() -> #span_limits{}.
+get() ->
+    persistent_term:get(?SPAN_LIMITS_KEY).
+
+%% -spec set(#{attribute_count_limit => integer(),
+%%             attribute_value_length_limit => integer() | infinity,
+%%             event_count_limit => integer(),
+%%             link_count_limit => integer(),
+%%             attribute_per_event_limit => integer(),
+%%             attribute_per_link_limit => integer()}) -> ok.
+-spec set(list()) -> ok.
+set(Opts) ->
+    SpanLimits = lists:foldl(fun({attribute_count_limit, AttributeCountLimit}, Acc) ->
+                                     Acc#span_limits{attribute_count_limit=AttributeCountLimit};
+                                ({attribute_value_length_limit, AttributeValueLengthLimit}, Acc) ->
+                                     Acc#span_limits{attribute_value_length_limit=AttributeValueLengthLimit};
+                                ({event_count_limit, EventCountLimit}, Acc) ->
+                                     Acc#span_limits{event_count_limit=EventCountLimit};
+                                ({link_count_limit, LinkCountLimit}, Acc) ->
+                                     Acc#span_limits{link_count_limit=LinkCountLimit};
+                                ({attribute_per_event_limit, AttributePerEventLimit}, Acc) ->
+                                     Acc#span_limits{attribute_per_event_limit=AttributePerEventLimit};
+                                ({attribute_per_link_limit, AttributePerLinkLimit}, Acc) ->
+                                     Acc#span_limits{attribute_per_link_limit=AttributePerLinkLimit};
+                                (_, Acc) ->
+                                   Acc
+                           end, #span_limits{}, Opts),
+    persistent_term:put(?SPAN_LIMITS_KEY, SpanLimits).

--- a/apps/opentelemetry/src/otel_span_limits.erl
+++ b/apps/opentelemetry/src/otel_span_limits.erl
@@ -35,21 +35,21 @@ get() ->
 %%             link_count_limit => integer(),
 %%             attribute_per_event_limit => integer(),
 %%             attribute_per_link_limit => integer()}) -> ok.
--spec set(list()) -> ok.
+-spec set(otel_configuration:t()) -> ok.
 set(Opts) ->
-    SpanLimits = lists:foldl(fun({attribute_count_limit, AttributeCountLimit}, Acc) ->
-                                     Acc#span_limits{attribute_count_limit=AttributeCountLimit};
-                                ({attribute_value_length_limit, AttributeValueLengthLimit}, Acc) ->
-                                     Acc#span_limits{attribute_value_length_limit=AttributeValueLengthLimit};
-                                ({event_count_limit, EventCountLimit}, Acc) ->
-                                     Acc#span_limits{event_count_limit=EventCountLimit};
-                                ({link_count_limit, LinkCountLimit}, Acc) ->
-                                     Acc#span_limits{link_count_limit=LinkCountLimit};
-                                ({attribute_per_event_limit, AttributePerEventLimit}, Acc) ->
-                                     Acc#span_limits{attribute_per_event_limit=AttributePerEventLimit};
-                                ({attribute_per_link_limit, AttributePerLinkLimit}, Acc) ->
-                                     Acc#span_limits{attribute_per_link_limit=AttributePerLinkLimit};
-                                (_, Acc) ->
+    SpanLimits = maps:fold(fun(attribute_count_limit, AttributeCountLimit, Acc) ->
+                                   Acc#span_limits{attribute_count_limit=AttributeCountLimit};
+                              (attribute_value_length_limit, AttributeValueLengthLimit, Acc) ->
+                                   Acc#span_limits{attribute_value_length_limit=AttributeValueLengthLimit};
+                              (event_count_limit, EventCountLimit, Acc) ->
+                                   Acc#span_limits{event_count_limit=EventCountLimit};
+                              (link_count_limit, LinkCountLimit, Acc) ->
+                                   Acc#span_limits{link_count_limit=LinkCountLimit};
+                              (attribute_per_event_limit, AttributePerEventLimit, Acc) ->
+                                   Acc#span_limits{attribute_per_event_limit=AttributePerEventLimit};
+                              (attribute_per_link_limit, AttributePerLinkLimit, Acc) ->
+                                   Acc#span_limits{attribute_per_link_limit=AttributePerLinkLimit};
+                              (_, _, Acc) ->
                                    Acc
                            end, #span_limits{}, Opts),
     persistent_term:put(?SPAN_LIMITS_KEY, SpanLimits).

--- a/apps/opentelemetry/src/otel_span_sup.erl
+++ b/apps/opentelemetry/src/otel_span_sup.erl
@@ -32,12 +32,12 @@ start_link(Opts) ->
 start_child(ChildSpec) ->
     supervisor:start_child(?SERVER, ChildSpec).
 
-init([Opts]) ->
+init([_Opts]) ->
     SupFlags = #{strategy => one_for_one,
                  intensity => 1,
                  period => 5},
 
-    SweeperOpts = proplists:get_value(sweeper, Opts, #{}),
+    SweeperOpts = application:get_env(opentelemetry, sweeper, #{}),
     Sweeper = #{id => otel_span_sweeper,
                 start => {otel_span_sweeper, start_link, [SweeperOpts]},
                 restart => permanent,

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -62,14 +62,12 @@ start_link(Opts) ->
 init(Opts) ->
     Resource = otel_resource_detector:get_resource(),
 
-    IdGeneratorModule = proplists:get_value(id_generator, Opts, otel_id_generator),
+    IdGeneratorModule = application:get_env(opentelemetry, id_generator, otel_id_generator),
 
-    SamplerSpec = proplists:get_value(
-        sampler, Opts, {parent_based, #{root => always_on}}
-    ),
+    SamplerSpec = maps:get(sampler, Opts),
     Sampler = otel_sampler:new(SamplerSpec),
-    Processors = proplists:get_value(processors, Opts, []),
-    DenyList = proplists:get_value(deny_list, Opts, []),
+    Processors = maps:get(processors, Opts),
+    DenyList = application:get_env(opentelemetry, deny_list, []),
 
     {ok, LibraryVsn} = application:get_key(opentelemetry, vsn),
     LibraryName = <<"opentelemetry">>,

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -123,15 +123,18 @@ registered_tracers(_Config) ->
 
 propagator_configuration(_Config) ->
     ?assertEqual({otel_propagator_text_map_composite,
-                  [{otel_propagator_b3, b3multi}, otel_propagator_baggage]}, opentelemetry:get_text_map_extractor()),
+                  [{otel_propagator_b3, b3multi}, otel_propagator_baggage]},
+                 opentelemetry:get_text_map_extractor()),
     ?assertEqual({otel_propagator_text_map_composite,
-                  [{otel_propagator_b3, b3multi}, otel_propagator_baggage]}, opentelemetry:get_text_map_injector()),
+                  [{otel_propagator_b3, b3multi}, otel_propagator_baggage]},
+                 opentelemetry:get_text_map_injector()),
 
     opentelemetry:set_text_map_extractor({otel_propagator_baggage, []}),
 
     ?assertEqual({otel_propagator_baggage, []}, opentelemetry:get_text_map_extractor()),
     ?assertEqual({otel_propagator_text_map_composite,
-                  [{otel_propagator_b3, b3multi}, otel_propagator_baggage]}, opentelemetry:get_text_map_injector()),
+                  [{otel_propagator_b3, b3multi}, otel_propagator_baggage]},
+                 opentelemetry:get_text_map_injector()),
 
     opentelemetry:set_text_map_injector({{otel_propagator_b3, b3multi}, []}),
 

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -19,7 +19,8 @@ all() ->
     [empty_os_environment, sampler, sampler_parent_based, sampler_parent_based_zero,
      sampler_trace_id, sampler_trace_id_default, sampler_parent_based_one,
      log_level, propagators, propagators_b3, propagators_b3multi, otlp_exporter,
-     jaeger_exporter, zipkin_exporter, none_exporter, span_limits, bad_span_limits].
+     jaeger_exporter, zipkin_exporter, none_exporter, span_limits, bad_span_limits,
+     bad_app_config, app_env_exporter].
 
 init_per_testcase(empty_os_environment, Config) ->
     Vars = [],
@@ -122,12 +123,12 @@ init_per_testcase(span_limits, Config) ->
 
     setup_env(Vars),
 
-    ExpectedOpts = [{attribute_count_limit, 111},
-                    {attribute_value_length_limit, 9},
-                    {event_count_limit, 200},
-                    {link_count_limit, 1101},
-                    {attribute_per_event_limit, 400},
-                    {attribute_per_link_limit, 500}],
+    ExpectedOpts = #{attribute_count_limit => 111,
+                     attribute_value_length_limit => 9,
+                     event_count_limit => 200,
+                     link_count_limit => 1101,
+                     attribute_per_event_limit => 400,
+                     attribute_per_link_limit => 500},
     ExpectedRecord = #span_limits{attribute_count_limit=111,
                                   attribute_value_length_limit=9,
                                   event_count_limit=200,
@@ -146,7 +147,7 @@ init_per_testcase(bad_span_limits, Config) ->
 
     setup_env(Vars),
 
-    ExpectedOpts = [],
+    ExpectedOpts = #{},
     ExpectedRecord = #span_limits{attribute_count_limit=128,
                                   attribute_value_length_limit=infinity,
                                   event_count_limit=128,
@@ -154,7 +155,12 @@ init_per_testcase(bad_span_limits, Config) ->
                                   attribute_per_event_limit=128,
                                   attribute_per_link_limit=128},
 
-    [{expected_opts, ExpectedOpts}, {expected_record, ExpectedRecord}, {os_vars, Vars} | Config].
+    [{expected_opts, ExpectedOpts}, {expected_record, ExpectedRecord}, {os_vars, Vars} | Config];
+init_per_testcase(bad_app_config, Config) ->
+    [{os_vars, []} | Config];
+init_per_testcase(app_env_exporter, Config) ->
+
+    [{os_vars, []} | Config].
 
 end_per_testcase(_, Config) ->
     Vars = ?config(os_vars, Config),
@@ -164,100 +170,105 @@ end_per_testcase(_, Config) ->
     ok.
 
 empty_os_environment(_Config) ->
-    ?assertIsSubset([{log_level,info},
-                     {text_map_propagators,[trace_context, baggage]},
-                     {sampler,{parent_based,#{root => always_on}}}],
-                    otel_configuration:merge_with_os([])),
+    ?assertMatch(#{log_level := info,
+                   text_map_propagators := [trace_context, baggage],
+                   sampler := {parent_based, #{root := always_on}}},
+                 otel_configuration:merge_with_os([])),
 
-    ?assertIsSubset([{log_level, error}], otel_configuration:merge_with_os([{log_level, error}])),
+    ?assertMatch(#{log_level := error},
+                 otel_configuration:merge_with_os([{log_level, error}])),
 
     ok.
 
 sampler(_Config) ->
-    ?assertMatch({sampler, {parent_based, #{root := always_off}}},
-                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch({parent_based, #{root := always_off}},
+                 maps:get(sampler, otel_configuration:merge_with_os([]))),
 
     ok.
 
 sampler_parent_based(_Config) ->
-    ?assertMatch({sampler, {parent_based, #{root := {trace_id_ratio_based, 0.5}}}},
-                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch({parent_based, #{root := {trace_id_ratio_based, 0.5}}},
+                 maps:get(sampler, otel_configuration:merge_with_os([]))),
 
     ok.
 
 sampler_trace_id(_Config) ->
-    ?assertMatch({sampler, {trace_id_ratio_based, 0.5}},
-                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch({trace_id_ratio_based, 0.5},
+                 maps:get(sampler, otel_configuration:merge_with_os([]))),
 
     ok.
 
 sampler_trace_id_default(_Config) ->
-    ?assertMatch({sampler, {trace_id_ratio_based, 1.0}},
-                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch({trace_id_ratio_based, 1.0},
+                 maps:get(sampler, otel_configuration:merge_with_os([]))),
 
     ok.
 
 sampler_parent_based_one(_Config) ->
-    ?assertMatch({sampler, {parent_based, #{root := {trace_id_ratio_based, 1.0}}}},
-                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch({parent_based, #{root := {trace_id_ratio_based, 1.0}}},
+                 maps:get(sampler, otel_configuration:merge_with_os([]))),
 
     ok.
 
 sampler_parent_based_zero(_Config) ->
-    ?assertMatch({sampler, {parent_based, #{root := {trace_id_ratio_based, 0.0}}}},
-                 lists:keyfind(sampler, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch({parent_based, #{root := {trace_id_ratio_based, 0.0}}},
+                 maps:get(sampler, otel_configuration:merge_with_os([]))),
 
     ok.
 
 log_level(_Config) ->
-    %% TODO: can make this a better error message when it fails with a custom assert macro
-    ?assertIsSubset([{log_level, error}], otel_configuration:merge_with_os([])),
-
-    ?assertIsSubset([{log_level, error}], otel_configuration:merge_with_os([{log_level, info}])),
+    ?assertMatch(#{log_level := error}, otel_configuration:merge_with_os([])),
+    ?assertMatch(#{log_level := error}, otel_configuration:merge_with_os([{log_level, info}])),
 
     ok.
 
 propagators(_Config) ->
-    %% TODO: can make this a better error message when it fails with a custom assert macro
-    ?assertIsSubset([{log_level, error},
-                     {text_map_propagators, [baggage]}],
-                    otel_configuration:merge_with_os([{log_level, error}])),
+    ?assertMatch(#{log_level := error,
+                   text_map_propagators := [baggage]},
+                 otel_configuration:merge_with_os([{log_level, error}])),
 
     ok.
 
 propagators_b3(_Config) ->
-    ?assertIsSubset([{log_level, error},
-                     {text_map_propagators, [b3]}],
-                    otel_configuration:merge_with_os([{log_level, error}])),
+    ?assertMatch(#{log_level := error,
+                   text_map_propagators := [b3]},
+                 otel_configuration:merge_with_os([{log_level, error}])),
 
     ok.
 
 propagators_b3multi(_Config) ->
-    ?assertIsSubset([{log_level, error},
-                     {text_map_propagators, [b3multi]}],
-                    otel_configuration:merge_with_os([{log_level, error}])),
+    ?assertMatch(#{log_level := error,
+                   text_map_propagators := [b3multi]},
+                 otel_configuration:merge_with_os([{log_level, error}])),
 
     ok.
 
 otlp_exporter(_Config) ->
-    ?assertMatch({traces_exporter, {opentelemetry_exporter, #{}}},
-                 lists:keyfind(traces_exporter, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch({opentelemetry_exporter, #{}},
+                 maps:get(traces_exporter, otel_configuration:merge_with_os([]))),
 
     ok.
 
 jaeger_exporter(_Config) ->
-    ?assertMatch({traces_exporter, undefined},
-                 lists:keyfind(traces_exporter, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch(undefined,
+                 maps:get(traces_exporter, otel_configuration:merge_with_os([]))),
     ok.
 
 zipkin_exporter(_Config) ->
-    ?assertMatch({traces_exporter, undefined},
-                 lists:keyfind(traces_exporter, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch(undefined,
+                 maps:get(traces_exporter, otel_configuration:merge_with_os([]))),
     ok.
 
 none_exporter(_Config) ->
-    ?assertMatch({traces_exporter, undefined},
-                 lists:keyfind(traces_exporter, 1, otel_configuration:merge_with_os([]))),
+    ?assertMatch(undefined,
+                 maps:get(traces_exporter, otel_configuration:merge_with_os([]))),
+    ok.
+
+app_env_exporter(_Config) ->
+    ?assertMatch({someother_exporter, #{}},
+                 maps:get(traces_exporter,
+                          otel_configuration:merge_with_os([{traces_exporter, {someother_exporter, #{}}}]))),
+
     ok.
 
 span_limits(Config) ->
@@ -266,14 +277,20 @@ span_limits(Config) ->
 bad_span_limits(Config) ->
     compare_span_limits(Config).
 
+bad_app_config(_Config) ->
+    ?assertMatch(#{attribute_value_length_limit := infinity},
+                 otel_configuration:merge_with_os([{attribute_value_length_limit, "aaa"}])),
+
+    ok.
+
 compare_span_limits(Config) ->
     ExpectedRecord = ?config(expected_record, Config),
-    ExpectedOpts = ?config(expected_opts, Config),
-    Opts = otel_configuration:merge_with_os([]),
+    ExpectedOpts = maps:to_list(?config(expected_opts, Config)),
+    Opts = maps:to_list(otel_configuration:merge_with_os([])),
 
     ?assertIsSubset(ExpectedOpts, Opts),
 
-    otel_span_limits:set(Opts),
+    otel_span_limits:set(maps:from_list(Opts)),
 
     SpanLimits = otel_span_limits:get(),
 

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -29,8 +29,8 @@
 -record(state, {meter :: meter(),
                 deny_list :: [atom() | {atom(), string()}]}).
 
-init(Opts) ->
-    DenyList = proplists:get_value(deny_list, Opts, []),
+init(_Opts) ->
+    DenyList = application:get_env(opentelemetry_experimental, deny_list, []),
 
     Meter = #meter{module=otel_meter_default},
     opentelemetry_experimental:set_default_meter({otel_meter_default, Meter}),

--- a/apps/opentelemetry_experimental/src/otel_metric_exporter.erl
+++ b/apps/opentelemetry_experimental/src/otel_metric_exporter.erl
@@ -39,7 +39,7 @@ export(Records) ->
     erlang:apply(Module, export, [Records | Args]).
 
 init(Opts) ->
-    Exporter = proplists:get_value(metric_exporter, Opts, {otel_metric_exporter_stdout, []}),
+    Exporter = maps:get(metric_exporter, Opts, {otel_metric_exporter_stdout, []}),
     {ok, #state{exporter=Exporter}}.
 
 handle_call(exporter, _From, State=#state{exporter=Exporter}) ->

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -288,8 +288,13 @@ merge_with_environment(Opts) ->
     %% available to read configuration from.
     application:load(opentelemetry_exporter),
 
+    Config = #{otlp_endpoint => undefined,
+               otlp_traces_endpoint => undefined,
+               otlp_headers => undefined,
+               otlp_traces_headers => undefined},
+
     AppEnv = application:get_all_env(opentelemetry_exporter),
-    AppOpts = otel_configuration:merge_list_with_environment(config_mapping(), AppEnv),
+    AppOpts = otel_configuration:merge_list_with_environment(config_mapping(), AppEnv, Config),
 
     %% append the default path `/v1/traces` only to the path of otlp_endpoint
     Opts1 = update_opts(otlp_endpoint, endpoints, ?DEFAULT_ENDPOINTS, AppOpts, Opts, fun endpoints_append_path/1),
@@ -332,9 +337,10 @@ update_opts(AppKey, OptKey, Default, AppOpts, Opts) ->
     update_opts(AppKey, OptKey, Default, AppOpts, Opts, fun id/1).
 
 update_opts(AppKey, OptKey, Default, AppOpts, Opts, Transform) ->
-    case proplists:get_value(AppKey, AppOpts) of
+    case maps:get(AppKey, AppOpts) of
         undefined ->
-            maps:update_with(OptKey, Transform, Transform(Default), Opts);
+            %% use default unless already set, in which case just transform
+            maps:update_with(OptKey, Transform, Default, Opts);
         EnvValue ->
             maps:put(OptKey, Transform(EnvValue), Opts)
     end.
@@ -345,13 +351,13 @@ id(X) ->
 config_mapping() ->
     [
      %% endpoint the Otel protocol exporter should connect to
-     {"OTEL_EXPORTER_OTLP_ENDPOINT", otlp_endpoint, undefined, url},
-     {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", otlp_traces_endpoint, undefined, url},
+     {"OTEL_EXPORTER_OTLP_ENDPOINT", otlp_endpoint, url},
+     {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", otlp_traces_endpoint, url},
      %% {"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", otlp_metrics_endpoint, "https://localhost:4317", url},
 
      %% headers to include in requests the exporter makes over the Otel protocol
-     {"OTEL_EXPORTER_OTLP_HEADERS", otlp_headers, undefined, key_value_list},
-     {"OTEL_EXPORTER_OTLP_TRACES_HEADERS", otlp_traces_headers, undefined, key_value_list}
+     {"OTEL_EXPORTER_OTLP_HEADERS", otlp_headers, key_value_list},
+     {"OTEL_EXPORTER_OTLP_TRACES_HEADERS", otlp_traces_headers, key_value_list}
      %% {"OTEL_EXPORTER_OTLP_METRICS_HEADERS", otlp_metrics_headers, "", key_value_list}
 
      %% the following are not yet defined in the spec


### PR DESCRIPTION
For span limits this only has the record and sets it to a persistent term through the application environment or OS environment configuration.

Once I realized I wanted to improve the configuration I stopped at that point to open a PR and then will follow it up with one that actually utilizes the span limits.

Two main issues were resolved with the configuration updates here: first, it will now fall back to the default value if transforming the user supplied value fails, and second, application environment configuration values are transformed as well, so setting a string for a limit in the application environment will fallback to the default as well.