### PR TITLE
Improvements to MeterProvider startup

### DIFF
--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -47,6 +47,8 @@
                text_map_propagators := [atom()],
                traces_exporter := {atom(), term()} | none | undefined,
                metrics_exporter := {atom(), term()} | none | undefined,
+               views := list(), %% TODO: type should be `[otel_meter_server:view_config]'
+                                %% when Metrics are moved out of the experimental app
                readers := [#{id := atom(), module => module(), config => map()}],
                processors := list(),
                sampler := {atom(), term()},
@@ -83,6 +85,7 @@ new() ->
                    text_map_propagators => [trace_context, baggage],
                    traces_exporter => {opentelemetry_exporter, #{}},
                    metrics_exporter => {opentelemetry_exporter, #{}},
+                   views => [],
                    readers => [],
                    processors => [{otel_batch_processor, ?BATCH_PROCESSOR_DEFAULTS}],
                    sampler => {parent_based, #{root => always_on}},
@@ -303,6 +306,7 @@ config_mappings(general_sdk) ->
      {"OTEL_PROPAGATORS", text_map_propagators, propagators},
      {"OTEL_TRACES_EXPORTER", traces_exporter, exporter},
      {"OTEL_METRICS_EXPORTER", metrics_exporter, exporter},
+     {"OTEL_METRIC_VIEWS", views, views},
      {"OTEL_METRIC_READERS", readers, readers},
      {"OTEL_RESOURCE_DETECTORS", resource_detectors, existing_atom_list},
      {"OTEL_RESOURCE_DETECTOR_TIMEOUT", resource_detector_timeout, integer},
@@ -491,7 +495,9 @@ transform(span_processor, simple) ->
 transform(span_processor, SpanProcessor) ->
     SpanProcessor;
 transform(readers, Readers) ->
-    Readers.
+    Readers;
+transform(views, Views) ->
+    Views.
 
 
 probability_string_to_float(Probability) ->

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -58,7 +58,8 @@
          events/1,
          status/1,
          status/2,
-         verify_and_set_term/3]).
+         verify_and_set_term/3,
+         vsn_to_binary/1]).
 
 -include("opentelemetry.hrl").
 -include_lib("kernel/include/logger.hrl").

--- a/apps/opentelemetry_api_experimental/include/otel_meter.hrl
+++ b/apps/opentelemetry_api_experimental/include/otel_meter.hrl
@@ -1,0 +1,8 @@
+-define(GLOBAL_METER_PROVIDER_NAME, global).
+-define(GLOBAL_METER_PROVIDER_REG_NAME, otel_meter_provider_global).
+
+%% macros for metrics
+%% Meters for applications are automatically created on boot
+
+-define(current_meter, opentelemetry_experimental:get_meter(?MODULE)).
+

--- a/apps/opentelemetry_api_experimental/src/opentelemetry_experimental.erl
+++ b/apps/opentelemetry_api_experimental/src/opentelemetry_experimental.erl
@@ -17,31 +17,104 @@
 %%%-------------------------------------------------------------------------
 -module(opentelemetry_experimental).
 
--export([set_meter/2,
+-export([start_meter_provider/2,
+         set_meter/2,
+         set_meter/4,
+         set_meter/5,
          set_default_meter/1,
+         set_default_meter/2,
          get_meter/0,
          get_meter/1]).
 
 -include_lib("kernel/include/logger.hrl").
+-include("otel_meter.hrl").
 
 -export_type([meter/0]).
 
 -type meter() :: {module(), term()}.
 
 -define(METER_KEY(Name), {?MODULE, meter, Name}).
+-define(METER_KEY(MeterProvider, Name), {?MODULE, MeterProvider, meter, Name}).
+-define(DEFAULT_METER_KEY(MeterProvider), ?METER_KEY(MeterProvider, '$__default_meter')).
+
+-spec start_meter_provider(atom(), map()) -> {ok, pid() | undefined} | {error, term()}.
+start_meter_provider(Name, Config) ->
+    otel_meter_provider:start(Name, Config).
 
 -spec set_default_meter(meter()) -> boolean().
 set_default_meter(Meter) ->
-    opentelemetry:verify_and_set_term(Meter, ?METER_KEY(default_meter), otel_meter).
+    set_default_meter(?GLOBAL_METER_PROVIDER_NAME, Meter).
 
--spec set_meter(atom(), meter()) -> boolean().
-set_meter(Name, Meter) ->
-    opentelemetry:verify_and_set_term(Meter, ?METER_KEY(Name), otel_meter).
+-spec set_default_meter(atom(), meter()) -> boolean().
+set_default_meter(MeterProvider, Meter) ->
+    opentelemetry:verify_and_set_term(Meter, ?DEFAULT_METER_KEY(MeterProvider), otel_meter).
 
 -spec get_meter() -> meter().
 get_meter() ->
-    persistent_term:get(?METER_KEY(default_meter), {otel_meter_noop, []}).
+    get_meter_(?GLOBAL_METER_PROVIDER_NAME).
 
--spec get_meter(atom()) -> meter().
+-spec get_meter_(atom()) -> meter().
+get_meter_(MeterProvider) ->
+    persistent_term:get(?DEFAULT_METER_KEY(MeterProvider), {otel_meter_noop, []}).
+
+-spec get_meter(Name) -> Meter when
+      Name :: atom() | {atom(), Vsn, SchemaUrl},
+      Vsn :: unicode:chardata() | undefined,
+      SchemaUrl :: uri_string:uri_string() | undefined,
+      Meter:: opentelemetry:meter().
+get_meter('$__default_meter') ->
+    get_meter();
+get_meter({Name, Vsn, SchemaUrl}) ->
+    get_meter(Name, Vsn, SchemaUrl);
 get_meter(Name) ->
-    persistent_term:get(?METER_KEY(Name), get_meter()).
+    get_meter(Name, undefined, undefined).
+
+-spec get_meter(Name, Vsn, SchemaUrl) -> Meter when
+      Name :: atom(),
+      Vsn :: unicode:chardata() | undefined,
+      SchemaUrl :: uri_string:uri_string() | undefined,
+      Meter:: opentelemetry:meter().
+get_meter(Name, Vsn, SchemaUrl) ->
+    get_meter(?GLOBAL_METER_PROVIDER_NAME, Name, Vsn, SchemaUrl).
+
+-spec get_meter(MeterProvider, Name, Vsn, SchemaUrl) -> Meter when
+      MeterProvider :: atom() | pid(),
+      Name :: atom(),
+      Vsn :: unicode:chardata() | undefined,
+      SchemaUrl :: uri_string:uri_string() | undefined,
+      Meter:: opentelemetry:meter().
+get_meter(MeterProvider, Name, Vsn, SchemaUrl) ->
+    %% check cache and then use provider to get the meter if it isn't cached yet
+    case persistent_term:get(?METER_KEY(MeterProvider, {Name, Vsn, SchemaUrl}), undefined) of
+        undefined ->
+            VsnBin = opentelemetry:vsn_to_binary(Vsn),
+            Meter = otel_meter_provider:get_meter(MeterProvider, Name, VsnBin, SchemaUrl),
+
+            %% cache the meter
+            _ = set_meter(Name, Vsn, SchemaUrl, Meter),
+
+            Meter;
+        Meter ->
+            Meter
+    end.
+
+-spec set_meter(atom(), meter()) -> boolean().
+set_meter(Name, Meter) ->
+    set_meter(Name, <<>>, undefined, Meter).
+
+-spec set_meter(Name, Vsn, SchemaUrl, Meter) -> boolean() when
+      Name :: atom(),
+      Vsn :: unicode:chardata() | undefined,
+      SchemaUrl :: uri_string:uri_string() | undefined,
+      Meter:: opentelemetry:meter().
+set_meter(Name, Vsn, SchemaUrl, Meter) ->
+    set_meter(?GLOBAL_METER_PROVIDER_NAME, Name, Vsn, SchemaUrl, Meter).
+
+-spec set_meter(MeterProvider, Name, Vsn, SchemaUrl, Meter) -> boolean() when
+      MeterProvider :: atom(),
+      Name :: atom(),
+      Vsn :: unicode:chardata() | undefined,
+      SchemaUrl :: uri_string:uri_string() | undefined,
+      Meter:: opentelemetry:meter().
+set_meter(MeterProvider, Name, Vsn, SchemaUrl, Meter) ->
+    opentelemetry:verify_and_set_term(Meter, ?METER_KEY(MeterProvider, {Name, Vsn, SchemaUrl}), otel_meter).

--- a/apps/opentelemetry_api_experimental/src/otel_meter_provider.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_meter_provider.erl
@@ -21,7 +21,8 @@
 %%%-------------------------------------------------------------------------
 -module(otel_meter_provider).
 
--export([get_meter/3,
+-export([start/2,
+         get_meter/3,
          get_meter/4,
          resource/0,
          resource/1,
@@ -29,6 +30,12 @@
          force_flush/1]).
 
 -type meter() :: term().
+
+start(Name, Config) ->
+    %% SDK must register a simple one for one supervisor of tracer providers
+    %% under the name `otel_meter_provider_sup'
+    %% {ok, _} = otel_meter_provider_sup:start_child(default, Config),
+    supervisor:start_child(otel_meter_provider_sup, [Name, Config]).
 
 -spec get_meter(Name, Vsn, SchemaUrl) -> Meter when
       Name :: atom(),

