### PR TITLE
Exporter app env SSL options

### DIFF
--- a/apps/opentelemetry_exporter/README.md
+++ b/apps/opentelemetry_exporter/README.md
@@ -57,21 +57,15 @@ endpoints used by the exporter with the Application environment variable
 `ssl_options`:
 
 ```erlang
-%% mTLS example
-SSLOptions = [{cert, "..."}, {key, "..."}] ++ tls_certificate_check:options("example.com"),
-
 {opentelemetry_exporter,
   [{otlp_endpoint, "https://example.com:4318"},
-   {ssl_options, SSLOptions}]}
+   {ssl_options, [{cert, "..."}, {key, "..."}]}]}
 ```
 
 ```elixir
-# mTLS example
-ssl_options = [cert: "...", key: "..."] ++ :tls_certificate_check.options("example.com")
-
 config :opentelemetry_exporter,
   otlp_endpoint: "https://example.com:4318",
-  ssl_options: ssl_options
+  ssl_options: [cert: "...", key: "..."]
 ```
 
 See [secure coding with

--- a/apps/opentelemetry_exporter/README.md
+++ b/apps/opentelemetry_exporter/README.md
@@ -23,6 +23,7 @@ Available configuration keys:
 - `otlp_traces_protocol`: The transport protocol to use for exporting traces, supported values: `grpc` and `http_protobuf`. Defaults to `http_protobuf`.
 - `otlp_compression`: Compression type to use, supported values: `gzip`. Defaults to no compression.
 - `otlp_traces_compression`: Compression type to use for exporting traces, supported values: `gzip`. Defaults to no compression.
+- `ssl_options`: See [below](#ssl-options).
 
 ```erlang
 {opentelemetry_exporter,
@@ -53,7 +54,25 @@ package also provides the [CA certificates from Mozilla](https://curl.se/docs/ca
 
 The user can override these options either as part of the endpoint or for all
 endpoints used by the exporter with the Application environment variable
-`ssl_options`
+`ssl_options`:
+
+```erlang
+%% mTLS example
+SSLOptions = [{cert, "..."}, {key, "..."}] ++ tls_certificate_check:options("example.com"),
+
+{opentelemetry_exporter,
+  [{otlp_endpoint, "https://example.com:4318"},
+   {ssl_options, SSLOptions}]}
+```
+
+```elixir
+# mTLS example
+ssl_options = [cert: "...", key: "..."] ++ :tls_certificate_check.options("example.com")
+
+config :opentelemetry_exporter,
+  otlp_endpoint: "https://example.com:4318",
+  ssl_options: ssl_options
+```
 
 See [secure coding with
 inets](https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/inets)

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -339,8 +339,14 @@ parse_endpoint(Endpoint=#{host := Host, scheme := Scheme, path := Path}, Default
                                 host => HostString,
                                 path => unicode:characters_to_list(Path)})};
 parse_endpoint(String, DefaultSSLOpts) when is_list(String) orelse is_binary(String) ->
-    ParsedUri = maybe_add_scheme_port(uri_string:parse(unicode:characters_to_list(String))),
-    parse_endpoint(ParsedUri, DefaultSSLOpts);
+    case uri_string:parse(unicode:characters_to_list(String)) of
+        {error, Reason, Message} ->
+            ?LOG_ERROR("error parsing endpoint URI: ~s : ~p", [Reason, Message]),
+            false;
+        ParsedUri ->
+            ParsedUri1 = maybe_add_scheme_port(ParsedUri),
+            parse_endpoint(ParsedUri1, DefaultSSLOpts)
+    end;
 parse_endpoint(_, _) ->
     false.
 
@@ -417,20 +423,28 @@ merge_with_environment(Opts) ->
     AppEnv = application:get_all_env(opentelemetry_exporter),
     AppOpts = otel_configuration:merge_list_with_environment(config_mapping(), AppEnv, Config),
 
-    %% append the default path `/v1/traces` only to the path of otlp_endpoint
-    Opts1 = update_opts(otlp_endpoint, endpoints, ?DEFAULT_HTTP_ENDPOINTS, AppOpts, Opts, fun endpoints_append_path/1),
-    Opts2 = update_opts(otlp_traces_endpoint, endpoints, ?DEFAULT_HTTP_ENDPOINTS, AppOpts, Opts1, fun maybe_to_list/1),
+    %% check for error in app env value parsing
+    case maps:get(otlp_endpoint, AppOpts) of
+        {error, Reason, Message} ->
+            ?LOG_ERROR("error parsing endpoint URI: ~s : ~p", [Reason, Message]),
+            maps:put(endpoints, [], Opts);
 
-    Opts3 = update_opts(otlp_headers, headers, [], AppOpts, Opts2),
-    Opts4 = update_opts(otlp_traces_headers, headers, [], AppOpts, Opts3),
+        _ ->
+            %% append the default path `/v1/traces` only to the path of otlp_endpoint
+            Opts1 = update_opts(otlp_endpoint, endpoints, ?DEFAULT_HTTP_ENDPOINTS, AppOpts, Opts, fun endpoints_append_path/1),
+            Opts2 = update_opts(otlp_traces_endpoint, endpoints, ?DEFAULT_HTTP_ENDPOINTS, AppOpts, Opts1, fun maybe_to_list/1),
 
-    Opts5 = update_opts(otlp_protocol, protocol, http_protobuf, AppOpts, Opts4),
-    Opts6 = update_opts(otlp_traces_protocol, protocol, http_protobuf, AppOpts, Opts5),
+            Opts3 = update_opts(otlp_headers, headers, [], AppOpts, Opts2),
+            Opts4 = update_opts(otlp_traces_headers, headers, [], AppOpts, Opts3),
 
-    Opts7 = update_opts(otlp_compression, compression, undefined, AppOpts, Opts6),
-    Opts8 = update_opts(otlp_traces_compression, compression, undefined, AppOpts, Opts7),
+            Opts5 = update_opts(otlp_protocol, protocol, http_protobuf, AppOpts, Opts4),
+            Opts6 = update_opts(otlp_traces_protocol, protocol, http_protobuf, AppOpts, Opts5),
 
-    update_opts(ssl_options, ssl_options, undefined, AppOpts, Opts8).
+            Opts7 = update_opts(otlp_compression, compression, undefined, AppOpts, Opts6),
+            Opts8 = update_opts(otlp_traces_compression, compression, undefined, AppOpts, Opts7),
+
+            update_opts(ssl_options, ssl_options, undefined, AppOpts, Opts8)
+    end.
 
 maybe_to_list(E) when is_list(E) ->
     case io_lib:printable_list(E) of

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -341,7 +341,7 @@ parse_endpoint(Endpoint=#{host := Host, scheme := Scheme, path := Path}, Default
 parse_endpoint(String, DefaultSSLOpts) when is_list(String) orelse is_binary(String) ->
     case uri_string:parse(unicode:characters_to_list(String)) of
         {error, Reason, Message} ->
-            ?LOG_ERROR("error parsing endpoint URI: ~s : ~p", [Reason, Message]),
+            ?LOG_WARNING("error parsing endpoint URI: ~s : ~p", [Reason, Message]),
             false;
         ParsedUri ->
             ParsedUri1 = maybe_add_scheme_port(ParsedUri),
@@ -426,7 +426,7 @@ merge_with_environment(Opts) ->
     %% check for error in app env value parsing
     case maps:get(otlp_endpoint, AppOpts) of
         {error, Reason, Message} ->
-            ?LOG_ERROR("error parsing endpoint URI: ~s : ~p", [Reason, Message]),
+            ?LOG_WARNING("error parsing endpoint URI: ~s : ~p", [Reason, Message]),
             maps:put(endpoints, [], Opts);
 
         _ ->

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -411,7 +411,8 @@ merge_with_environment(Opts) ->
                otlp_protocol => undefined,
                otlp_traces_protocol => undefined,
                otlp_compression => undefined,
-               otlp_traces_compression => undefined},
+               otlp_traces_compression => undefined,
+               ssl_options => undefined},
 
     AppEnv = application:get_all_env(opentelemetry_exporter),
     AppOpts = otel_configuration:merge_list_with_environment(config_mapping(), AppEnv, Config),
@@ -427,7 +428,9 @@ merge_with_environment(Opts) ->
     Opts6 = update_opts(otlp_traces_protocol, protocol, http_protobuf, AppOpts, Opts5),
 
     Opts7 = update_opts(otlp_compression, compression, undefined, AppOpts, Opts6),
-    update_opts(otlp_traces_compression, compression, undefined, AppOpts, Opts7).
+    Opts8 = update_opts(otlp_traces_compression, compression, undefined, AppOpts, Opts7),
+
+    update_opts(ssl_options, ssl_options, undefined, AppOpts, Opts8).
 
 maybe_to_list(E) when is_list(E) ->
     case io_lib:printable_list(E) of
@@ -493,7 +496,7 @@ config_mapping() ->
      %% {"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", exporter_otlp_metrics_protocol, string}
 
      {"OTEL_EXPORTER_OTLP_COMPRESSION", otlp_compression, existing_atom},
-     {"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION", otlp_traces_compression, existing_atom}
+     {"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION", otlp_traces_compression, existing_atom},
      %% {"OTEL_EXPORTER_OTLP_METRICS_COMPRESSION", otlp_metrics_compression, existing_atom}
 
      %% {"OTEL_EXPORTER_OTLP_CERTIFICATE", otlp_certificate, path},
@@ -503,6 +506,8 @@ config_mapping() ->
      %% {"OTEL_EXPORTER_OTLP_TIMEOUT", otlp_timeout, integer},
      %% {"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", otlp_traces_timeout, integer},
      %% {"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT", otlp_metrics_timeout, integer}
+
+     {"OTEL_EXPORTER_SSL_OPTIONS", ssl_options, key_value_list}
     ].
 
 tab_to_proto(Tab, Resource) ->

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -138,6 +138,9 @@ configuration(_Config) ->
                                        scheme := "http"}]},
                      opentelemetry_exporter:merge_with_environment(#{endpoints => [{http, "localhost", 9090, []}]})),
 
+        application:set_env(opentelemetry_exporter, otlp_endpoint, "\"http://withextraquotes.com:5353\""),
+        ?assertMatch(#{endpoints := []}, opentelemetry_exporter:merge_with_environment(#{})),
+
         %% test that the os env and app env give the same configuration
         application:set_env(opentelemetry_exporter, otlp_endpoint, <<"http://localhost:4317">>),
         application:set_env(opentelemetry_exporter, otlp_protocol, grpc),


### PR DESCRIPTION
* support `ssl_options` top-level application environment key
* handle URI string endpoint value parsing errors
* add example `ssl_options` config to README
* closes #417 