### PR TITLE
Only call tls_certificate_check when no explicit ssl_options provided

### DIFF
--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -278,15 +278,14 @@ parse_endpoint({Scheme, Host, Port, _}, DefaultSSLOpts) ->
              port => Port,
              path => [],
              ssl_options => update_ssl_opts(HostString, DefaultSSLOpts)}};
-parse_endpoint(Endpoint=#{host := Host, port := _Port, scheme := _Scheme, path := Path}, DefaultSSLOpts) ->
-    HostString = unicode:characters_to_list(Host),
-    {true, maps:merge(#{host => HostString,
+parse_endpoint(Endpoint=#{host := Host, scheme := _Scheme, path := Path, ssl_options := SSLOptions}, _DefaultSSLOpts) when is_list(SSLOptions) ->
+    {true, maps:merge(#{host => unicode:characters_to_list(Host),
                         path => unicode:characters_to_list(Path),
                         port => ?DEFAULT_PORT,
-                        ssl_options => update_ssl_opts(HostString, DefaultSSLOpts)}, Endpoint)};
+                        ssl_options => SSLOptions}, Endpoint)};
 parse_endpoint(Endpoint=#{host := Host, scheme := _Scheme, path := Path}, DefaultSSLOpts) ->
     HostString = unicode:characters_to_list(Host),
-    {true, maps:merge(#{host => unicode:characters_to_list(Host),
+    {true, maps:merge(#{host => HostString,
                         port => ?DEFAULT_PORT,
                         path => unicode:characters_to_list(Path),
                         ssl_options => update_ssl_opts(HostString, DefaultSSLOpts)}, Endpoint)};


### PR DESCRIPTION
Should fix https://github.com/open-telemetry/opentelemetry-erlang/issues/350

Tries to mimic what is done in:

https://github.com/open-telemetry/opentelemetry-erlang/blob/main/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl#L268-L273