### PR TITLE
set default endpoint path to the default path for traces /v1/traces

### DIFF
--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -114,7 +114,7 @@
 
 -define(DEFAULT_HTTP_PORT, 4318).
 -define(DEFAULT_HTTP_ENDPOINTS, [#{host => "localhost",
-                                   path => [],
+                                   path => filename:join([], ?DEFAULT_TRACES_PATH),
                                    port => ?DEFAULT_HTTP_PORT,
                                    scheme => "http"}]).
 
@@ -430,7 +430,7 @@ append_path({Scheme, Host, Port, SSLOptions}) ->
 append_path(Endpoint=#{path := Path}) ->
     Endpoint#{path => filename:join(Path, ?DEFAULT_TRACES_PATH)};
 append_path(Endpoint=#{}) ->
-    Endpoint#{path => ?DEFAULT_TRACES_PATH};
+    Endpoint#{path => filename:join([], ?DEFAULT_TRACES_PATH)};
 append_path(EndpointString) when is_list(EndpointString) orelse is_binary(EndpointString) ->
     Endpoint=#{path := Path} = uri_string:parse(EndpointString),
     Endpoint#{path => filename:join(Path, ?DEFAULT_TRACES_PATH)}.

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -50,6 +50,10 @@ end_per_group(_, _) ->
 
 configuration(_Config) ->
     try
+        ?assertMatch(#{endpoints := [#{host := "localhost", path := "/v1/traces", port := 4318,
+                                       scheme := "http"}]},
+                     opentelemetry_exporter:merge_with_environment(#{})),
+
         ?assertMatch(#{endpoints :=
                            [#{scheme := "http", host := "localhost",
                               port := 9090, path := "/v1/traces", ssl_options := []}]},


### PR DESCRIPTION
Fixes #377 

It needs to do the `filename:join` because the default path can't start with a  `/` or it won't properly append to user defined paths, but I thougth `"/" ++ ?DEFAULT_TRACES_PATH` looked stupid *shrug*