### PR TITLE
Minor fix for example on otel_propragator_text_map example

### DIFF
--- a/apps/opentelemetry_api/src/otel_propagator_text_map.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_text_map.erl
@@ -36,7 +36,7 @@
 %%   hackney_headers:store(Key, Value, Headers).
 %%
 %% some_fun_calling_hackney() ->
-%%   Headers = otel_propagator_text_map:inject(:opentelemetry.get_text_map_injector(), hackney_headers:new(), fun set_header/2),
+%%   Headers = otel_propagator_text_map:inject(opentelemetry:get_text_map_injector(), hackney_headers:new(), fun set_header/2),
 %%   ...
 %% '''
 %%

--- a/apps/opentelemetry_api/src/otel_propagator_text_map.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_text_map.erl
@@ -32,11 +32,11 @@
 %% done with <a href="https://github.com/benoitc/hackney">Hackney</a> specific functions:
 %%
 %% ```
-%% set_header(Headers, Key, Value) ->
+%% set_header(Key, Value, Headers) ->
 %%   hackney_headers:store(Key, Value, Headers).
 %%
 %% some_fun_calling_hackney() ->
-%%   Headers = otel_propagator_text_map:inject(hackney_headers:new(), fun set_header/2),
+%%   Headers = otel_propagator_text_map:inject(:opentelemetry.get_text_map_injector(), hackney_headers:new(), fun set_header/2),
 %%   ...
 %% '''
 %%


### PR DESCRIPTION
Minor fix on example on documentation of `otel_propragator_text_map`, in particular:
- `otel_propagator_text_map:inject` doesn't have two argument function which argument are `(Carrier, CarrierSetFunc)`, but only have `(Propragator, Carrier)`. Change the example to use three argument `(Propragator, Carrier, CarrierSetFunc)` function.
- `CarrierSetFunc` signature is actually `(StringKey, StringValue, Carrier)`, not `(Carrier, StringKey, StringValue)`