### PR TITLE
move readers under metrics supervisor and require registered reader

### DIFF
--- a/apps/opentelemetry/src/opentelemetry_sup.erl
+++ b/apps/opentelemetry/src/opentelemetry_sup.erl
@@ -69,7 +69,7 @@ init([Opts]) ->
                 start => {otel_span_sup, start_link, [Opts]},
                 type => supervisor,
                 restart => permanent,
-                shutdown => 5000,
+                shutdown => infinity,
                 modules => [otel_span_sup]},
 
     %% `TracerServer' *must* start before the `BatchProcessor'

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -49,6 +49,7 @@
                text_map_propagators := [atom()],
                traces_exporter := {atom(), term()} | none | undefined,
                metrics_exporter := {atom(), term()} | none | undefined,
+               readers := [#{id := atom(), module => module(), config => map()}],
                processors := list(),
                sampler := {atom(), term()},
                sweeper := #{interval => integer() | infinity,
@@ -79,6 +80,7 @@ new() ->
       text_map_propagators => [trace_context, baggage],
       traces_exporter => {opentelemetry_exporter, #{}},
       metrics_exporter => {opentelemetry_exporter, #{}},
+      readers => [],
       processors => [{otel_batch_processor, ?BATCH_PROCESSOR_DEFAULTS}],
       sampler => {parent_based, #{root => always_on}},
       sweeper => #{interval => timer:minutes(10),
@@ -296,6 +298,7 @@ config_mappings(general_sdk) ->
      {"OTEL_PROPAGATORS", text_map_propagators, propagators},
      {"OTEL_TRACES_EXPORTER", traces_exporter, exporter},
      {"OTEL_METRICS_EXPORTER", metrics_exporter, exporter},
+     {"OTEL_METRIC_READERS", readers, readers},
      {"OTEL_RESOURCE_DETECTORS", resource_detectors, existing_atom_list},
      {"OTEL_RESOURCE_DETECTOR_TIMEOUT", resource_detector_timeout, integer},
 
@@ -470,7 +473,10 @@ transform(span_processor, batch) ->
 transform(span_processor, simple) ->
     {otel_simple_processor, ?SIMPLE_PROCESSOR_DEFAULTS};
 transform(span_processor, SpanProcessor) ->
-    SpanProcessor.
+    SpanProcessor;
+transform(readers, Readers) ->
+    Readers.
+
 
 probability_string_to_float(Probability) ->
     try list_to_float(Probability) of

--- a/apps/opentelemetry_experimental/src/opentelemetry_experimental_sup.erl
+++ b/apps/opentelemetry_experimental/src/opentelemetry_experimental_sup.erl
@@ -25,7 +25,7 @@ init([Opts]) ->
     MetricSup = #{id => otel_metrics_sup,
                   start => {otel_metrics_sup, start_link, [Opts]},
                   restart => permanent,
-                  shutdown => 5000,
+                  shutdown => infinity,
                   type => supervisor,
                   modules => [otel_metrics_sup]},
 

--- a/apps/opentelemetry_experimental/src/otel_metric_exporter_pid.erl
+++ b/apps/opentelemetry_experimental/src/otel_metric_exporter_pid.erl
@@ -21,7 +21,7 @@
 -export([init/1,
          export/2,
          force_flush/0,
-         shutdown/0]).
+         shutdown/1]).
 
 -include_lib("opentelemetry_api_experimental/include/otel_metrics.hrl").
 -include("otel_view.hrl").
@@ -41,7 +41,7 @@ export(Metrics, {Tag, Pid}) ->
 force_flush() ->
     ok.
 
-shutdown() ->
+shutdown(_) ->
     ok.
 
 %%

--- a/apps/opentelemetry_experimental/src/otel_metric_reader_sup.erl
+++ b/apps/opentelemetry_experimental/src/otel_metric_reader_sup.erl
@@ -1,0 +1,56 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2022, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%-------------------------------------------------------------------------
+-module(otel_metric_reader_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/1,
+         start_child/5]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link(Opts) ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, [Opts]).
+
+start_child(SupRef, ChildId, ViewAggregationTable, MetricsTable, ReaderConfig) ->
+    supervisor:start_child(SupRef, #{id => ChildId,
+                                     start => {otel_metric_reader, start_link, [ChildId,
+                                                                                ViewAggregationTable,
+                                                                                MetricsTable,
+                                                                                ReaderConfig]},
+                                     type => worker,
+                                     restart => permanent,
+                                     shutdown => 1000}).
+
+init([Opts]) ->
+    Readers = maps:get(readers, Opts, []),
+
+    SupFlags = #{strategy => one_for_one,
+                 intensity => 5,
+                 period => 10},
+    ChildSpecs = [#{id => ChildId,
+                    start => {otel_metric_reader, start_link, [ChildId, ReaderConfig]},
+                    type => worker,
+                    restart => permanent,
+                    shutdown => 1000} || #{id := ChildId,
+                                           module := otel_metric_reader,
+                                           config := ReaderConfig} <- Readers],
+
+    {ok, {SupFlags, ChildSpecs}}.

