### PR TITLE
Build Erlang and Elixir docs for opentelemetry_api

### DIFF
--- a/apps/opentelemetry_api/docs.config
+++ b/apps/opentelemetry_api/docs.config
@@ -1,0 +1,5 @@
+{source_url, <<"https://github.com/open-telemetry/opentelemetry-erlang">>}.
+{extras, [<<"apps/opentelemetry_api/README.md">>,
+<<"apps/opentelemetry_api/LICENSE">>]}.
+{main, <<"readme">>}.
+{proglang, erlang}.

--- a/apps/opentelemetry_api/rebar.config
+++ b/apps/opentelemetry_api/rebar.config
@@ -1,2 +1,12 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
+
+{profiles,
+ [{docs, [{deps, [edown]},
+          {edoc_opts,
+           [
+            {doclet, edoc_doclet_chunks},
+            {layout, edoc_layout_chunks},
+            {preprocess, true},
+            {dir, "apps/opentelemetry_api/_build/dev/lib/opentelemetry_api/doc"},
+            {subpackages, true}]}]}]}.

--- a/docs.sh
+++ b/docs.sh
@@ -20,3 +20,12 @@ ex_doc "opentelemetry_exporter" $version "_build/default/lib/opentelemetry_expor
   --source-ref v${version} \
   --config apps/opentelemetry_exporter/docs.config $@ \
   --output "apps/opentelemetry_exporter/doc"
+
+pushd apps/opentelemetry_api
+mix deps.get
+mix compile
+popd
+ex_doc "opentelemetry_api" $version "apps/opentelemetry_api/_build/dev/lib/opentelemetry_api/ebin" \
+  --source-ref v${version} \
+  --config apps/opentelemetry_api/docs.config $@ \
+  --output "apps/opentelemetry_api/doc"


### PR DESCRIPTION
Hey, @tsloughter, this builds the ExDoc HTML docs for Erlang and Elixir modules for `opentelemtry_api`, as discussed on the EEF Slack.