### PR TITLE
simpler and flat configuration options

### DIFF
--- a/apps/opentelemetry/src/opentelemetry.app.src
+++ b/apps/opentelemetry/src/opentelemetry.app.src
@@ -8,21 +8,7 @@
     stdlib,
     opentelemetry_api
    ]},
-  {env, [{sampler, {parent_based, #{root => always_on}}}, % default sampler
-
-         {text_map_propagators, [trace_context, baggage]},
-
-         %% list of disabled tracers
-         {deny_list, []},
-
-         {resource_detectors, [otel_resource_env_var,
-                               otel_resource_app_env]},
-
-         %% list of span processors
-         {processors, [%% #{id => my_processor,
-                       %%   module => otel_batch_processor,
-                       %%   config => #{}}
-                        ]}]},
+  {env, []},
   {modules, []},
 
   {doc, "doc"},

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -309,15 +309,15 @@ transform(existing_atom_list, String) when is_list(String) ->
                                     false
                             end
                     end, List);
-transform(exporter, "otlp") ->
+transform(exporter, Exporter) when Exporter =:= "otlp" ; Exporter =:= otlp ->
     {opentelemetry_exporter, #{}};
-transform(exporter, "jaeger") ->
+transform(exporter, Exporter) when Exporter =:= "jaeger" ; Exporter =:= jaeger ->
     ?LOG_WARNING("configuring jaeger exporter through OTEL_TRACES_EXPORTER is not yet supported ", []),
     undefined;
-transform(exporter, "zipkin") ->
+transform(exporter, Exporter)  when Exporter =:= "zipkin" ; Exporter =:= zipkin ->
     ?LOG_WARNING("configuring zipkin exporter through OTEL_TRACES_EXPORTER is not yet supported ", []),
     undefined;
-transform(exporter, "none") ->
+transform(exporter, Exporter) when Exporter =:= "none" ; Exporter =:= none ->
     undefined;
 transform(exporter, Value={Term, _}) when is_atom(Term) ->
     Value;

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -295,6 +295,18 @@ app_env_exporter(_Config) ->
                  maps:get(traces_exporter,
                           otel_configuration:merge_with_os([{traces_exporter, {someother_exporter, #{}}}]))),
 
+    ?assertMatch({opentelemetry_exporter, #{}},
+                 maps:get(traces_exporter,
+                          otel_configuration:merge_with_os([{traces_exporter, otlp}]))),
+
+    ?assertMatch(undefined,
+                 maps:get(traces_exporter,
+                          otel_configuration:merge_with_os([{traces_exporter, jaeger}]))),
+
+    ?assertMatch(undefined,
+                 maps:get(traces_exporter,
+                          otel_configuration:merge_with_os([{traces_exporter, zipkin}]))),
+
     ok.
 
 otlp_metrics_exporter(_Config) ->


### PR DESCRIPTION
These patches are to simplify configuration, which includes better defaults for the exporter when a specific protocol is specified so the user doesn't also have to set the port for that protocol. One way to look at these changes is that it makes the otel environment variable config options into also being available to set in the application environment.

So instead of having to pass a map to `otel_batch_processor` under `processors` the user can set `bsp_max_queue_size` the same as they'd do the env var `OTEL_BSP_MAX_QUEUE_SIZE`.

These variables are converted to the form of passing a map of options to `otel_batch_processor`, so nothing breaks for anyone already configuring this way. And the more verbose configuration will always remain since it is the generalized form that works for any processor that may be written by a third party.