### PR TITLE
Fix exporting spans with links

### DIFF
--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -562,7 +562,7 @@ to_links([#link{trace_id=TraceId,
     to_links(Rest, [#{trace_id => <<TraceId:128>>,
                       span_id => <<SpanId:64>>,
                       trace_state => to_tracestate_string(TraceState),
-                      attributes => to_attributes(Attributes),
+                      attributes => to_attributes(otel_attributes:map(Attributes)),
                       dropped_attributes_count => 0} | Acc]);
 to_links([_ | Rest], Acc) ->
     to_links(Rest, Acc).

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -6,6 +6,7 @@
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
+-include_lib("opentelemetry_api/include/otel_tracer.hrl").
 -include_lib("opentelemetry/include/otel_span.hrl").
 
 all() ->
@@ -267,6 +268,8 @@ verify_export(Config) ->
               attributes = otel_attributes:new([{<<"attr-2">>, <<"value-2">>}], 128, 128)},
     true = ets:insert(Tid, ParentSpan),
 
+    Link1 = opentelemetry:link(?start_span(<<"linked-span">>)),
+
     ChildSpan = #span{name = <<"span-2">>,
                       trace_id = TraceId,
                       span_id = otel_id_generator:generate_span_id(),
@@ -274,7 +277,7 @@ verify_export(Config) ->
                       kind = ?SPAN_KIND_SERVER,
                       start_time = opentelemetry:timestamp(),
                       end_time = opentelemetry:timestamp(),
-                      links = otel_links:new([], 128, 128, 128),
+                      links = otel_links:new([Link1], 128, 128, 128),
                       events = otel_events:add([#event{system_time_nano=erlang:system_time(nanosecond),
                                                        name = <<"event-1">>,
                                                        attributes = otel_attributes:new([{<<"attr-1">>, <<"value-1">>}], 128, 128)},


### PR DESCRIPTION
This fixes exporting spans that include links. Previously these resulted
in this error:
```
exception error: bad map: {attributes,128,infinity,0,#{}}
```

The test is not the most sophisticated one, but it at least catches this
particular error.