### PR TITLE
Bump 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### [SDK]
+## [API 1.0.2] - 2022-02-22
 
-#### Added
+### [Docs for Erlang and Elixir macros added](https://github.com/open-telemetry/opentelemetry-erlang/pull/362)
+
+## [SDK 1.0.2] - 2022-02-22
+
+### Added
 
 - [Simpler configuration of span processors](https://github.com/open-telemetry/opentelemetry-erlang/pull/357)
 
-#### Fixed
+### Fixed
 
 - Span Status: Ignore status changes that don't follow the [define precedence in
   the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/api.md#set-status)
 
-### [Zipkin Exporter]
+## [Zipkin Exporter 1.0.0] - 2022-2-22
 
-#### Fixed
+### Fixed
 
-- Attribute values that are lists are converted to strings in Zipkin tags
-- Status converted to Zipkin tags
+- [Attribute values that are lists are converted to strings in Zipkin tags](https://github.com/open-telemetry/opentelemetry-erlang/pull/363)
+- [Status converted to Zipkin tags](https://github.com/open-telemetry/opentelemetry-erlang/pull/363)
 
 ## 1.0.1 - 2022-02-03
 

--- a/apps/opentelemetry_api/src/opentelemetry_api.app.src
+++ b/apps/opentelemetry_api/src/opentelemetry_api.app.src
@@ -1,6 +1,6 @@
 {application, opentelemetry_api,
  [{description, "OpenTelemetry API"},
-  {vsn, "1.0.1"},
+  {vsn, "1.0.2"},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/opentelemetry_zipkin/docs.config
+++ b/apps/opentelemetry_zipkin/docs.config
@@ -1,0 +1,4 @@
+{source_url, <<"https://github.com/open-telemetry/opentelemetry-erlang">>}.
+{extras, [<<"apps/opentelemetry_zipkin/README.md">>, <<"apps/opentelemetry_zipkin/LICENSE">>]}.
+{main, <<"readme">>}.
+{proglang, erlang}.

--- a/apps/opentelemetry_zipkin/src/opentelemetry_zipkin.app.src
+++ b/apps/opentelemetry_zipkin/src/opentelemetry_zipkin.app.src
@@ -1,6 +1,6 @@
 {application, opentelemetry_zipkin,
  [{description, "OpenTelemetry Zipkin Exporter"},
-  {vsn, "0.5.0"},
+  {vsn, "1.0.0"},
   {registered, []},
   {applications,
    [kernel,

--- a/docs.sh
+++ b/docs.sh
@@ -9,23 +9,31 @@ set -e
 
 rebar3 compile
 rebar3 edoc
-version=1.0.1
+sdk_version=1.0.2
+api_version=1.0.2
+otlp_version=1.0.2
+zipkin_version=1.0.0
 
-ex_doc "opentelemetry" $version "_build/default/lib/opentelemetry/ebin" \
-  --source-ref v${version} \
+ex_doc "opentelemetry" $sdk_version "_build/default/lib/opentelemetry/ebin" \
+  --source-ref v${sdk_version} \
   --config apps/opentelemetry/docs.config $@ \
   --output "apps/opentelemetry/doc"
 
-ex_doc "opentelemetry_exporter" $version "_build/default/lib/opentelemetry_exporter/ebin" \
-  --source-ref v${version} \
+ex_doc "opentelemetry_exporter" $otlp_version "_build/default/lib/opentelemetry_exporter/ebin" \
+  --source-ref v${otlp_version} \
   --config apps/opentelemetry_exporter/docs.config $@ \
   --output "apps/opentelemetry_exporter/doc"
+
+ex_doc "opentelemetry_zipkin" $zipkin_version "_build/default/lib/opentelemetry_zipkin/ebin" \
+  --source-ref v${zipkin_version} \
+  --config apps/opentelemetry_zipkin/docs.config $@ \
+  --output "apps/opentelemetry_zipkin/doc"
 
 pushd apps/opentelemetry_api
 mix deps.get
 mix compile
 popd
-ex_doc "opentelemetry_api" $version "apps/opentelemetry_api/_build/dev/lib/opentelemetry_api/ebin" \
-  --source-ref v${version} \
+ex_doc "opentelemetry_api" $api_version "apps/opentelemetry_api/_build/dev/lib/opentelemetry_api/ebin" \
+  --source-ref v${api_version} \
   --config apps/opentelemetry_api/docs.config $@ \
   --output "apps/opentelemetry_api/doc"


### PR DESCRIPTION
I went with 1.0.2 because it is mainly docs improvements except for the config additions for the exporter.

Sadly zipkin exporter still has the more complicated configuration only so will need a new release of it soon to make that better, but I heard from Greg that 0.5.0 is currently broken so don't want to wait on making those improvements to make a 1.0.0 release.