### PR TITLE
span processor config: don't override user settings with defaults

### DIFF
--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -395,6 +395,18 @@ span_processors(_Config) ->
                                                            scheduled_delay_ms := 5000}}]},
                  otel_configuration:merge_with_os([{span_processor, batch}])),
 
+    ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := {opentelemetry_exporter,
+                                                                        #{endpoints := ["https://example.com"]}},
+                                                           exporting_timeout_ms := 2,
+                                                           max_queue_size := 1,
+                                                           scheduled_delay_ms := 15000}}]},
+                 otel_configuration:merge_with_os([{processors, [{otel_batch_processor, #{exporter => {opentelemetry_exporter,#{endpoints => ["https://example.com"]}},
+                                                                                          scheduled_delay_ms => 15000,
+                                                                                          max_queue_size => 4,
+                                                                                          exporting_timeout_ms => 3}}]},
+                                                   {bsp_exporting_timeout_ms, 2},
+                                                   {bsp_max_queue_size, 1}])),
+
     ?assertMatch(#{processors := [{otel_simple_processor, #{exporter := {opentelemetry_exporter,#{}},
                                                             exporting_timeout_ms := 2}}]},
                  otel_configuration:merge_with_os([{span_processor, simple},


### PR DESCRIPTION
I really hope this is the last one of these PRs...

This time the issue was that a user setting span processor config like:

```
{opentelemetry,
  [{processors,
    [{otel_batch_processor,
        #{exporter => {opentelemetry_exporter, #{endpoints =>
        ["http://localhost:9090"],
            headers => [{"x-honeycomb-dataset", "experiments"}]}}}}]}]}
```

Was ending up with the defaults instead of the endpoints they configured. This was because the merge code wasn't taking into account whether `traces_exporter` was set by the user or came from the defaults.

This hack checks to make sure it isn't setting it with the default, unless it isn't already set.

Maybe some future refactoring can clean this up, but it is only the span processors that have to go through these hoops, so may not be worth it to refactor.