--- a/apps/opentelemetry_experimental/src/opentelemetry_experimental_app.erl
+++ b/apps/opentelemetry_experimental/src/opentelemetry_experimental_app.erl
@@ -11,13 +11,15 @@
          prep_stop/1,
          stop/1]).
 
+-include_lib("opentelemetry_api_experimental/include/otel_meter.hrl").
+
 start(_StartType, _StartArgs) ->
-    Opts = otel_configuration:merge_with_os(
-             application:get_all_env(opentelemetry_experimental)),
+    Config = otel_configuration:merge_with_os(
+               application:get_all_env(opentelemetry_experimental)),
 
-    {ok, Pid} = opentelemetry_experimental_sup:start_link(Opts),
+    {ok, Pid} = opentelemetry_experimental_sup:start_link(Config),
 
-    {ok, _} = otel_meter_provider_sup:start_child(default, Opts),
+    {ok, _} = opentelemetry_experimental:start_meter_provider(?GLOBAL_METER_PROVIDER_NAME, Config),
 
     {ok, Pid}.
 

--- a/apps/opentelemetry_experimental/src/opentelemetry_experimental_app.erl
+++ b/apps/opentelemetry_experimental/src/opentelemetry_experimental_app.erl
@@ -15,7 +15,11 @@ start(_StartType, _StartArgs) ->
     Opts = otel_configuration:merge_with_os(
              application:get_all_env(opentelemetry_experimental)),
 