--- a/apps/opentelemetry_experimental/src/otel_metrics_sup.erl
+++ b/apps/opentelemetry_experimental/src/otel_metrics_sup.erl
@@ -33,12 +33,21 @@ init([Opts]) ->
                  intensity => 1,
                  period => 5},
 
+    ProviderShutdownTimeout = maps:get(meter_provider_shutdown_timeout, Opts, 5000),
+
+    MetricReaderSup = #{id => otel_metric_reader_sup,
+                        start => {otel_metric_reader_sup, start_link, [Opts]},
+                        restart => permanent,
+                        shutdown => infinity,
+                        type => supervisor,
+                        modules => [otel_metric_reader_sup]},
+
     MeterServer = #{id => otel_meter_server,
                     start => {otel_meter_server, start_link, [Opts]},
                     restart => permanent,
-                    shutdown => 5000,
+                    shutdown => ProviderShutdownTimeout,
                     type => worker,
                     modules => [otel_meter_provider, otel_meter_server]},
 
-    ChildSpecs = [MeterServer],
+    ChildSpecs = [MeterServer, MetricReaderSup],
     {ok, {SupFlags, ChildSpecs}}.

--- a/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
@@ -417,7 +417,7 @@ kill_reader(Config) ->
 
     %% have to set the exporter again since it wasn't part of the original config
     %% `my_reader_id' may not be up yet so keep trying until this succeeds
-    ?UNTIL(ok =:= catch otel_metric_reader:set_exporter(my_reader_id, otel_metric_exporter_pid, self())),
+    ?UNTIL(ok =:= otel_metric_reader:set_exporter(my_reader_id, otel_metric_exporter_pid, self())),
 
     ?assertEqual(ok, otel_counter:add(Counter, 4, #{<<"c">> => <<"b">>})),
     ?assertEqual(ok, otel_counter:add(Counter, 5, #{<<"c">> => <<"b">>})),

--- a/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
@@ -50,18 +50,61 @@
          end)()).
 
 all() ->
-    [default_view, provider_test, view_creation_test, counter_add, add_readers,
-     explicit_histograms, reader_aggregations, cumulative_counter].
+    [default_view, provider_test, view_creation_test, counter_add, multiple_readers,
+     explicit_histograms, cumulative_counter, kill_reader, kill_server].
 
 init_per_suite(Config) ->
+    application:load(opentelemetry_experimental),
     Config.
 
 end_per_suite(_Config) ->
     ok.
 
-init_per_testcase(_, Config) ->
+init_per_testcase(multiple_readers, Config) ->
+    ReaderId = my_reader_id,
+    DropReaderId = drop_reader_id,
+
+    application:load(opentelemetry_experimental),
+    ok = application:set_env(opentelemetry_experimental, readers, [#{id => ReaderId,
+                                                                     module => otel_metric_reader,
+                                                                     config => #{}},
+                                                                   #{id => DropReaderId,
+                                                                     module => otel_metric_reader,
+                                                                     config => #{default_aggregation_mapping =>
+                                                                                     #{?KIND_COUNTER => otel_aggregation_drop}}}]),
+
     {ok, _} = application:ensure_all_started(opentelemetry_experimental),
-    Config.
+
+    ?assertEqual(ok, otel_metric_reader:set_exporter(ReaderId, otel_metric_exporter_pid, self())),
+    ?assertEqual(ok, otel_metric_reader:set_exporter(DropReaderId, otel_metric_exporter_pid, self())),
+
+    [{reader_id, ReaderId} | Config];
+init_per_testcase(cumulative_counter, Config) ->
+    ReaderId = my_reader_id,
+    CumulativeCounterTemporality = #{?KIND_COUNTER =>?AGGREGATION_TEMPORALITY_CUMULATIVE},
+    application:load(opentelemetry_experimental),
+    ok = application:set_env(opentelemetry_experimental, readers, [#{id => ReaderId,
+                                                                     module => otel_metric_reader,
+                                                                     config => #{default_temporality_mapping =>
+                                                               CumulativeCounterTemporality}}]),
+
+    {ok, _} = application:ensure_all_started(opentelemetry_experimental),
+
+    ?assertEqual(ok, otel_metric_reader:set_exporter(ReaderId, otel_metric_exporter_pid, self())),
+
+    [{reader_id, ReaderId} | Config];
+init_per_testcase(_, Config) ->
+    ReaderId = my_reader_id,
+    application:load(opentelemetry_experimental),
+    ok = application:set_env(opentelemetry_experimental, readers, [#{id => ReaderId,
+                                                                     module => otel_metric_reader,
+                                                                     config => #{}}]),
+
+    {ok, _} = application:ensure_all_started(opentelemetry_experimental),
+
+    ?assertEqual(ok, otel_metric_reader:set_exporter(ReaderId, otel_metric_exporter_pid, self())),
+
+    [{reader_id, ReaderId} | Config].
 
 end_per_testcase(_, _Config) ->
     ok = application:stop(opentelemetry_experimental),
@@ -88,8 +131,6 @@ default_view(_Config) ->
                              kind = counter,
                              value_type = ValueType,
                              unit = CounterUnit}, Counter),
-
-    ?assertEqual(ok, otel_meter_server:add_metric_reader(?DEFAULT_METER_PROVIDER, otel_metric_reader, #{exporter => {otel_metric_exporter_pid, self()}})),
 
     ?assertEqual(ok, otel_counter:add(Counter, 2, #{<<"c">> => <<"b">>})),
     ?assertEqual(ok, otel_counter:add(Counter, 3, #{<<"a">> => <<"b">>, <<"d">> => <<"e">>})),
@@ -123,8 +164,6 @@ provider_test(_Config) ->
                              kind = counter,
                              value_type = ValueType,
                              unit = CounterUnit}, Counter),
-
-    ?assertEqual(ok, otel_meter_server:add_metric_reader(?DEFAULT_METER_PROVIDER, otel_metric_reader, #{exporter => {otel_metric_exporter_pid, self()}})),
 
     otel_meter_server:add_view(?DEFAULT_METER_PROVIDER, #{instrument_name => a_counter}, #{aggregation => otel_aggregation_sum}),
     otel_meter_server:add_view(?DEFAULT_METER_PROVIDER, view_a, #{instrument_name => a_counter}, #{aggregation => otel_aggregation_sum}),
@@ -179,7 +218,6 @@ view_creation_test(_Config) ->
                              value_type = ValueType,
                              unit = CounterUnit}, Counter),
 
-
     ?assert(otel_meter_server:add_view(?DEFAULT_METER_PROVIDER, view_a, #{instrument_name => a_counter}, #{aggregation => otel_aggregation_sum})),
 
     View = otel_view:new(#{instrument_name => a_counter}, #{aggregation => otel_aggregation_sum}),
@@ -217,7 +255,7 @@ counter_add(_Config) ->
     ?assertMatch(ok, otel_counter:add(Counter, 3, #{})),
     ok.
 
-add_readers(_Config) ->
+multiple_readers(_Config) ->
     Meter = opentelemetry_experimental:get_meter(),
 
     CounterDesc = <<"counter description">>,
@@ -230,15 +268,6 @@ add_readers(_Config) ->
     CounterB = otel_meter:counter(Meter, b_counter, ValueType,
                                   #{description => CounterDesc,
                                     unit => CounterUnit}),
-
-    ?assertEqual(ok, otel_meter_server:add_metric_reader(?DEFAULT_METER_PROVIDER,
-                                                         otel_metric_reader,
-                                                         #{exporter => {otel_metric_exporter_pid, self()}})),
-    ?assertEqual(ok, otel_meter_server:add_metric_reader(?DEFAULT_METER_PROVIDER,
-                                                         otel_metric_reader,
-                                                         #{exporter => {otel_metric_exporter_pid, self()},
-                                                           default_aggregation_mapping =>
-                                                               #{?KIND_COUNTER => otel_aggregation_drop}})),
 
     otel_meter_server:add_view(?DEFAULT_METER_PROVIDER, #{instrument_name => a_counter}, #{aggregation => otel_aggregation_sum}),
     otel_meter_server:add_view(?DEFAULT_METER_PROVIDER, #{instrument_name => b_counter}, #{}),
@@ -283,8 +312,6 @@ explicit_histograms(_Config) ->
                              value_type = ValueType,
                              unit = HistogramUnit}, Histogram),
 
-    ?assertEqual(ok, otel_meter_server:add_metric_reader(?DEFAULT_METER_PROVIDER, otel_metric_reader, #{exporter => {otel_metric_exporter_pid, self()}})),
-
     otel_meter_server:add_view(?DEFAULT_METER_PROVIDER, #{instrument_name => a_histogram}, #{}),
 
 
@@ -314,14 +341,6 @@ explicit_histograms(_Config) ->
 
     ok.
 
-reader_aggregations(_Config) ->
-    %% ?assertEqual(ok, otel_meter_server:add_metric_reader(otel_metric_reader,
-    %%                                                      #{default_aggregation_mapping =>
-    %%                                                            #{?KIND_COUNTER => otel_aggregation_histogram_explicit,
-    %%                                                              ?KIND_OBSERVABLE_GAUGE => otel_aggregation_histogram_explicit}})),
-
-    ok.
-
 cumulative_counter(_Config) ->
     DefaultMeter = otel_meter_default,
 
@@ -344,14 +363,9 @@ cumulative_counter(_Config) ->
                              value_type = ValueType,
                              unit = CounterUnit}, Counter),
 
-    CumulativeCounterTemporality = #{?KIND_COUNTER =>?AGGREGATION_TEMPORALITY_CUMULATIVE},
-    ?assertEqual(ok, otel_meter_server:add_metric_reader(?DEFAULT_METER_PROVIDER,
-                                                         otel_metric_reader,
-                                                         #{exporter => {otel_metric_exporter_pid, self()},
-                                                           default_temporality_mapping =>
-                                                               CumulativeCounterTemporality})),
-
-    otel_meter_server:add_view(?DEFAULT_METER_PROVIDER, #{instrument_name => a_counter}, #{aggregation => otel_aggregation_sum}),
+    otel_meter_server:add_view(?DEFAULT_METER_PROVIDER,
+                               #{instrument_name => a_counter},
+                               #{aggregation => otel_aggregation_sum}),
 
     ?assertEqual(ok, otel_counter:add(Counter, 2, #{<<"c">> => <<"b">>})),
     ?assertEqual(ok, otel_counter:add(Counter, 3, #{<<"a">> => <<"b">>, <<"d">> => <<"e">>})),
@@ -368,5 +382,95 @@ cumulative_counter(_Config) ->
     otel_meter_server:force_flush(?DEFAULT_METER_PROVIDER),
 
     ?assertReceive(a_counter, <<"counter description">>, kb, [{18, #{<<"c">> => <<"b">>}}]),
+
+    ok.
+
+kill_reader(Config) ->
+    ReaderId = ?config(reader_id, Config),
+    DefaultMeter = otel_meter_default,
+
+    Meter = opentelemetry_experimental:get_meter(),
+    ?assertMatch({DefaultMeter, _}, Meter),
+
+    CounterName = z_counter,
+    CounterDesc = <<"counter description">>,
+    CounterUnit = kb,
+    ValueType = integer,
+
+    Counter = otel_meter:counter(Meter, CounterName, ValueType,
+                                 #{description => CounterDesc,
+                                   unit => CounterUnit}),
+    ?assertMatch(#instrument{meter = {DefaultMeter,_},
+                             module = DefaultMeter,
+                             name = CounterName,
+                             description = CounterDesc,
+                             kind = counter,
+                             value_type = ValueType,
+                             unit = CounterUnit}, Counter),
+
+    ?assertEqual(ok, otel_metric_reader:set_exporter(ReaderId, otel_metric_exporter_pid, self())),
+
+    ?assertEqual(ok, otel_counter:add(Counter, 2, #{<<"c">> => <<"b">>})),
+    ?assertEqual(ok, otel_counter:add(Counter, 3, #{<<"a">> => <<"b">>, <<"d">> => <<"e">>})),
+
+    erlang:exit(erlang:whereis(my_reader_id), kill),
+
+    %% have to set the exporter again since it wasn't part of the original config
+    %% `my_reader_id' may not be up yet so keep trying until this succeeds
+    ?UNTIL(ok =:= catch otel_metric_reader:set_exporter(my_reader_id, otel_metric_exporter_pid, self())),
+
+    ?assertEqual(ok, otel_counter:add(Counter, 4, #{<<"c">> => <<"b">>})),
+    ?assertEqual(ok, otel_counter:add(Counter, 5, #{<<"c">> => <<"b">>})),
+
+    otel_meter_server:force_flush(?DEFAULT_METER_PROVIDER),
+
+    ?assertReceive(z_counter, <<"counter description">>, kb, [{11, #{<<"c">> => <<"b">>}}]),
+
+    ok.
+
+kill_server(_Config) ->
+    DefaultMeter = otel_meter_default,
+
+    Meter = opentelemetry_experimental:get_meter(),
+    ?assertMatch({DefaultMeter, _}, Meter),
+
+    ACounterName = a_counter,
+    CounterName = z_counter,
+    CounterDesc = <<"counter description">>,
+    CounterUnit = kb,
+    ValueType = integer,
+
+    ACounter = otel_meter:counter(Meter, ACounterName, ValueType,
+                                  #{description => CounterDesc,
+                                    unit => CounterUnit}),
+    Counter = otel_meter:counter(Meter, CounterName, ValueType,
+                                 #{description => CounterDesc,
+                                   unit => CounterUnit}),
+    ?assertMatch(#instrument{meter = {DefaultMeter,_},
+                             module = DefaultMeter,
+                             name = CounterName,
+                             description = CounterDesc,
+                             kind = counter,
+                             value_type = ValueType,
+                             unit = CounterUnit}, Counter),
+
+    ?assertEqual(ok, otel_counter:add(ACounter, 2, #{<<"c">> => <<"b">>})),
+    ?assertEqual(ok, otel_counter:add(Counter, 3, #{<<"a">> => <<"b">>, <<"d">> => <<"e">>})),
+
+    CurrentPid = erlang:whereis(?DEFAULT_METER_PROVIDER),
+    erlang:exit(erlang:whereis(?DEFAULT_METER_PROVIDER), kill),
+
+    %% wait until process has died and born again
+    ?UNTIL(erlang:whereis(?DEFAULT_METER_PROVIDER) =/= CurrentPid),
+    ?UNTIL(erlang:whereis(?DEFAULT_METER_PROVIDER) =/= undefined),
+
+    ?assertEqual(ok, otel_counter:add(Counter, 4, #{<<"c">> => <<"b">>})),
+    ?assertEqual(ok, otel_counter:add(Counter, 5, #{<<"c">> => <<"b">>})),
+
+    otel_meter_server:force_flush(?DEFAULT_METER_PROVIDER),
+
+    %% at this time a crashed meter server will mean losing the recorded metrics up to that point
+    ?assertNotReceive(a_counter, <<"counter description">>, kb),
+    ?assertReceive(z_counter, <<"counter description">>, kb, [{9, #{<<"c">> => <<"b">>}}]),
 
     ok.

--- a/apps/opentelemetry_experimental/test/otel_test_utils.hrl
+++ b/apps/opentelemetry_experimental/test/otel_test_utils.hrl
@@ -2,10 +2,14 @@
 -define(UNTIL(X), (fun Until(I) when I =:= 10 ->
                            ct:fail("timeout: UNTIL(~s)", [??X]);
                        Until(I) ->
-                           case X of
+                           try X of
                                true ->
                                    ok;
                                false ->
+                                   timer:sleep(100),
+                                   Until(I+1)
+                           catch
+                               _:_ ->
                                    timer:sleep(100),
                                    Until(I+1)
                            end

--- a/apps/opentelemetry_experimental/test/otel_test_utils.hrl
+++ b/apps/opentelemetry_experimental/test/otel_test_utils.hrl
@@ -9,7 +9,8 @@
                                    timer:sleep(100),
                                    Until(I+1)
                            catch
-                               _:_ ->
+                               C:T:S ->
+                                   ct:pal("exception in UNTIL(~s): ~p:~p:~p", [??X, C, T, S]),
                                    timer:sleep(100),
                                    Until(I+1)
                            end


### PR DESCRIPTION
This patch moves readers under a readers supervisor instead of being
started from the metrics server. Readers must be declared in config
and provided with a unique atom name that is used for registration
of the process. This name is also used to create named ets tables
to store the view aggregation mappings and the metrics.

Use of named ets tables and registered processes means the pid and
tids don't need to be tracked but a future update may find it
better to remove the need for names.