### PR TITLE
remove opentelemetry from exporter applications list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Exporter]
 
 - [Fix use of `otlp_endpoint` configuration from Elixir](https://github.com/open-telemetry/opentelemetry-erlang/pull/376)
+- [Remove the SDK application `opentelemetry` from the Exporter's runtime dependencies](https://github.com/open-telemetry/opentelemetry-erlang/pull/387)
 
 ## [API 1.0.2] - 2022-02-22
 

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.app.src
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.app.src
@@ -8,7 +8,6 @@
     inets,
     grpcbox,
     tls_certificate_check,
-    opentelemetry,
     opentelemetry_api
    ]},
   {env,[]},

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -29,22 +29,28 @@ end_per_suite(_Config) ->
 init_per_group(Group, Config) when Group =:= grpc ;
                                    Group =:= http_protobuf ->
     application:ensure_all_started(opentelemetry_exporter),
+    application:ensure_all_started(opentelemetry),
     [{protocol, Group}| Config];
 init_per_group(http_protobuf_gzip, Config) ->
     application:ensure_all_started(opentelemetry_exporter),
+    application:ensure_all_started(opentelemetry),
     [{protocol, http_protobuf}, {compression, gzip} | Config];
 init_per_group(grpc_gzip, Config) ->
     application:ensure_all_started(opentelemetry_exporter),
+    application:ensure_all_started(opentelemetry),
     [{protocol, grpc}, {compression, gzip} | Config];
 init_per_group(_, _) ->
     application:load(opentelemetry_exporter),
+    application:ensure_all_started(opentelemetry),
     ok.
 
 end_per_group(Group, _Config) when Group =:= grpc ;
                                    Group =:= http_protobuf ->
+    application:stop(opentelemetry),
     application:stop(opentelemetry_exporter),
     ok;
 end_per_group(_, _) ->
+    application:stop(opentelemetry),
     application:unload(opentelemetry_exporter),
     ok.
 


### PR DESCRIPTION
The exporter does not depend on the opentelemetry application to
be started before it, so there is no need for it to be in the
list of applications in .app.src since that is for ensuring
an application has been started in a release before it.