### PR TITLE
Support for Schema URLs on the Resource and Tracer (Instrumentation Library)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   information of a Tracer. For more information about Schema URLs see the
   specification for [Resources](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/resource/sdk.md)
   and [getting a Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/api.md).
-     
+- `OTEL_CREATE_APPLICATION_TRACERS` is a new environment variable,
+  `create_application_tracers` is the application environment key, for disabling
+  the automatic creation of Tracers for every Application at boot. The old keys,
+  `OTEL_REGISTER_LOADED_APPLICATIONS` and `register_loaded_applications`, will
+  continue to work as well.
+
 ### Removed
 
 - The `sampler` option to `start_span` and `with_span` was removed.
+- `register_tracer` has been removed and now `get_tracer` will cache the Tracer
+  after creation if needed.
 
 ## [API 1.0.0-rc.3.2] - 2021-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `OTEL_SPAN_LINK_COUNT_LIMIT`: Limit number of Links on a Span.
   - `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`: Limit on number of Attributes on an Event.
   - `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT`: Limit on number of Attributes on a Link.
+- Support for a Schema URL in a Resource and in the Instrumentation Library
+  information of a Tracer. For more information about Schema URLs see the
+  specification for [Resources](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/resource/sdk.md)
+  and [getting a Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/api.md).
      
 ### Removed
 

--- a/apps/opentelemetry/include/otel_resource.hrl
+++ b/apps/opentelemetry/include/otel_resource.hrl
@@ -1,3 +1,6 @@
+%% The schema url for telemetry resources
+-define(SCHEMA_URL, <<"https://opentelemetry.io/schemas/1.8.0">>).
+
 %% if any `service' attribute is defined then
 %% `service.name' and `service.instance.id' are required
 

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -38,7 +38,7 @@ start(_StartType, _StartArgs) ->
     %% must be done after the supervisor starts so that otel_tracer_server is running
     %% TODO: make this work with release upgrades. Currently if an application's version
     %% changes the version in the tracer will not be updated.
-    register_loaded_application_tracers(Config),
+    create_loaded_application_tracers(Config),
 
     SupResult.
 
