### PR TITLE
Fix OTLP Protocol allowed values

### DIFF
--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -358,6 +358,17 @@ transform(exporter, UnknownExporter) when is_list(UnknownExporter) ->
     ?LOG_WARNING("unknown exporter ~p. falling back to default otlp", [UnknownExporter]),
     {opentelemetry_exporter, #{}};
 
+transform(otlp_protocol, Proto) when Proto =:= "grpc"; Proto =:= grpc ->
+  grpc;
+transform(otlp_protocol, Proto) when Proto =:= "http/protobuf"; Proto =:= "http_protobuf"; Proto =:= http_protobuf ->
+  http_protobuf;
+transform(otlp_protocol, Proto) when Proto =:= "http/json"; Proto =:= "http_json"; Proto =:= http_json ->
+  ?LOG_WARNING("The http/json transport protocol is not supported by the OTLP exporter, spans will not be exported.", []),
+  undefined;
+transform(otlp_protocol, Proto) ->
+  ?LOG_WARNING("unknown ~ts transport protocol, spans will not be exported.", [Proto]),
+  undefined;
+
 transform(integer_infinity, infinity) ->
     infinity;
 transform(integer_infinity, Value) ->

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -505,9 +505,9 @@ config_mapping() ->
      {"OTEL_EXPORTER_OTLP_TRACES_HEADERS", otlp_traces_headers, key_value_list},
      %% {"OTEL_EXPORTER_OTLP_METRICS_HEADERS", otlp_metrics_headers, "", key_value_list}
 
-     {"OTEL_EXPORTER_OTLP_PROTOCOL", otlp_protocol, existing_atom},
-     {"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", otlp_traces_protocol, existing_atom},
-     %% {"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", exporter_otlp_metrics_protocol, string}
+     {"OTEL_EXPORTER_OTLP_PROTOCOL", otlp_protocol, otlp_protocol},
+     {"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", otlp_traces_protocol, otlp_protocol},
+     %% {"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", exporter_otlp_metrics_protocol, otlp_protocol}
 
      {"OTEL_EXPORTER_OTLP_COMPRESSION", otlp_compression, existing_atom},
      {"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION", otlp_traces_compression, existing_atom},

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -180,6 +180,26 @@ configuration(_Config) ->
                        ssl_options => undefined},
                      opentelemetry_exporter:merge_with_environment(#{endpoints => []})),
 
+        %% test all supported protocols
+        application:unset_env(opentelemetry_exporter, otlp_protocol),
+        os:putenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc"),
+        ?assertMatch(#{protocol := grpc},
+                     opentelemetry_exporter:merge_with_environment(#{})),
+
+        %% the specification defines the value as "http/protobuf"
+        %% https://github.com/open-telemetry/opentelemetry-specification/blob/82707fd9f7b1266f1246b02ff3e00bebdee6b538/specification/protocol/exporter.md#specify-protocol
+        application:unset_env(opentelemetry_exporter, otlp_protocol),
+        os:putenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
+        ?assertMatch(#{protocol := http_protobuf},
+                     opentelemetry_exporter:merge_with_environment(#{})),
+
+        %% backwards compatible with earlier stable version that uses "http_protobuf"
+        application:unset_env(opentelemetry_exporter, otlp_protocol),
+        os:putenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http_protobuf"),
+        ?assertMatch(#{protocol := http_protobuf},
+                     opentelemetry_exporter:merge_with_environment(#{})),
+
+
         %% TRACES_ENDPOINT takes precedence
         os:putenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://localhost:5353/traces/path"),
         os:putenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "key2=value2"),


### PR DESCRIPTION
As the [specification describes][1], there are 3 possible values for ENV vars that set the OTLP protocol used by OTLP exporter:
- grpc
- http/protobuf
- http/json

The SDK implementation leans on `list_to_existing_atom` function, so our expected values are in fact `http_protobuf` instead of `http/protobuf` for example.

This is confusing for ones following the generic documentation, and also may become a problem in polyglot environments: let's say, I share the same ENV setup for a Java and Erlang application.

The fix here account for the current atom values, and strings with the same snake_case format for backwards compatibility. But also accept the standard approach.

The fix includes `http/json` as possible transform, but the exporter will still fails as that isn't supported by our impl.

[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/82707fd9f7b1266f1246b02ff3e00bebdee6b538/specification/protocol/exporter.md#specify-protocol