-    opentelemetry_experimental_sup:start_link(Opts).
+    {ok, Pid} = opentelemetry_experimental_sup:start_link(Opts),
+
+    {ok, _} = otel_meter_provider_sup:start_child(default, Opts),
+
+    {ok, Pid}.
 
 %% called before the supervision tree is shutdown.
 prep_stop(_State) ->

--- a/apps/opentelemetry_experimental/src/opentelemetry_experimental_sup.erl
+++ b/apps/opentelemetry_experimental/src/opentelemetry_experimental_sup.erl
@@ -16,14 +16,14 @@
 start_link(Opts) ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, [Opts]).
 
-init([Opts]) ->
+init([_Opts]) ->
     SupFlags = #{strategy => one_for_one,
                  intensity => 1,
                  period => 5},
 
     %%
     MetricSup = #{id => otel_metrics_sup,
-                  start => {otel_metrics_sup, start_link, [Opts]},
+                  start => {otel_metrics_sup, start_link, []},
                   restart => permanent,
                   shutdown => infinity,
                   type => supervisor,

--- a/apps/opentelemetry_experimental/src/otel_meter_default.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_default.erl
@@ -30,8 +30,11 @@
 -include("otel_metrics.hrl").
 
 instrument(Meter, Name, Kind, ValueType, Opts) ->
-    otel_instrument:new(?MODULE, Meter, Kind, Name, maps:get(description, Opts, undefined),
-                        maps:get(unit, Opts, undefined), ValueType).
+    Instrument=#instrument{meter={_, #meter{provider=_Provider}}} =
+        otel_instrument:new(?MODULE, Meter, Kind, Name, maps:get(description, Opts, undefined),
+                            maps:get(unit, Opts, undefined), ValueType),
+    %% _ = otel_meter_server:add_instrument(Provider, Instrument),
+    Instrument.
 
 instrument(Meter, Name, Kind, ValueType, Callback, CallbackArgs, Opts) ->
     Instrument=#instrument{meter={_, #meter{provider=Provider}}} =

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -182,7 +182,7 @@ new_view(ViewConfig) ->
     Selector = maps:get(selector, ViewConfig, undefined),
     AttributeKeys = maps:get(attribute_keys, ViewConfig, undefined),
     AggregationModule = maps:get(aggregation_module, ViewConfig, undefined),
