### PR TITLE
Exporter boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ Approvers ([@open-telemetry/erlang-approvers](https://github.com/orgs/open-telem
 - [Tristan Sloughter](https://github.com/tsloughter), [Splunk](https://www.splunk.com/en_us/observability/apm-application-performance-monitoring.html)
 - [Bryan Naegele](https://github.com/bryannaegele), [SimpleBet](https://simplebet.io/)
 - [Greg Mefford](https://github.com/GregMefford), [STORD](https://www.stord.com/)
-- [Zach Daniel](https://github.com/zachdaniel), 
 - [Fred Hebert](https://github.com/ferd), [Honeycomb](https://www.honeycomb.io/)
 - [Łukasz Jan Niemier](https://github.com/hauleth)
 - [Iliia Khaprov](https://github.com/deadtrickster), [VMWare](https://www.vmware.com/)


### PR DESCRIPTION
In batch_processor and simple_processor the exporter:init is moved out of the
gen_statem `init`. If it fails (returns `undefined`) then the `init` will be
attempted again each time spans are to be exported.

The only issue is the warnings about failing to init the exporter
will continue to print forever if it can never initialize. We
can't simply stop trying to init if the failure is one that can
never resolve on its own because the exporter can be changed at
anytime by the user.

This is not meant to be used for retry logic and has no exp
backoff. It is only meant to deal with issues like the exporter's
deps not being started when the SDK tries to init the exporter and
it will soon successfully init because the release is in the
process of booting.