### PR TITLE
ignore large proto generated files in coverage

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -34,3 +34,5 @@
 {cover_export_enabled, true}.
 {covertool, [{coverdata_files, ["ct.coverdata"]}]}.
 {cover_excl_apps, [opentelemetry_api_experimental, opentelemetry_experimental]}.
+{cover_excl_mods, [opentelemetry_exporter_trace_service_pb, opentelemetry_trace_service,
+                   opentelemetry_zipkin_pb]}.


### PR DESCRIPTION
Still trying to get the codecov total coverage to be a useful representation of the actual coverage, this should get us closer. 