### PR TITLE
Update documentation on configuring the exporter via a map

### DIFF
--- a/apps/opentelemetry_exporter/README.md
+++ b/apps/opentelemetry_exporter/README.md
@@ -54,19 +54,8 @@ The second element of the configuration tuple is a configuration map. It can con
 - `protocol` - one of: `http_protobuf`, `grpc` or `http_json`. Defaults to `http_protobuf`. `http_json` is not implemented yet.
 - `endpoints` - A list of endpoints to send traces to. Can take one of the forms described below. By default, exporter sends data to `http://localhost:4318`.
 - `headers` - a list of headers to send to the collector (i.e `[{<<"x-access-key">> <<"secret">>}]`). Defaults to an empty list.
-- `compression` - An atom. Setting it to `gzip` enables gzip compression.
-
-### Endpoints configuration
-
-You can pass your collector endpoints in three forms:
-
-- As a string, i.e `"https://localhost:4000"`.
-- As a map, with the following keys: `#{host => unicode:chardata(), path => unicode:chardata(), port => integer() >= 0 | undefined, scheme => unicode:chardata()}`
-- As a 4 element tuple in format `{Scheme, Host, Port, SSLOptions}`.
-
-Unless specified directly, the port is not inferred from scheme, but defaults to `4318`. If you want to use standard port 443, you need to specify it.
-
-While using `http_protobuf` protocol, currently only the first endpoint in that list is used to export traces, the rest is effectively ignored. `grpc` supports multiple endpoints.
+- `compression` - an atom. Setting it to `gzip` enables gzip compression.
+- `ssl_options` - a list of SSL options. See Erlang's [SSL docs](https://www.erlang.org/doc/man/ssl.html#TLS/DTLS%20OPTION%20DESCRIPTIONS%20-%20CLIENT) for what options are available.
 
 ### Application Environment
 

--- a/apps/opentelemetry_exporter/README.md
+++ b/apps/opentelemetry_exporter/README.md
@@ -12,14 +12,14 @@ Currently only supports the Tracer protocol using either GRPC or Protobuffers ov
 
 ### Options to Batch Processor
 
