### PR TITLE
remove resource field from tracer record

### DIFF
--- a/apps/opentelemetry/src/otel_tracer.hrl
+++ b/apps/opentelemetry/src/otel_tracer.hrl
@@ -10,8 +10,7 @@
          on_end_processors       :: fun((opentelemetry:span()) -> boolean() | {error, term()}),
          sampler                 :: otel_sampler:t(),
          id_generator            :: otel_id_generator:t(),
-         instrumentation_scope :: otel_tracer_server:instrumentation_scope() | undefined,
-         telemetry_library       :: otel_tracer_server:telemetry_library() | undefined,
-         resource                :: otel_resource:t() | undefined
+         instrumentation_scope   :: otel_tracer_server:instrumentation_scope() | undefined,
+         telemetry_library       :: otel_tracer_server:telemetry_library() | undefined
         }).
 -type tracer() :: #tracer{}.

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -80,7 +80,6 @@ init(#{id_generator := IdGeneratorModule,
                      on_start_processors=on_start(Processors),
                      on_end_processors=on_end(Processors),
                      id_generator=IdGeneratorModule,
-                     resource=Resource,
                      telemetry_library=TelemetryLibrary},
     opentelemetry:set_default_tracer({otel_tracer_default, Tracer}),
 

--- a/apps/opentelemetry/test/otel_resource_SUITE.erl
+++ b/apps/opentelemetry/test/otel_resource_SUITE.erl
@@ -22,15 +22,11 @@ startup(_Config) ->
         os:putenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=cttest,service.version=1.1.1"),
 
         {ok, _} = application:ensure_all_started(opentelemetry),
-        {_, Tracer} = opentelemetry:get_tracer(),
         Resource = otel_tracer_provider:resource(),
         _ = application:stop(opentelemetry),
 
         ?assertMatch(#{<<"service.name">> := <<"cttest">>,
                        <<"service.version">> := <<"1.1.1">>}, otel_attributes:map(otel_resource:attributes(Resource))),
-
-       ?assertMatch(#{<<"service.name">> := <<"cttest">>,
-                      <<"service.version">> := <<"1.1.1">>}, otel_attributes:map(otel_resource:attributes(Tracer#tracer.resource))),
         ok
     after
         os:unsetenv("OTEL_RESOURCE_ATTRIBUTES"),
@@ -44,15 +40,11 @@ startup_env_service_name(_Config) ->
         os:putenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=cttest,service.version=1.1.1"),
 
         {ok, _} = application:ensure_all_started(opentelemetry),
-        {_, Tracer} = opentelemetry:get_tracer(),
         Resource = otel_tracer_provider:resource(),
         _ = application:stop(opentelemetry),
 
         ?assertMatch(#{<<"service.name">> := <<"env-service-name">>,
                        <<"service.version">> := <<"1.1.1">>}, otel_attributes:map(otel_resource:attributes(Resource))),
-
-        ?assertMatch(#{<<"service.name">> := <<"env-service-name">>,
-                       <<"service.version">> := <<"1.1.1">>}, otel_attributes:map(otel_resource:attributes(Tracer#tracer.resource))),
         ok
     after
         os:unsetenv("OTEL_SERVICE_NAME"),


### PR DESCRIPTION
The Resource is created on startup and the same for the entire
node. There is no need to carry it in the tracer record since
the processor that exports spans gets the Resource from the
tracer provider for attaching to the spans it exports.