### PR TITLE
fix use of traces_exporter app env var for setting the exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [SDK]
+
+#### Fixed
+
+- [Setting the exporter with `traces_exporter` application environment variable
+  now properly overrides the configuration passed to the
+  processor](https://github.com/open-telemetry/opentelemetry-erlang/pull/393)
+
 ## Exporter 1.0.4 - 2022-05-06
 
 - [fix bug where port 80 is used even for https](https://github.com/open-telemetry/opentelemetry-erlang/pull/389)

--- a/apps/opentelemetry/src/otel_batch_processor.erl
+++ b/apps/opentelemetry/src/otel_batch_processor.erl
@@ -117,7 +117,7 @@ init([Args]) ->
     enable(),
 
     {ok, idle, #data{exporter=undefined,
-                     exporter_config=maps:get(exporter, Args, undefined),
+                     exporter_config=maps:get(exporter, Args, none),
                      resource = Resource,
                      handed_off_table=undefined,
                      max_queue_size=case SizeLimit of

--- a/apps/opentelemetry/src/otel_exporter.erl
+++ b/apps/opentelemetry/src/otel_exporter.erl
@@ -38,8 +38,6 @@
 
 -include_lib("kernel/include/logger.hrl").
 
-init(undefined) ->
-    undefined;
 init({ExporterModule, Config}) when is_atom(ExporterModule) ->
     try ExporterModule:init(Config) of
         {ok, ExporterState} when ExporterModule =:= opentelemetry_exporter ->
@@ -111,6 +109,8 @@ init({ExporterModule, Config}) when is_atom(ExporterModule) ->
                     undefined
             end
     end;
+init(Exporter) when Exporter =:= none ; Exporter =:= undefined ->
+    undefined;
 init(ExporterModule) when is_atom(ExporterModule) ->
     init({ExporterModule, []}).
 

--- a/apps/opentelemetry/src/otel_simple_processor.erl
+++ b/apps/opentelemetry/src/otel_simple_processor.erl
@@ -91,7 +91,7 @@ init([Args]) ->
     Resource = otel_tracer_provider:resource(),
 
     {ok, idle, #data{exporter=undefined,
-                     exporter_config=maps:get(exporter, Args, undefined),
+                     exporter_config=maps:get(exporter, Args, none),
                      resource = Resource,
                      handed_off_table=undefined,
                      exporting_timeout_ms=ExportingTimeout}, [{next_event, internal, init_exporter}]}.

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -278,18 +278,25 @@ otlp_exporter(_Config) ->
     ok.
 
 jaeger_exporter(_Config) ->
-    ?assertMatch(undefined,
+    ?assertMatch(none,
                  maps:get(traces_exporter, otel_configuration:merge_with_os([]))),
     ok.
 
 zipkin_exporter(_Config) ->
-    ?assertMatch(undefined,
+    ?assertMatch(none,
                  maps:get(traces_exporter, otel_configuration:merge_with_os([]))),
     ok.
 
 none_exporter(_Config) ->
-    ?assertMatch(undefined,
+    ?assertMatch(none,
                  maps:get(traces_exporter, otel_configuration:merge_with_os([]))),
+
+    ?assertMatch(#{processors := [{otel_simple_processor, #{exporter := none}}]},
+                 otel_configuration:merge_with_os([{span_processor, simple}])),
+
+    ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := none}}]},
+                 otel_configuration:merge_with_os([{span_processor, batch}])),
+
     ok.
 
 app_env_exporter(_Config) ->
@@ -301,11 +308,11 @@ app_env_exporter(_Config) ->
                  maps:get(traces_exporter,
                           otel_configuration:merge_with_os([{traces_exporter, otlp}]))),
 
-    ?assertMatch(undefined,
+    ?assertMatch(none,
                  maps:get(traces_exporter,
                           otel_configuration:merge_with_os([{traces_exporter, jaeger}]))),
 
-    ?assertMatch(undefined,
+    ?assertMatch(none,
                  maps:get(traces_exporter,
                           otel_configuration:merge_with_os([{traces_exporter, zipkin}]))),
 
@@ -318,7 +325,7 @@ otlp_metrics_exporter(_Config) ->
     ok.
 
 none_metrics_exporter(_Config) ->
-    ?assertMatch(undefined,
+    ?assertMatch(none,
                  maps:get(metrics_exporter, otel_configuration:merge_with_os([]))),
 
     ok.
@@ -378,14 +385,15 @@ span_processors(_Config) ->
                                                    {bsp_exporting_timeout_ms, 2},
                                                    {bsp_max_queue_size, 1}])),
 
+    ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := none}}]},
+                 otel_configuration:merge_with_os([{span_processor, batch},
+                                                   {traces_exporter, none}])),
+
     ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := {opentelemetry_exporter,#{}},
                                                            exporting_timeout_ms := 30000,
                                                            max_queue_size := 2048,
                                                            scheduled_delay_ms := 5000}}]},
-                 otel_configuration:merge_with_os([{span_processor, batch},
-                                                   {bsp_scheduled_delay_ms, undefined},
-                                                   {bsp_exporting_timeout_ms, undefined},
-                                                   {bsp_max_queue_size, undefined}])),
+                 otel_configuration:merge_with_os([{span_processor, batch}])),
 
     ?assertMatch(#{processors := [{otel_simple_processor, #{exporter := {opentelemetry_exporter,#{}},
                                                             exporting_timeout_ms := 2}}]},


### PR DESCRIPTION
The atom `none` is now used instead of `undefined` for telling the
exporter to do nothing. This was done because `undefined` is used
in `otel_configuration` to signal that a variable is not set and
to not override it in the processor's config. That lead to the
`traces_exporter` value not being used if it was set to `none` or
`undefined` by the user.