@@ -59,10 +59,10 @@ setup_text_map_propagators(#{text_map_propagators := List}) ->
     CompositePropagator = otel_propagator_text_map_composite:create(List),
     opentelemetry:set_text_map_propagator(CompositePropagator).
 
-register_loaded_application_tracers(#{register_loaded_applications := true}) ->
+create_loaded_application_tracers(#{create_application_tracers := true}) ->
     %% TODO: filter out OTP apps that will not have any instrumentation
     LoadedApplications = application:loaded_applications(),
-    opentelemetry:register_applications(LoadedApplications),
+    opentelemetry:create_application_tracers(LoadedApplications),
     ok;
-register_loaded_application_tracers(_) ->
+create_loaded_application_tracers(_) ->
     ok.

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -371,7 +371,7 @@ transform(sampler, {"parentbased_traceidratio", Probability}) ->
 transform(sampler, Value) ->
     Value;
 transform(key_value_list, Value) when is_list(Value) ->
-    case io_lib:printable_list(Value) of
+    case io_lib:printable_unicode_list(Value) of
         true ->
             Pairs = string:split(Value, ",", all),
             lists:filtermap(fun(Pair) ->

--- a/apps/opentelemetry/src/otel_resource.erl
+++ b/apps/opentelemetry/src/otel_resource.erl
@@ -19,23 +19,33 @@
 -module(otel_resource).
 
 -export([create/1,
+         create/2,
          merge/2,
+         schema_url/1,
          attributes/1]).
 
--type key() :: unicode:latin1_chardata().
--type value() :: unicode:latin1_chardata() | integer() | float() | boolean().
--type resource() :: {otel_resource, otel_attributes:t()}.
--opaque t() :: resource().
+-include("otel_resource.hrl").
 
--export_type([t/0]).
+-type key() :: unicode:latin1_binary().
+%% values allowed in attributes of a resource are limited
+-type value() :: unicode:latin1_binary() | integer() | float() | boolean().
+-type schema_url() :: uri_string:uri_string().
 
 -define(MAX_LENGTH, 255).
 
-%% verifies each key and value and drops any that don't pass verification
+-record(resource, {schema_url :: schema_url() | undefined,
+                   attributes :: otel_attributes:t()}).
+-type t() :: #resource{}.
+
 -spec create(#{key() => value()} | [{key(), value()}]) -> t().
-create(Map) when is_map(Map) ->
-    create(maps:to_list(Map));
-create(List) when is_list(List) ->
+create(Attributes) ->
+    create(Attributes, undefined).
+
+%% verifies each key and value and drops any that don't pass verification
+-spec create(#{key() => value()} | [{key(), value()}], schema_url()) -> t().
+create(Map, SchemaUrl) when is_map(Map) ->
+    create(maps:to_list(Map), SchemaUrl);
+create(List, SchemaUrl) when is_list(List) ->
     List1 = lists:filtermap(fun({K, V}) ->
                                     %% TODO: log an info or debug message when dropping?
                                     case check_key(K) andalso check_value(V) of
@@ -45,19 +55,42 @@ create(List) when is_list(List) ->
                                             false
                                     end
                             end, lists:ukeysort(1, List)),
-    {otel_resource, otel_attributes:new(List1, 128, 255)}.
+    #resource{schema_url=SchemaUrl,
+              attributes=otel_attributes:new(List1, 128, 255)}.
+
+-spec schema_url(t()) -> schema_url() | undefined.
+schema_url(#resource{schema_url=Schema}) ->
+    Schema.
 
 -spec attributes(t()) -> otel_attributes:t().
-attributes({otel_resource, Attributes}) ->
+attributes(#resource{attributes=Attributes}) ->
     Attributes.
 
-%% In case of collision the updating, first argument, resource takes precedence.
+%% in case of collision the updating, first argument, resource takes precedence.
 -spec merge(t(), t()) -> t().
-merge({otel_resource, NewAttributes}, {otel_resource, CurrentAttributes}) ->
+merge(#resource{schema_url=NewSchemaUrl,
+                attributes=NewAttributes}, Current=#resource{schema_url=CurrentSchemaUrl,
+                                                             attributes=CurrentAttributes}) ->
+    SchameUrl = merge_schema_url(NewSchemaUrl, CurrentSchemaUrl),
     NewMap = otel_attributes:map(NewAttributes),
-    {otel_resource, otel_attributes:set(NewMap, CurrentAttributes)}.
+    Current#resource{schema_url=SchameUrl,
+                     attributes=otel_attributes:set(NewMap, CurrentAttributes)}.
 
 %%
+
+%% when merging resources the schemas are checked to verify they match.
+%% if they do match then the schema is set to `undefined' and the attributes are kept.
+merge_schema_url(SchemaUrl, undefined) ->
+    SchemaUrl;
+merge_schema_url(undefined, SchemaUrl) ->
+    SchemaUrl;
+merge_schema_url(NewSchemaUrl, CurrentSchemaUrl) ->
+    merge_schema_url_(uri_string:normalize(NewSchemaUrl), uri_string:normalize(CurrentSchemaUrl)).
+
+merge_schema_url_(SchemaUrl, SchemaUrl) ->
+    SchemaUrl;
+merge_schema_url_(_, _) ->
+    undefined.
 
 %% all resource strings, key or value, must be latin1 with length less than 255
 check_string(S) ->

--- a/apps/opentelemetry/src/otel_resource.erl
+++ b/apps/opentelemetry/src/otel_resource.erl
@@ -42,7 +42,7 @@ create(Attributes) ->
     create(Attributes, undefined).
 
 %% verifies each key and value and drops any that don't pass verification
--spec create(#{key() => value()} | [{key(), value()}], schema_url()) -> t().
+-spec create(#{key() => value()} | [{key(), value()}], schema_url() | undefined) -> t().
 create(Map, SchemaUrl) when is_map(Map) ->
     create(maps:to_list(Map), SchemaUrl);
 create(List, SchemaUrl) when is_list(List) ->

--- a/apps/opentelemetry/src/otel_resource_app_env.erl
+++ b/apps/opentelemetry/src/otel_resource_app_env.erl
@@ -69,7 +69,7 @@ parse_values(Key, Value) ->
 
 -spec to_string(atom() | binary() | list()) -> binary().
 to_string(K) when is_atom(K) ->
-    atom_to_binary(K);
+    atom_to_binary(K, utf8);
 to_string(K) when is_list(K) ->
     list_to_binary(K);
 to_string(K) ->

--- a/apps/opentelemetry/src/otel_resource_app_env.erl
+++ b/apps/opentelemetry/src/otel_resource_app_env.erl
@@ -50,7 +50,7 @@ parse(_) ->
 parse_values(Key, Values) when is_map(Values) ->
     parse_values(Key, maps:to_list(Values));
 parse_values(Key, Values) when is_list(Values) ->
-    case io_lib:printable_latin1_list(Values) of
+    case io_lib:printable_unicode_list(Values) of
         true ->
             [{unicode:characters_to_binary(Key), unicode:characters_to_binary(Values)}];
         false ->

--- a/apps/opentelemetry/src/otel_resource_detector.erl
+++ b/apps/opentelemetry/src/otel_resource_detector.erl
@@ -166,9 +166,9 @@ required_attributes(Resource) ->
 process_attributes() ->
     OtpVsn = otp_vsn(),
     ErtsVsn = erts_vsn(),
-    [{?PROCESS_RUNTIME_NAME, emulator()},
-     {?PROCESS_RUNTIME_VERSION, ErtsVsn},
-     {?PROCESS_RUNTIME_DESCRIPTION, runtime_description(OtpVsn, ErtsVsn)}].
+    [{?PROCESS_RUNTIME_NAME, unicode:characters_to_binary(emulator())},
+     {?PROCESS_RUNTIME_VERSION, unicode:characters_to_binary(ErtsVsn)},
+     {?PROCESS_RUNTIME_DESCRIPTION, unicode:characters_to_binary(runtime_description(OtpVsn, ErtsVsn))}].
 
 runtime_description(OtpVsn, ErtsVsn) ->
     io_lib:format("Erlang/OTP ~s erts-~s", [OtpVsn, ErtsVsn]).
@@ -185,7 +185,7 @@ emulator() ->
 prog_name() ->
     %% RELEASE_PROG is set by mix and rebar3 release scripts
     %% PROGNAME is an OS variable set by `erl' and rebar3 release scripts
-    os_or_default("RELEASE_PROG", os_or_default("PROGNAME", "erl")).
+    unicode:characters_to_binary(os_or_default("RELEASE_PROG", os_or_default("PROGNAME", <<"erl">>))).
 
 os_or_default(EnvVar, Default) ->
     case os:getenv(EnvVar) of
@@ -232,7 +232,9 @@ add_service_name(Resource, ProgName) ->
         ServiceName ->
             %% service.name resource first to override any other service.name
             %% attribute that could be set in the resource
-            otel_resource:merge(otel_resource:create([{?SERVICE_NAME, ServiceName}]), Resource)
+            ServiceNameResource = otel_resource:create([{?SERVICE_NAME,
+                                                         unicode:characters_to_binary(ServiceName)}]),
+            otel_resource:merge(ServiceNameResource, Resource)
     end.
 
 service_release_name(ProgName) ->
@@ -244,5 +246,5 @@ service_release_name(ProgName) ->
                                       _ -> [{?SERVICE_VERSION, RelVsn}]
                                   end]);
         _ ->
-            otel_resource:create([{?SERVICE_NAME, "unknown_service:" ++ ProgName}])
+            otel_resource:create([{?SERVICE_NAME, <<"unknown_service:", ProgName/binary>>}])
     end.

--- a/apps/opentelemetry/src/otel_tracer_default.erl
+++ b/apps/opentelemetry/src/otel_tracer_default.erl
@@ -20,8 +20,8 @@
 -behaviour(otel_tracer).
 
 -export([start_span/4,
-         with_span/5
-        ]).
+         with_span/5,
+         update_instrumentation_library/3]).
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include("otel_tracer.hrl").
@@ -54,3 +54,7 @@ with_span(Ctx, Tracer, SpanName, Opts, Fun) ->
         otel_ctx:detach(Ctx)
     end.
 