-    AggregationOptions = maps:get(aggregation_options, ViewConfig, undefined),
+    AggregationOptions = maps:get(aggregation_options, ViewConfig, #{}),
     otel_view:new(Name, Selector, #{description => Description,
                                     attribute_keys => AttributeKeys,
                                     aggregation_module => AggregationModule,

--- a/apps/opentelemetry_experimental/src/otel_meter_server_sup.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server_sup.erl
@@ -55,8 +55,7 @@ init([Name, Opts]) ->
 
     ProviderShutdownTimeout = maps:get(meter_provider_shutdown_timeout, Opts, 5000),
     MeterServer = #{id => otel_meter_server,
-                    start => {otel_meter_server, start_link, [MeterServerRegName,
-                                                              Opts]},
+                    start => {otel_meter_server, start_link, [Name, MeterServerRegName, Opts]},
                     restart => permanent,
                     shutdown => ProviderShutdownTimeout,
                     type => worker,

--- a/apps/opentelemetry_experimental/src/otel_meter_server_sup.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server_sup.erl
@@ -1,0 +1,67 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2022, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%-------------------------------------------------------------------------
+-module(otel_meter_server_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/2,
+         provider_pid/1]).
+
+-export([init/1]).
+
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
+
+start_link(Name, Opts) ->
+    supervisor:start_link(?MODULE, [Name, Opts]).
+
+-spec provider_pid(supervisor:sup_ref()) -> pid() | restarting | undefined.
+provider_pid(SupPid) ->
+    Children = supervisor:which_children(SupPid),
+    case lists:keyfind(otel_meter_server, 1, Children) of
+        {_, Child, _, _} ->
+            Child;
+        false ->
+            undefined
+    end.
+
+init([Name, Opts]) ->
+    SupFlags = #{strategy => rest_for_one, %% restart the readers if the server dies
+                 intensity => 1,
+                 period => 5},
+
+    MeterServerRegName = list_to_atom(lists:concat([otel_meter_provider, "_", Name])),
+
+    MetricReaderSup = #{id => otel_metric_reader_sup,
+                        start => {otel_metric_reader_sup, start_link, [self(), Opts]},
+                        restart => permanent,
+                        shutdown => infinity,
+                        type => supervisor,
+                        modules => [otel_metric_reader_sup]},
+
+    ProviderShutdownTimeout = maps:get(meter_provider_shutdown_timeout, Opts, 5000),
+    MeterServer = #{id => otel_meter_server,
+                    start => {otel_meter_server, start_link, [MeterServerRegName,
+                                                              Opts]},
+                    restart => permanent,
+                    shutdown => ProviderShutdownTimeout,
+                    type => worker,
+                    modules => [otel_meter_provider, otel_meter_server]},
+
+    ChildSpecs = [MeterServer, MetricReaderSup],
+
+    {ok, {SupFlags, ChildSpecs}}.

--- a/apps/opentelemetry_experimental/src/otel_metric_reader_sup.erl
+++ b/apps/opentelemetry_experimental/src/otel_metric_reader_sup.erl
@@ -38,8 +38,9 @@ init([ProviderSup, Opts]) ->
                     start => {Module, start_link, [ProviderSup, ReaderConfig]},
                     type => worker,
                     restart => permanent,
-                    shutdown => 1000} || #{module := Module,
-                                           config := ReaderConfig} <- Readers
+                    shutdown => 1000}
+                  || #{module := Module,
+                       config := ReaderConfig} <- Readers
                  ],
 
     {ok, {SupFlags, ChildSpecs}}.

--- a/apps/opentelemetry_experimental/src/otel_view.erl
+++ b/apps/opentelemetry_experimental/src/otel_view.erl
@@ -102,7 +102,7 @@ match_instrument_to_views(Instrument=#instrument{name=Name,
                                          instrument=Instrument,
                                          temporality=Temporality,
                                          is_monotonic=IsMonotonic,
-                                         aggregation_options=[],
+                                         aggregation_options=#{},
                                          description=Description}}];
         Aggs ->
             Aggs

