### PR TITLE
drop spans immediately if no exporter is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [Allow custom text propagator to be configured via application env](https://github.com/open-telemetry/opentelemetry-erlang/pull/408)
+- [Allow custom text propagator to be configured via application
+  env](https://github.com/open-telemetry/opentelemetry-erlang/pull/408)
+- [No longer grow export table in batch processor if no export table is
+  configured](https://github.com/open-telemetry/opentelemetry-erlang/pull/413)
 
 ### [Exporter]
 

--- a/apps/opentelemetry/src/otel_batch_processor.erl
+++ b/apps/opentelemetry/src/otel_batch_processor.erl
@@ -70,6 +70,12 @@
 
 -define(ENABLED_KEY, {?MODULE, enabled_key}).
 
+-ifdef(TEST).
+-export([current_tab_to_list/0]).
+current_tab_to_list() ->
+    ets:tab2list(?CURRENT_TABLE).
+-endif.
+
 start_link(Opts) ->
     gen_statem:start_link({local, ?MODULE}, ?MODULE, [Opts], []).
 

--- a/apps/opentelemetry/src/otel_simple_processor.erl
+++ b/apps/opentelemetry/src/otel_simple_processor.erl
@@ -99,6 +99,8 @@ init([Args]) ->
 callback_mode() ->
     state_functions.
 
+idle({call, From}, {export, _Span}, #data{exporter=undefined}) ->
+    {keep_state_and_data, [{reply, From, dropped}]};
 idle({call, From}, {export, Span}, Data) ->
     {next_state, exporting, Data, [{next_event, internal, {export, From, Span}}]};
 idle(EventType, Event, Data) ->


### PR DESCRIPTION
This change tries to balance not losing spans while an exporter is still being initialized and not bothering to insert spans into the export table if the user has configured the exporter to be none.