### PR TITLE
update and add exporter options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [Exporter]
+
+#### Added
+
+- New `opentelemetry_exporter` application environment options:
+  - `otlp_protocol`: The transport protocol, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`.
+  - `otlp_traces_protocol`: The transport protocol to use for exporting traces, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`.
+  - `otlp_compression`: Compression type to use, supported values: `gzip`. Defaults to no compression.
+  - `otlp_traces_compression`: Compression type to use for exporting traces, supported values: `gzip`. Defaults to no compression.
+
+- New environment variable options:
+  - `OTEL_EXPORTER_OTLP_PROTOCOL`: The transport protocol to use, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`
+  - `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`: The transport protocol to use for exporting traces, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`.
+  - `OTEL_EXPORTER_OTLP_COMPRESSION`: Compression to use, supported value: gzip. Defaults to no compression.
+  - `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION`: Compression to use when exporting traces, supported value: gzip. Defaults to no compression.
+
 ## [API 1.0.0-rc.4.1] - 2021-12-28
 
 ##### Fixed

--- a/apps/opentelemetry_exporter/README.md
+++ b/apps/opentelemetry_exporter/README.md
@@ -51,12 +51,18 @@ config :opentelemetry, :processors,
 - `otlp_endpoint`: The URL to send traces and metrics to, for traces the path `v1/traces` is appended to the path in the URL.
 - `otlp_traces_endpoint`: URL to send only traces to. This takes precedence for exporting traces and the path of the URL is kept as is, no suffix is appended.
 - `otlp_headers`: List of additional headers (`[{unicode:chardata(), unicode:chardata()}]`) to add to export requests.
-- `otlp_traces_headers`: Additional headers (`[{unicode:chardata(), unicode:chardata()}]`) to add to only trace export requests.
-    
+- `otlp_traces_headers`: Additional headers (`[{unicode:chardata(),
+  unicode:chardata()}]`) to add to only trace export requests.
+- `otlp_protocol`: The transport protocol, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`.
+- `otlp_traces_protocol`: The transport protocol to use for exporting traces, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`.
+- `otlp_compression`: Compression type to use, supported values: `gzip`. Defaults to no compression.
+- `otlp_traces_compression`: Compression type to use for exporting traces, supported values: `gzip`. Defaults to no compression.
     
 ``` erlang
 {opentelemetry_exporter,
-  [{otlp_endpoint, "https://api.honeycomb.io:443"},
+  [{otlp_protocol, grpc},
+   {otlp_compression, gzip},
+   {otlp_endpoint, "https://api.honeycomb.io:443"},
    {otlp_headers, [{"x-honeycomb-dataset", "experiments"}]}]}
 ```
 
@@ -64,6 +70,8 @@ An Elixir release uses `releases.exs`:
 
 ``` elixir
 config :opentelemetry_exporter,
+  otlp_protocol: :grpc,
+  otlp_compression: :gzip,
   otlp_endpoint: "https://api.honeycomb.io:443",
   otlp_headers: [{"x-honeycomb-dataset", "experiments"}]
 ```