--- a/apps/opentelemetry_experimental/src/otel_view.hrl
+++ b/apps/opentelemetry_experimental/src/otel_view.hrl
@@ -7,18 +7,18 @@
          schema_url = '_'      :: unicode:unicode_binary() | undefined | '_'}).
 
 -record(view,
-        {name             :: otel_instrument:name() | '_' | undefined,
-         selection        :: #selection{} | undefined,
-         %% instrument_kind  :: otel_instrument:kind(),
-         %% instrument_name  :: otel_instrument:name(),
-         %% meter_name       :: otel_meter:name(),
-         %% meter_version    :: otel_meter:version(),
-         %% meter_schema_url :: otel_meter:schema_url(),
-         description      :: unicode:unicode_binary() | undefined,
-         attribute_keys   :: [opentelemetry:attribute_key()] | undefined,
+        {name                    :: otel_instrument:name() | '_' | undefined,
+         selection               :: #selection{} | undefined,
+         %% instrument_kind      :: otel_instrument:kind(),
+         %% instrument_name      :: otel_instrument:name(),
+         %% meter_name           :: otel_meter:name(),
+         %% meter_version        :: otel_meter:version(),
+         %% meter_schema_url     :: otel_meter:schema_url(),
+         description             :: unicode:unicode_binary() | undefined,
+         attribute_keys          :: [opentelemetry:attribute_key()] | undefined,
          aggregation_module      :: module() | undefined,
-         aggregation_options :: map(),
-         number=0 :: number()}).
+         aggregation_options=#{} :: map(),
+         number=0                :: number()}).
 
 -record(view_aggregation,
         {%% name of the view or instrument if the view has no name

--- a/apps/opentelemetry_experimental/src/otel_view.hrl
+++ b/apps/opentelemetry_experimental/src/otel_view.hrl
@@ -17,7 +17,7 @@
          description      :: unicode:unicode_binary() | undefined,
          attribute_keys   :: [opentelemetry:attribute_key()] | undefined,
          aggregation_module      :: module() | undefined,
-         aggregation_options :: term(),
+         aggregation_options :: map(),
          number=0 :: number()}).
 
 -record(view_aggregation,
@@ -27,7 +27,7 @@
          instrument :: otel_instrument:t(),
 
          aggregation_module :: module(),
-         aggregation_options :: term(),
+         aggregation_options :: map(),
 
          temporality :: otel_aggregation:temporality(),
          is_monotonic :: boolean(),

--- a/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
@@ -7,6 +7,7 @@
 
 -include("otel_test_utils.hrl").
 -include_lib("opentelemetry_api_experimental/include/otel_metrics.hrl").
+-include_lib("opentelemetry_api_experimental/include/otel_meter.hrl").
 -include("otel_view.hrl").
 -include("otel_metrics.hrl").
 
@@ -472,7 +473,7 @@ cumulative_counter(_Config) ->
                              value_type = ValueType,
                              unit = CounterUnit}, Counter),
 
-    otel_meter_server:add_view(?DEFAULT_METER_PROVIDER,
+    otel_meter_server:add_view(?GLOBAL_METER_PROVIDER_REG_NAME,
                                #{instrument_name => a_counter},
                                #{aggregation => otel_aggregation_sum}),
 
@@ -480,7 +481,7 @@ cumulative_counter(_Config) ->
     ?assertEqual(ok, otel_counter:add(Counter, 3, #{<<"a">> => <<"b">>, <<"d">> => <<"e">>})),
     ?assertEqual(ok, otel_counter:add(Counter, 4, #{<<"c">> => <<"b">>})),
 
-    otel_meter_server:force_flush(?DEFAULT_METER_PROVIDER),
+    otel_meter_server:force_flush(?GLOBAL_METER_PROVIDER_REG_NAME),
 
     ?assertSumReceive(a_counter, <<"counter description">>, kb, [{6, #{<<"c">> => <<"b">>}}]),
 
@@ -489,7 +490,7 @@ cumulative_counter(_Config) ->
     ?assertEqual(ok, otel_counter:add(Counter, 3, #{<<"a">> => <<"b">>, <<"d">> => <<"e">>})),
     ?assertEqual(ok, otel_counter:add(Counter, 7, #{<<"c">> => <<"b">>})),
 
-    otel_meter_server:force_flush(?DEFAULT_METER_PROVIDER),
+    otel_meter_server:force_flush(?GLOBAL_METER_PROVIDER_REG_NAME),
 
     ?assertSumReceive(a_counter, <<"counter description">>, kb, [{18, #{<<"c">> => <<"b">>}}]),
 


### PR DESCRIPTION
These patches updates MeterProvider/Meter setup to align with how the TracerProvider/Tracer work to allow multiple Providers running at the same time.

Additionally the Readers now start and register themselves to the Provider (`otel_meter_server`). A `rest_for_one` supervisor is used so that Readers are restarted and register with the Provider if the Provider were to crash.