-Exporter configuration can be done as arguments to the batch processor in
-the OpenTelemetry application environment.
+Exporter configuration can be done as arguments to the batch processor in the OpenTelemetry application environment.
+
 
 For an Erlang release in `sys.config`:
 
 ``` erlang
 {opentelemetry,
-  [{processors, 
+  [{processors,
     [{otel_batch_processor,
         #{exporter => {opentelemetry_exporter, #{endpoints =>
         ["http://localhost:9090"],
@@ -31,7 +31,7 @@ The default protocol is `http_protobuf`, to override this and use grpc add
 
 ``` erlang
 {opentelemetry,
-  [{processors, 
+  [{processors,
     [{otel_batch_processor,
         #{exporter => {opentelemetry_exporter, #{protocol => grpc,
                                                  endpoints => ["http://localhost:9090"],
@@ -48,6 +48,38 @@ config :opentelemetry, :processors,
   }
 ```
 
+  [{processors,
+    [{otel_batch_processor, #{exporter => {opentelemetry_exporter, #{}}}}]}]}
+```
+
+An Elixir release uses `releases.exs` or `runtime.ex`:
+
+``` elixir
+config :opentelemetry, :processors,
+  otel_batch_processor: %{exporter: {:opentelemetry_exporter, %{}}}
+```
+
+### The configuration map
+
+The second element of the configuration tuple is a configuration map. It can contain the following keys:
+
+- `protocol` - one of: `http_protobuf`, `grpc` or `http_json`. Defaults to `http_protobuf`. `http_json` is not implemented yet.
+- `endpoints` - A list of endpoints to send traces to. Can take one of the forms described below. By default, exporter sends data to `http://localhost:4318`.
+- `headers` - a list of headers to send to the collector (i.e `[{<<"x-access-key">> <<"secret">>}])`. Defaults to an empty list.
+- `compression` - An atom. Setting it to `gzip` enables gzip compression.
+
+### Endpoints configuration
+
+You can pass your collector endpoints in three forms:
+
+- As a string, i.e `"https://localhost:4000"`.
+- As a map, with the following keys: `#{host => unicode:chardata(), path => unicode:chardata(), port => integer() >= 0 | undefined, scheme => unicode:chardata()}`
+- As a 4 element tuple in format `{Scheme, Host, Port, SSLOptions}`.
+
+Unless specified directly, the port is not inferred from scheme, but defaults to `4318`. If you want to use standard port 443, you need to specify it.
+
+Also, while the endpoints value can be a list, currently only the first endpoint in that list is used to export traces, the rest is effectively ignored.
+
 ### Application Environment
 
 Alternatively the `opentelemetry_exporter` Application can be configured itself.
@@ -62,7 +94,7 @@ Available configuration keys:
 - `otlp_traces_protocol`: The transport protocol to use for exporting traces, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`.
 - `otlp_compression`: Compression type to use, supported values: `gzip`. Defaults to no compression.
 - `otlp_traces_compression`: Compression type to use for exporting traces, supported values: `gzip`. Defaults to no compression.
-    
+
 ``` erlang
 {opentelemetry_exporter,
   [{otlp_protocol, grpc},
@@ -136,4 +168,3 @@ $ mv src/opentelemetry_proto_collector_trace_v_1_trace_service_client.erl src/op
 ```
 
 Then open `src/opentelemetry_trace_service.erl` and fix the module name.
-

--- a/apps/opentelemetry_exporter/README.md
+++ b/apps/opentelemetry_exporter/README.md
@@ -10,10 +10,9 @@ Currently only supports the Tracer protocol using either GRPC or Protobuffers ov
 
 ## Configuration
 
-### Options to Batch Processor
+### Options to span processor
 
-Exporter configuration can be done as arguments to the batch processor in the OpenTelemetry application environment.
-
+Exporter configuration can be done as arguments to the span processor (simple or batch) in the OpenTelemetry application environment.
 
 For an Erlang release in `sys.config`:
 
@@ -32,13 +31,13 @@ The default protocol is `http_protobuf`, to override this and use grpc add
 ``` erlang
 {opentelemetry,
   [{processors,
-    [{otel_batch_processor,
+    [{otel_simple_processor,
         #{exporter => {opentelemetry_exporter, #{protocol => grpc,
                                                  endpoints => ["http://localhost:9090"],
                                                  headers => [{"x-honeycomb-dataset", "experiments"}]}}}}]}]}
 ```
 
-An Elixir release uses `releases.exs`:
+In Elixir, you can use `config.exs` or `runtime.exs`:
 
 ``` elixir
 config :opentelemetry, :processors,
@@ -48,24 +47,13 @@ config :opentelemetry, :processors,
   }
 ```
 
-  [{processors,
-    [{otel_batch_processor, #{exporter => {opentelemetry_exporter, #{}}}}]}]}
-```
-
-An Elixir release uses `releases.exs` or `runtime.ex`:
-
-``` elixir
-config :opentelemetry, :processors,
-  otel_batch_processor: %{exporter: {:opentelemetry_exporter, %{}}}
-```
-
 ### The configuration map
 
 The second element of the configuration tuple is a configuration map. It can contain the following keys:
 
 - `protocol` - one of: `http_protobuf`, `grpc` or `http_json`. Defaults to `http_protobuf`. `http_json` is not implemented yet.
 - `endpoints` - A list of endpoints to send traces to. Can take one of the forms described below. By default, exporter sends data to `http://localhost:4318`.
-- `headers` - a list of headers to send to the collector (i.e `[{<<"x-access-key">> <<"secret">>}])`. Defaults to an empty list.
+- `headers` - a list of headers to send to the collector (i.e `[{<<"x-access-key">> <<"secret">>}]`). Defaults to an empty list.
 - `compression` - An atom. Setting it to `gzip` enables gzip compression.
 
 ### Endpoints configuration
@@ -78,7 +66,7 @@ You can pass your collector endpoints in three forms:
 
 Unless specified directly, the port is not inferred from scheme, but defaults to `4318`. If you want to use standard port 443, you need to specify it.
 
-Also, while the endpoints value can be a list, currently only the first endpoint in that list is used to export traces, the rest is effectively ignored.
+While using `http_protobuf` protocol, currently only the first endpoint in that list is used to export traces, the rest is effectively ignored. `grpc` supports multiple endpoints.
 
 ### Application Environment
 

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -63,6 +63,35 @@
 %%   <li>`OTEL_EXPORTER_OTLP_TRACES_COMPRESSION': Compression to use when exporting traces, supported value: gzip. Defaults to no compression.</li>
 %% </ul>
 %%
+%% You can also set these configuration values in the map passed to the
+%% opentelemetry processor configuration.
+%% <ul>
+%%   <li>`endpoints': A list of endpoints to send traces to. Can take one of the forms described below. By default, exporter sends data to `http://localhost:4318'.</li>
+%%   <li>`headers': List of additional headers to add to export requests.</li>
+%%   <li>`protocol': The transport protocol to use, supported values: `grpc' and `http_protobuf'. Defaults to `http_protobuf'.</li>
+%%   <li>`compression': Compression to use, supported value: `gzip'. Defaults to no compression.</li>
+%%   <li>`ssl_options': a list of SSL options.  See Erlang's <a href='https://www.erlang.org/doc/man/ssl.html#TLS/DTLS%20OPTION%20DESCRIPTIONS%20-%20CLIENT'>SSL docs</a> for what options are available.</li>
+%% </ul>
+%%
+%% Endpoints configuration
+%%
+%% You can pass your collector endpoints in three forms:
+%%
+%% <ul>
+%%   <li> As a string, i.e `"https://localhost:4000"'.</li>
+%%   <li> As a map, with the following keys:
+%%     <ul>
+%%       <li>`host => unicode:chardata()'</li>
+%%       <li>`path => unicode:chardata()'</li>
+%%       <li>`port => integer() >= 0 | undefined'</li>
+%%       <li>`scheme => unicode:chardata()'</li>
+%%     </ul>
+%%   </li>
+%%   <li> As a 4 element tuple in format `{Scheme, Host, Port, SSLOptions}'.</li>
+%% </ul>
+%%
+%% While using `http_protobuf' protocol, currently only the first endpoint in that list is used to export traces, the rest is effectively ignored. `grpc' supports multiple endpoints.
+%%
 %% @end
 %%%-------------------------------------------------------------------------
 -module(opentelemetry_exporter).

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -17,7 +17,7 @@
 %% environment, the OS environment or directly through a map of options
 %% passed when setting up the exporter in the batch processor.
 %%
-%% `opentelemetry_exporter' application enevironment options are:
+%% `opentelemetry_exporter' application environment options are:
 %%
 %% <ul>
 %%   <li>


### PR DESCRIPTION
- Add info on compression
- Describe all 3 ways in which an endpoint can be configured
- Add information on default port
- Add the gotcha about using only the first endpoint
- Fix a minor typo

AKA all the things that one could only learn from reading the source code.