@@ -87,11 +95,16 @@ for more information on securing HTTP requests in Erlang.
 - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`: URL to send only traces to. This takes precedence for exporting traces and the path of the URL is kept as is, no suffix is appended.
 - `OTEL_EXPORTER_OTLP_HEADERS`: List of additional headers to add to export requests.
 - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Additional headers to add to only trace export requests.
+- `OTEL_EXPORTER_OTLP_PROTOCOL`: The transport protocol to use, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`
+- `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`: The transport protocol to use for exporting traces, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`.
+- `OTEL_EXPORTER_OTLP_COMPRESSION`: Compression to use, supported value: gzip. Defaults to no compression.
+- `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION`: Compression to use when exporting traces, supported value: gzip. Defaults to no compression.
 
 Example usage of setting the environment variables:
 ```
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://api.honeycomb.io:443
-OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_TRACES_COMPRESSION=gzip
 OTEL_EXPORTER_OTLP_TRACES_HEADERS=x-honeycomb-team=<HONEYCOMB API TOKEN>,x-honeycomb-dataset=experiments
 ```
 

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -93,9 +93,9 @@
 
 -define(DEFAULT_ENDPOINTS, [#{host => "localhost",
                               path => [],
-                              port => 4317,
-                              scheme => "https"}]).
--define(DEFAULT_PORT, 4317).
+                              port => 4318,
+                              scheme => "http"}]).
+-define(DEFAULT_PORT, 4318).
 -define(DEFAULT_TRACES_PATH, "v1/traces").
 
 -type headers() :: [{unicode:chardata(), unicode:chardata()}].

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -97,7 +97,9 @@ configuration(_Config) ->
         ?assertEqual(#{endpoints =>
                            [#{host => "localhost", path => "/v1/traces", port => 4343,
                               scheme => "http"}],
-                       headers => [{"key1", "value1"}]},
+                       headers => [{"key1", "value1"}],
+                       compression => undefined,
+                       protocol => http_protobuf},
                      opentelemetry_exporter:merge_with_environment(#{endpoints => []})),
 
         os:putenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4343/internal"),
@@ -105,7 +107,9 @@ configuration(_Config) ->
         ?assertEqual(#{endpoints =>
                            [#{host => "localhost", path => "/internal/v1/traces", port => 4343,
                               scheme => "http"}],
-                       headers => [{"key1", "value1"}]},
+                       headers => [{"key1", "value1"}],
+                       compression => undefined,
+                       protocol => http_protobuf},
                      opentelemetry_exporter:merge_with_environment(#{endpoints => []})),
 
         %% TRACES_ENDPOINT takes precedence
@@ -114,16 +118,22 @@ configuration(_Config) ->
         ?assertEqual(#{endpoints =>
                            [#{host => "localhost", path => "/traces/path", port => 5353,
                               scheme => "http"}],
-                       headers => [{"key2", "value2"}]},
+                       headers => [{"key2", "value2"}],
+                       compression => undefined,
+                       protocol => http_protobuf},
                      opentelemetry_exporter:merge_with_environment(#{endpoints => []})),
 
+        os:putenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc"),
+        ?assertMatch(#{protocol := grpc},
+                     opentelemetry_exporter:merge_with_environment(#{})),
 
         ok
     after
         os:unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
         os:unsetenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"),
         os:unsetenv("OTEL_EXPORTER_OTLP_HEADERS"),
-        os:unsetenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS")
+        os:unsetenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS"),
+        os:unsetenv("OTEL_EXPORTER_OTLP_PROTOCOL")
     end.
 
 ets_instrumentation_info(_Config) ->
@@ -228,6 +238,7 @@ verify_export(Config) ->
     os:putenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=my-test-service,service.version=98da75ea6d38724743bf42b45565049238d86b3f"),
     Protocol = ?config(protocol, Config),
     Compression = ?config(compression, Config),
+
     Port = case Protocol of
                grpc ->
                    4317;

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -77,7 +77,7 @@ configuration(_Config) ->
         ?assertMatch([#{scheme := "https", host := "localhost", port := 443, path := "/used/path"}],
                      opentelemetry_exporter:endpoints(<<"https://localhost:443/used/path">>, [])),
 
-        ?assertMatch([#{scheme := "http", host := "localhost", port := 4317, path := []}],
+        ?assertMatch([#{scheme := "http", host := "localhost", port := 4318, path := []}],
                      opentelemetry_exporter:endpoints("http://localhost", [])),
 
         ?assertMatch([], opentelemetry_exporter:endpoints("://badendpoint", [])),
@@ -243,7 +243,7 @@ verify_export(Config) ->
                grpc ->
                    4317;
                http_protobuf ->
-                   55681
+                   4318
            end,
     {ok, State} = opentelemetry_exporter:init(#{protocol => Protocol,
                                                 compression => Compression,

--- a/config/otel-collector-config.yaml
+++ b/config/otel-collector-config.yaml
@@ -5,7 +5,7 @@ receivers:
       grpc:
         endpoint: "0.0.0.0:4317"
       http:
-        endpoint: "0.0.0.0:55681"
+        endpoint: "0.0.0.0:4318"
 processors:
   batch:
     send_batch_size: 1024

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     command: ["--config=/conf/otel-collector-config.yaml"]
     privileged: true
     ports:
-      - 55681:55681
       - 4317:4317
+      - 4318:4318
     volumes:
       - ./config/otel-collector-config.yaml:/conf/otel-collector-config.yaml
     links:


### PR DESCRIPTION
Added a couple new environment variables for configuring the exporter, from https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options

Also updates the port for `http_protobuf` to the default used in the specification.