### PR TITLE
fix: readme elixir release config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ def project do
   [
     releases: [
       my_instrumented_release: [
-        applications: [opentelemetry_exporter: :permanent, opentelemetry: :temporary, my_instrumented_app: :permanent]
+        applications: [opentelemetry_exporter: :permanent, opentelemetry: :temporary]
       ],
 
       ...

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ def project do
   [
     releases: [
       my_instrumented_release: [
-        applications: [:runtime_tools, :opentelemetry_exporter, {:opentelemetry, :temporary}, :my_instrumented_app]
+        applications: [opentelemetry_exporter: :permanent, opentelemetry: :temporary, my_instrumented_app: :permanent]
       ],
 
       ...


### PR DESCRIPTION
`releases.applications` must be a keyword list. If we try to generate a release with the configuration like the currently one in the README.md. 
`[:runtime_tools, :opentelemetry_exporter, {:opentelemetry, :temporary}, :my_instrumented_app]`
Then the following error will raise.

```
Generated basic_elixir app
** (ArgumentError) expected a keyword list as the second argument, got: [:runtime_tools, :opentelemetry_exporter, {:opentelemetry, :temporary}, :basic_elixir]
    (elixir 1.12.2) lib/keyword.ex:786: Keyword.merge/2
    (mix 1.12.2) lib/mix/release.ex:175: Mix.Release.find_release/2
    (mix 1.12.2) lib/mix/release.ex:77: Mix.Release.from_config!/3
    (mix 1.12.2) lib/mix/tasks/release.ex:1032: Mix.Tasks.Release.run/1
    (mix 1.12.2) lib/mix/task.ex:394: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.12.2) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```

