### PR TITLE
replace telemetry_library record with library info as resource attributes

### DIFF
--- a/apps/opentelemetry/include/otel_span.hrl
+++ b/apps/opentelemetry/include/otel_span.hrl
@@ -16,11 +16,6 @@
 %% @end
 %%%-------------------------------------------------------------------------
 
-%% The name, version and language of this OpenTelemetry library
--record(telemetry_library, {name     :: unicode:unicode_binary() | undefined,
-                            language :: unicode:unicode_binary() | undefined,
-                            version  :: unicode:unicode_binary() | undefined}).
-
 -record(span, {
           %% 128 bit int trace id
           trace_id                :: opentelemetry:trace_id() | undefined,

--- a/apps/opentelemetry/src/otel_resource_detector.erl
+++ b/apps/opentelemetry/src/otel_resource_detector.erl
@@ -162,7 +162,8 @@ default_resource_attributes(Resource) ->
     ProcessResource = otel_resource:create([{?PROCESS_EXECUTABLE_NAME, ProgName} | process_attributes()]),
     Resource1 = otel_resource:merge(ProcessResource, Resource),
     Resource2 = add_service_name(Resource1, ProgName),
-    add_service_instance(Resource2).
+    Resource3 = add_service_instance(Resource2),
+    add_telemetry_info(Resource3).
 
 process_attributes() ->
     OtpVsn = otp_vsn(),
@@ -284,3 +285,13 @@ service_release_name(ProgName) ->
         _ ->
             otel_resource:create([{?SERVICE_NAME, <<"unknown_service:", ProgName/binary>>}])
     end.
+
+add_telemetry_info(Resource) ->
+    {ok, LibraryVsn} = application:get_key(opentelemetry, vsn),
+    LibraryName = <<"opentelemetry">>,
+    LibraryLanguage = <<"erlang">>,
+    ResourceAttributes = [{?LIBRARY_NAME, LibraryName},
+                          {?LIBRARY_LANGUAGE, LibraryLanguage},
+                          {?LIBRARY_VERSION, unicode:characters_to_binary(LibraryVsn)}],
+    TelemetryInfoResource = otel_resource:create(ResourceAttributes),
+    otel_resource:merge(TelemetryInfoResource, Resource).

--- a/apps/opentelemetry/src/otel_tracer.hrl
+++ b/apps/opentelemetry/src/otel_tracer.hrl
@@ -10,7 +10,6 @@
          on_end_processors       :: fun((opentelemetry:span()) -> boolean() | {error, term()}),
          sampler                 :: otel_sampler:t(),
          id_generator            :: otel_id_generator:t(),
-         instrumentation_scope   :: otel_tracer_server:instrumentation_scope() | undefined,
-         telemetry_library       :: otel_tracer_server:telemetry_library() | undefined
+         instrumentation_scope   :: otel_tracer_server:instrumentation_scope() | undefined
         }).
 -type tracer() :: #tracer{}.

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -83,9 +83,6 @@
          views :: [otel_view:t()],
          readers :: [#reader{}],
 
-         %% the meter configuration shared between all named
-         %% meters created by this provider
-         telemetry_library :: #telemetry_library{} | undefined,
          resource :: otel_resource:t()
         }).
 
@@ -139,19 +136,11 @@ init([Name, Config]) ->
 
     opentelemetry_experimental:set_default_meter({otel_meter_default, Meter}),
 
-    {ok, LibraryVsn} = application:get_key(opentelemetry_experimental, vsn),
-    LibraryName = <<"opentelemetry">>,
-    LibraryLanguage = <<"erlang">>,
-    TelemetryLibrary = #telemetry_library{name=LibraryName,
-                                          language=LibraryLanguage,
-                                          version=list_to_binary(LibraryVsn)},
-
     Readers = add_metric_readers(Config),
 
     {ok, #state{shared_meter=Meter,
                 views=[],
                 readers=Readers,
-                telemetry_library=TelemetryLibrary,
                 resource=Resource}}.
 
 handle_call({record, Measurement}, _From, State=#state{readers=Readers,

--- a/apps/opentelemetry_experimental/src/otel_metrics.hrl
+++ b/apps/opentelemetry_experimental/src/otel_metrics.hrl
@@ -8,11 +8,6 @@
                 instrumentation_library :: otel_tracer_server:instrumentation_library() | undefined,
                 provider                :: atom()}).
 
-%% The name, version and language of this OpenTelemetry library
--record(telemetry_library, {name     :: unicode:unicode_binary() | undefined,
-                            language :: unicode:unicode_binary() | undefined,
-                            version  :: unicode:unicode_binary() | undefined}).
-
 -record(measurement,
         {
          instrument :: otel_instrument:t(),


### PR DESCRIPTION
I think this changed a while ago in the spec but never got done here.