+update_instrumentation_library(Vsn, SchemaUrl, Tracer=#tracer{instrumentation_library=IL}) ->
+    IL1 = IL#instrumentation_library{version=unicode:characters_to_binary(Vsn),
+                                     schema_url=SchemaUrl},
+    Tracer#tracer{instrumentation_library=IL1}.

--- a/apps/opentelemetry/src/otel_tracer_default.erl
+++ b/apps/opentelemetry/src/otel_tracer_default.erl
@@ -20,8 +20,7 @@
 -behaviour(otel_tracer).
 
 -export([start_span/4,
-         with_span/5,
-         update_instrumentation_library/3]).
+         with_span/5]).
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include("otel_tracer.hrl").
@@ -53,8 +52,3 @@ with_span(Ctx, Tracer, SpanName, Opts, Fun) ->
         _ = otel_span_ets:end_span(SpanCtx),
         otel_ctx:detach(Ctx)
     end.
-
-update_instrumentation_library(Vsn, SchemaUrl, Tracer=#tracer{instrumentation_library=IL}) ->
-    IL1 = IL#instrumentation_library{version=unicode:characters_to_binary(Vsn),
-                                     schema_url=SchemaUrl},
-    Tracer#tracer{instrumentation_library=IL1}.

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -97,15 +97,15 @@ handle_call({get_tracer, InstrumentationLibrary}, _From, State=#state{shared_tra
                                                                       deny_list=_DenyList}) ->
     {reply, {Tracer#tracer.module,
              Tracer#tracer{instrumentation_library=InstrumentationLibrary}}, State};
-handle_call({register_tracer, Name, Vsn}, _From, State=#state{shared_tracer=Tracer,
-                                                              deny_list=DenyList}) ->
+handle_call({register_tracer, Name, Vsn, SchemaUrl}, _From, State=#state{shared_tracer=Tracer,
+                                                                         deny_list=DenyList}) ->
     %% TODO: support semver constraints in denylist
     case proplists:is_defined(Name, DenyList) of
         true ->
             _ = opentelemetry:set_tracer(Name, {otel_tracer_noop, []}),
             {reply, ok, State};
         false ->
-            InstrumentationLibrary = opentelemetry:instrumentation_library(Name, Vsn),
+            InstrumentationLibrary = opentelemetry:instrumentation_library(Name, Vsn, SchemaUrl),
             TracerTuple = {Tracer#tracer.module,
                            Tracer#tracer{instrumentation_library=InstrumentationLibrary}},
             _ = opentelemetry:set_tracer(Name, TracerTuple),

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -379,7 +379,7 @@ tracer_instrumentation_library(Config) ->
 
     [Span1] = assert_exported(Tid, SpanCtx1),
 
-    ?assertEqual({instrumentation_library,<<"tracer1">>,<<"1.0.0">>}, Span1#span.instrumentation_library).
+    ?assertMatch({instrumentation_library,<<"tracer1">>,<<"1.0.0">>,_}, Span1#span.instrumentation_library).
 
 %% check that ending a span results in the tracer setting the previous tracer context
 %% as the current active and not use the parent span ctx of the span being ended --

--- a/apps/opentelemetry/test/otel_resource_SUITE.erl
+++ b/apps/opentelemetry/test/otel_resource_SUITE.erl
@@ -65,7 +65,8 @@ startup_env_service_name(_Config) ->
 crash_detector(_Config) ->
     try
         application:load(opentelemetry),
-        application:set_env(opentelemetry, resource, #{<<"c">> => <<"d">>}),
+        application:set_env(opentelemetry, resource, #{<<"c">> => <<"d">>,
+                                                       "sk" => "sv"}),
         os:putenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=cttest,service.version=2.1.1"),
 
         otel_resource_detector:start_link(#{resource_detectors => [otel_resource_env_var,
@@ -77,7 +78,8 @@ crash_detector(_Config) ->
 
         ?assertMatch(#{<<"service.name">> := <<"cttest">>,
                        <<"service.version">> := <<"2.1.1">>,
-                       <<"c">> := <<"d">>}, otel_attributes:map(otel_resource:attributes(Resource))),
+                       <<"c">> := <<"d">>,
+                       <<"sk">> := <<"sv">>}, otel_attributes:map(otel_resource:attributes(Resource))),
 
         ok
     after
@@ -118,7 +120,7 @@ os_env_resource(_Config) ->
 
 app_env_resource(_Config) ->
     Attributes = #{a => [{b,[{c,d}]}], service => #{name => <<"hello">>}},
-    Expected = [{"a.b.c", d}, {"service.name", <<"hello">>}],
+    Expected = [{<<"a.b.c">>, d}, {<<"service.name">>, <<"hello">>}],
 
     %% sort because this is created from a map and need to make sure
     %% the order is always the same when we do the assertion

--- a/apps/opentelemetry_api/include/opentelemetry.hrl
+++ b/apps/opentelemetry_api/include/opentelemetry.hrl
@@ -36,8 +36,9 @@
 
 %% Holds information about the instrumentation library specified when
 %% getting a Tracer from the TracerProvider.
--record(instrumentation_library, {name    :: unicode:unicode_binary() | undefined,
-                                  version :: unicode:unicode_binary() | undefined}).
+-record(instrumentation_library, {name       :: unicode:unicode_binary() | undefined,
+                                  version    :: unicode:unicode_binary() | undefined,
+                                  schema_url :: uri_string:uri_string() | undefined}).
 
 -record(span_ctx, {
           %% 128 bit int trace id

--- a/apps/opentelemetry_api/include/otel_tracer.hrl
+++ b/apps/opentelemetry_api/include/otel_tracer.hrl
@@ -1,5 +1,5 @@
 %% macros for tracing
-%% register a tracer for an application with opentelemetry:register_application_tracer(AppName)
+%% tracers for applications are automatically created on boot
 
 -define(current_tracer, opentelemetry:get_application_tracer(?MODULE)).
 -define(current_span_ctx, otel_tracer:current_span_ctx()).

--- a/apps/opentelemetry_api/lib/open_telemetry.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry.ex
@@ -116,7 +116,9 @@ defmodule OpenTelemetry do
   @type status() :: :opentelemetry.status()
 
   defdelegate get_tracer(name), to: :opentelemetry
+  defdelegate get_tracer(name, vsn, schema_url), to: :opentelemetry
   defdelegate register_tracer(name, vsn), to: :opentelemetry
+  defdelegate register_tracer(name, vsn, schema_url), to: :opentelemetry
   defdelegate set_default_tracer(t), to: :opentelemetry
 
   # Helpers to build OpenTelemetry structured types

--- a/apps/opentelemetry_api/lib/open_telemetry.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry.ex
@@ -117,8 +117,6 @@ defmodule OpenTelemetry do
 
   defdelegate get_tracer(name), to: :opentelemetry
   defdelegate get_tracer(name, vsn, schema_url), to: :opentelemetry
-  defdelegate register_tracer(name, vsn), to: :opentelemetry
-  defdelegate register_tracer(name, vsn, schema_url), to: :opentelemetry
   defdelegate set_default_tracer(t), to: :opentelemetry
 
   # Helpers to build OpenTelemetry structured types

--- a/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/tracer.ex
@@ -6,7 +6,7 @@ defmodule OpenTelemetry.Tracer do
   a different Span to be the current Span by passing the Span's context, end a Span or run a code
   block within the context of a newly started span that is ended when the code block completes.
 
-  The macros `start_span` and `with_span` use the Tracer registered to the Application the module
+  The macros `start_span` and `with_span` use the Tracer associated with the Application the module
   is included in. These Tracers are created at boot time for each loaded Application.
 
       require OpenTelemetry.Tracer

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -391,8 +391,13 @@ link_or_false(TraceId, SpanId, Attributes, TraceState) ->
     end.
 
 instrumentation_library(Name, Vsn) ->
-    #instrumentation_library{name=name_to_binary(Name),
-                             version=vsn_to_binary(Vsn)}.
+    case name_to_binary(Name) of
+        undefined ->
+            undefined;
+        BinaryName ->
+            #instrumentation_library{name=BinaryName,
+                                     version=vsn_to_binary(Vsn)}
+    end.
 
 %% Vsn can't be an atom or anything but a list or binary
 %% so return `undefined' if it isn't a list or binary.
@@ -401,7 +406,7 @@ vsn_to_binary(Vsn) when is_list(Vsn) ->
 vsn_to_binary(Vsn) when is_binary(Vsn) ->
     Vsn;
 vsn_to_binary(_) ->
-    undefined.
+    <<>>.
 
 %% name can be atom, list or binary. But atom `undefined'
 %% must stay as `undefined' atom.

--- a/apps/opentelemetry_api/src/otel_tracer_provider.erl
+++ b/apps/opentelemetry_api/src/otel_tracer_provider.erl
@@ -21,43 +21,33 @@
 %%%-------------------------------------------------------------------------
 -module(otel_tracer_provider).
 
--export([register_tracer/2,
-         register_tracer/3,
-         get_tracer/1,
+-export([get_tracer/1,
          get_tracer/2,
+         get_tracer/3,
          resource/0,
          resource/1,
          force_flush/0,
          force_flush/1]).
 
--spec register_tracer(atom(), binary()) -> boolean().
-register_tracer(Name, Vsn) ->
-    register_tracer(?MODULE, Name, Vsn, undefined).
+-spec get_tracer(atom()) -> boolean().
+get_tracer(Name) ->
+    get_tracer(?MODULE, Name, undefined, undefined).
 
--spec register_tracer(atom(), binary(), uri_string:uri_string() | undefined) -> boolean().
-register_tracer(Name, Vsn, SchemaUrl) ->
-    register_tracer(?MODULE, Name, Vsn, SchemaUrl).
+-spec get_tracer(atom(), binary() | undefined) -> boolean().
+get_tracer(Name, Vsn) ->
+    get_tracer(?MODULE, Name, Vsn, undefined).
 
--spec register_tracer(atom() | pid(), atom(), binary(), uri_string:uri_string() | undefined) -> boolean().
-register_tracer(ServerRef, Name, Vsn, SchemaUrl) ->
+-spec get_tracer(atom(), binary() | undefined, uri_string:uri_string() | undefined) -> boolean().
+get_tracer(Name, Vsn, SchemaUrl) ->
+    get_tracer(?MODULE, Name, Vsn, SchemaUrl).
+
+-spec get_tracer(atom() | pid(), atom(), binary() | undefined, uri_string:uri_string() | undefined) -> boolean().
+get_tracer(ServerRef, Name, Vsn, SchemaUrl) ->
     try
-        gen_server:call(ServerRef, {register_tracer, Name, Vsn, SchemaUrl})
+        gen_server:call(ServerRef, {get_tracer, Name, Vsn, SchemaUrl})
     catch exit:{noproc, _} ->
-            %% ignore register_tracer because no SDK has been included and started
+            %% ignore get_tracer because no SDK has been included and started
             false
-    end.
-
--spec get_tracer(opentelemetry:instrumentation_library()) -> opentelemetry:tracer() | undefined.
-get_tracer(InstrumentationLibrary) ->
-    get_tracer(?MODULE, InstrumentationLibrary).
-
--spec get_tracer(atom() | pid(), opentelemetry:instrumentation_library()) -> opentelemetry:tracer() | undefined.
-get_tracer(ServerRef, InstrumentationLibrary) ->
-    try
-        gen_server:call(ServerRef, {get_tracer, InstrumentationLibrary})
-    catch exit:{noproc, _} ->
-            %% ignore because likely no SDK has been included and started
-            {otel_tracer_noop, []}
     end.
 
 -spec resource() -> term() | undefined.

--- a/apps/opentelemetry_api/src/otel_tracer_provider.erl
+++ b/apps/opentelemetry_api/src/otel_tracer_provider.erl
@@ -21,27 +21,26 @@
 %%%-------------------------------------------------------------------------
 -module(otel_tracer_provider).
 
--export([get_tracer/1,
-         get_tracer/2,
-         get_tracer/3,
+-export([get_tracer/3,
          resource/0,
          resource/1,
          force_flush/0,
          force_flush/1]).
 
--spec get_tracer(atom()) -> boolean().
-get_tracer(Name) ->
-    get_tracer(?MODULE, Name, undefined, undefined).
-
--spec get_tracer(atom(), binary() | undefined) -> boolean().
-get_tracer(Name, Vsn) ->
-    get_tracer(?MODULE, Name, Vsn, undefined).
-
--spec get_tracer(atom(), binary() | undefined, uri_string:uri_string() | undefined) -> boolean().
+-spec get_tracer(Name, Vsn, SchemaUrl) -> Tracer when
+      Name :: atom(),
+      Vsn :: unicode:chardata() | undefined,
+      SchemaUrl :: uri_string:uri_string() | undefined,
+      Tracer:: opentelemetry:tracer().
 get_tracer(Name, Vsn, SchemaUrl) ->
     get_tracer(?MODULE, Name, Vsn, SchemaUrl).
 
--spec get_tracer(atom() | pid(), atom(), binary() | undefined, uri_string:uri_string() | undefined) -> boolean().
+-spec get_tracer(ServerRef, Name, Vsn, SchemaUrl) -> Tracer when
+      ServerRef :: atom() | pid(),
+      Name :: atom(),
+      Vsn :: unicode:chardata() | undefined,
+      SchemaUrl :: uri_string:uri_string() | undefined,
+      Tracer:: opentelemetry:tracer().
 get_tracer(ServerRef, Name, Vsn, SchemaUrl) ->
     try
         gen_server:call(ServerRef, {get_tracer, Name, Vsn, SchemaUrl})

--- a/apps/opentelemetry_api/src/otel_tracer_provider.erl
+++ b/apps/opentelemetry_api/src/otel_tracer_provider.erl
@@ -32,12 +32,16 @@
 
 -spec register_tracer(atom(), binary()) -> boolean().
 register_tracer(Name, Vsn) ->
-    register_tracer(?MODULE, Name, Vsn).
+    register_tracer(?MODULE, Name, Vsn, undefined).
 
--spec register_tracer(atom() | pid(), atom(), binary()) -> boolean().
-register_tracer(ServerRef, Name, Vsn) ->
+-spec register_tracer(atom(), binary(), uri_string:uri_string() | undefined) -> boolean().
+register_tracer(Name, Vsn, SchemaUrl) ->
+    register_tracer(?MODULE, Name, Vsn, SchemaUrl).
+
+-spec register_tracer(atom() | pid(), atom(), binary(), uri_string:uri_string() | undefined) -> boolean().
+register_tracer(ServerRef, Name, Vsn, SchemaUrl) ->
     try
-        gen_server:call(ServerRef, {register_tracer, Name, Vsn})
+        gen_server:call(ServerRef, {register_tracer, Name, Vsn, SchemaUrl})
     catch exit:{noproc, _} ->
             %% ignore register_tracer because no SDK has been included and started
             false

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -45,7 +45,7 @@ register_meter(Name, Vsn, #state{meter=Meter,
         true ->
             opentelemetry_experimental:set_meter(Name, {otel_meter_noop, []});
         false ->
-            InstrumentationLibrary = opentelemetry:instrumentation_library(Name, Vsn),
+            InstrumentationLibrary = opentelemetry:instrumentation_library(Name, Vsn, undefined),
             opentelemetry_experimental:set_meter(Name, {Meter#meter.module,
                                                         Meter#meter{instrumentation_library=InstrumentationLibrary}})
     end.

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -369,10 +369,15 @@ config_mapping() ->
 tab_to_proto(Tab, Resource) ->
     InstrumentationLibrarySpans = to_proto_by_instrumentation_library(Tab),
     Attributes = otel_resource:attributes(Resource),
-    ResourceSpans = [#{resource => #{attributes => to_attributes(otel_attributes:map(Attributes)),
-                                     dropped_attributes_count => otel_attributes:dropped(Attributes)},
-                       instrumentation_library_spans => InstrumentationLibrarySpans}],
-    #{resource_spans => ResourceSpans}.
+    ResourceSpans = #{resource => #{attributes => to_attributes(otel_attributes:map(Attributes)),
+                                    dropped_attributes_count => otel_attributes:dropped(Attributes)},
+                      instrumentation_library_spans => InstrumentationLibrarySpans},
+    case otel_resource:schema_url(Resource) of
+        undefined ->
+            #{resource_spans => [ResourceSpans]};
+        SchemaUrl ->
+            #{resource_spans => [ResourceSpans#{schema_url => SchemaUrl}]}
+    end.
 
 to_proto_by_instrumentation_library(Tab) ->
     Key = ets:first(Tab),

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -282,9 +282,8 @@ verify_export(Config) ->
     ?assertMatch([#{instrumentation_library := undefined,
                     spans := [_, _]}], opentelemetry_exporter:to_proto_by_instrumentation_library(Tid)),
     Resource = otel_resource_env_var:get_resource([]),
-    ?assertEqual({otel_resource, otel_attributes:new([{<<"service.name">>,<<"my-test-service">>},
-                                                      {<<"service.version">>,<<"98da75ea6d38724743bf42b45565049238d86b3f">>}], 128, 255)},
-                 Resource),
+    ?assertEqual(otel_attributes:new([{<<"service.name">>,<<"my-test-service">>},
+                                      {<<"service.version">>,<<"98da75ea6d38724743bf42b45565049238d86b3f">>}], 128, 255), otel_resource:attributes(Resource)),
     ?assertMatch(ok, opentelemetry_exporter:export(Tid, Resource, State)),
 
     ok.

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -194,11 +194,11 @@ span_round_trip(_Config) ->
                                                name = <<"event-2">>,
                                                attributes = [{<<"attr-3">>, <<"value-3">>}]}], Events),
               attributes = otel_attributes:new([
-                  {<<"attr-2">>, <<"value-2">>},
-                  {<<"map-key-1">>, #{<<"map-key-1">> => 123}},
-                  {<<"proplist-key-1">>, [{proplistkey1, 456}, {<<"proplist-key-2">>, 9.345}]},
-                  {<<"tuple-key-1">>, {a, 123, [456, {1, 2}]}}
-                ], 128, 128),
+                                                {<<"attr-2">>, <<"value-2">>},
+                                                {<<"map-key-1">>, #{<<"map-key-1">> => 123}},
+                                                {<<"proplist-key-1">>, [{proplistkey1, 456}, {<<"proplist-key-2">>, 9.345}]},
+                                                {<<"tuple-key-1">>, {a, 123, [456, {1, 2}]}}
+                                               ], 128, 128),
               status = #status{code=?OTEL_STATUS_OK,
                                message = <<"">>},
               instrumentation_library = #instrumentation_library{name = <<"tracer-1">>,
@@ -279,8 +279,8 @@ verify_export(Config) ->
                                                        ], 128, 128)},
     true = ets:insert(Tid, ChildSpan),
 
-    ?assertMatch([#{instrumentation_library := undefined,
-                    spans := [_, _]}], opentelemetry_exporter:to_proto_by_instrumentation_library(Tid)),
+    ?assertMatch([#{spans := [_, _]}],
+                 opentelemetry_exporter:to_proto_by_instrumentation_library(Tid)),
     Resource = otel_resource_env_var:get_resource([]),
     ?assertEqual(otel_attributes:new([{<<"service.name">>,<<"my-test-service">>},
                                       {<<"service.version">>,<<"98da75ea6d38724743bf42b45565049238d86b3f">>}], 128, 255), otel_resource:attributes(Resource)),

--- a/test/otel_tests.exs
+++ b/test/otel_tests.exs
@@ -17,7 +17,7 @@ defmodule OtelTests do
 
   test "use Tracer to set current active Span's attributes" do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    OpenTelemetry.register_tracer(:test_tracer, "0.1.0")
+    OpenTelemetry.get_tracer(:test_tracer, "0.1.0", :undefined)
 
     Tracer.with_span "span-1" do
       Tracer.set_attribute("attr-1", "value-1")
@@ -36,7 +36,7 @@ defmodule OtelTests do
 
   test "use Tracer to start a Span as currently active with an explicit parent" do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    OpenTelemetry.register_tracer(:test_tracer, "0.1.0")
+    OpenTelemetry.get_tracer(:test_tracer, "0.1.0", :undefined)
 
     s1 = Tracer.start_span("span-1")
     ctx = Tracer.set_current_span(Ctx.new(), s1)
@@ -88,7 +88,7 @@ defmodule OtelTests do
 
   test "create child Span in Task" do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    OpenTelemetry.register_tracer(:test_tracer, "0.1.0")
+    OpenTelemetry.get_tracer(:test_tracer, "0.1.0", :undefined)
 
     # create the parent span
     parent = Tracer.start_span("parent")
@@ -133,7 +133,7 @@ defmodule OtelTests do
 
   test "create Span with Link to outer Span in Task" do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    OpenTelemetry.register_tracer(:test_tracer, "0.1.0")
+    OpenTelemetry.get_tracer(:test_tracer, "0.1.0", :undefined)
 
     parent_ctx = Ctx.new()
 


### PR DESCRIPTION
Related parts of the spec:

- https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/resource/sdk.md
- https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/api.md#get-a-tracer

The work on Resource led to converting Resource attributes to binary strings because it was too much of a pain to keep them as list strings when everything else is binary. I think the original reasoning was just that they were only latin1 strings that were small, so a charlist would be more efficient memory wise.

There is also a commit with a fix for parsing the deny list and resource detectors configuration which I can break out to another PR if anyone thinks it needs separate discussion.