### PR TITLE
Metrics macro api

### DIFF
--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -455,7 +455,7 @@ verify_and_set_term(Module, TermKey, Behaviour) ->
             true;
         false ->
             ?LOG_WARNING("Module ~p does not exist. "
-                         "A noop ~p will be used until a module is configured.",
+                         "A noop ~p will be used.",
                          [Module, Behaviour]),
             false
     end.

--- a/apps/opentelemetry_api_experimental/.formatter.exs
+++ b/apps/opentelemetry_api_experimental/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.dialyzer_ignore,.formatter}.exs", "{lib,test}/**/*.{ex,exs}"]
+]

--- a/apps/opentelemetry_api_experimental/include/otel_meter.hrl
+++ b/apps/opentelemetry_api_experimental/include/otel_meter.hrl
@@ -6,3 +6,32 @@
 
 -define(current_meter, opentelemetry_experimental:get_meter(?MODULE)).
 
+-define(create_counter(Name, ValueType, Opts),
+        otel_meter:create_counter(?current_meter, Name, ValueType, Opts)).
+
+-define(create_observable_counter(Name, Callback, CallbackArgs, ValueType, Opts),
+        otel_meter:create_observable_counter(?current_meter, Name, Callback, CallbackArgs, ValueType, Opts)).
+
+-define(create_histogram(Name, ValueType, Opts),
+        otel_meter:create_histogram(?current_meter, Name, ValueType, Opts)).
+
+-define(create_observable_gauge(Name, Callback, CallbackArgs, ValueType, Opts),
+        otel_meter:create_observable_gauge(?current_meter, Name, Callback, CallbackArgs, ValueType, Opts)).
+
+-define(create_updown_counter(Name, ValueType, Opts),
+        otel_meter:create_updown_counter(?current_meter, Name, ValueType, Opts)).
+
+-define(create_observable_updowncounter(Name, Callback, CallbackArgs, ValueType, Opts),
+        otel_meter:create_observable_updowncounter(?current_meter, Name, Callback, CallbackArgs, ValueType, Opts)).
+
+-define(counter_add(Name, Number, Attributes),
+        otel_counter:add(?lookup_instrument(Name), Number, Attributes)).
+
+-define(updown_counter_add(Name, Number, Attributes),
+        otel_updown_counter:add(?lookup_instrument(Name), Number, Attributes)).
+
+-define(histogram_record(Name, Number, Attributes),
+        otel_histogram:record(?lookup_instrument(Name), Number, Attributes)).
+
+-define(lookup_instrument(Name),
+        otel_meter:lookup_instrument(?current_meter, Name)).

--- a/apps/opentelemetry_api_experimental/lib/open_telemetry/counter.ex
+++ b/apps/opentelemetry_api_experimental/lib/open_telemetry/counter.ex
@@ -1,0 +1,26 @@
+defmodule OpenTelemetryAPIExperimental.Counter do
+  @moduledoc """
+
+  """
+
+  defmacro create(name, value_type, opts) do
+    quote bind_quoted: [name: name, value_type: value_type, opts: opts] do
+      :otel_meter.create_counter(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        value_type,
+        opts
+      )
+    end
+  end
+
+  defmacro add(name, number, attributes) do
+    quote bind_quoted: [name: name, number: number, attributes: attributes] do
+      :otel_counter.add(
+        :otel_meter.lookup_instrument(:opentelemetry_experimental.get_meter(__MODULE__), name),
+        number,
+        attributes
+      )
+    end
+  end
+end

--- a/apps/opentelemetry_api_experimental/lib/open_telemetry/histogram.ex
+++ b/apps/opentelemetry_api_experimental/lib/open_telemetry/histogram.ex
@@ -1,0 +1,26 @@
+defmodule OpenTelemetryAPIExperimental.Histogram do
+  @moduledoc """
+
+  """
+
+  defmacro create(name, value_type, opts) do
+    quote bind_quoted: [name: name, value_type: value_type, opts: opts] do
+      :otel_meter.create_histogram(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        value_type,
+        opts
+      )
+    end
+  end
+
+  defmacro record(name, number, attributes) do
+    quote bind_quoted: [name: name, number: number, attributes: attributes] do
+      :otel_histogram.record(
+        :otel_meter.lookup_instrument(:opentelemetry_experimental.get_meter(__MODULE__), name),
+        number,
+        attributes
+      )
+    end
+  end
+end

--- a/apps/opentelemetry_api_experimental/lib/open_telemetry/meter.ex
+++ b/apps/opentelemetry_api_experimental/lib/open_telemetry/meter.ex
@@ -2,5 +2,138 @@ defmodule OpenTelemetryAPIExperimental.Meter do
   @moduledoc """
 
   """
+  defmacro current_meter do
+    quote do
+      :opentelemetry_experimental.get_meter(__MODULE__)
+    end
+  end
 
+  defmacro create_counter(name, value_type, opts) do
+    quote bind_quoted: [name: name, value_type: value_type, opts: opts] do
+      :otel_meter.create_counter(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        value_type,
+        opts
+      )
+    end
+  end
+
+  defmacro create_observable_counter(name, callback, callback_args, value_type, opts) do
+    quote bind_quoted: [
+            name: name,
+            value_type: value_type,
+            callback: callback,
+            callback_args: callback_args,
+            opts: opts
+          ] do
+      :otel_meter.create_observable_counter(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        callback,
+        callback_args,
+        value_type,
+        opts
+      )
+    end
+  end
+
+  defmacro create_histogram(name, value_type, opts) do
+    quote bind_quoted: [name: name, value_type: value_type, opts: opts] do
+      :otel_meter.create_histogram(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        value_type,
+        opts
+      )
+    end
+  end
+
+  defmacro create_observable_gauge(name, callback, callback_args, value_type, opts) do
+    quote bind_quoted: [
+            name: name,
+            value_type: value_type,
+            callback: callback,
+            callback_args: callback_args,
+            opts: opts
+          ] do
+      :otel_meter.create_observable_gauge(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        callback,
+        callback_args,
+        value_type,
+        opts
+      )
+    end
+  end
+
+  defmacro create_updown_counter(name, value_type, opts) do
+    quote bind_quoted: [name: name, value_type: value_type, opts: opts] do
+      :otel_meter.create_updown_counter(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        value_type,
+        opts
+      )
+    end
+  end
+
+  defmacro create_observable_updowncounter(name, callback, callback_args, value_type, opts) do
+    quote bind_quoted: [
+            name: name,
+            value_type: value_type,
+            callback: callback,
+            callback_args: callback_args,
+            opts: opts
+          ] do
+      :otel_meter.create_observable_updowncounter(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        callback,
+        callback_args,
+        value_type,
+        opts
+      )
+    end
+  end
+
+  defmacro counter_add(name, number, attributes) do
+    quote bind_quoted: [name: name, number: number, attributes: attributes] do
+      :otel_counter.add(
+        :otel_meter.lookup_instrument(:opentelemetry_experimental.get_meter(__MODULE__), name),
+        number,
+        attributes
+      )
+    end
+  end
+
+  defmacro updown_counter_add(name, number, attributes) do
+    quote bind_quoted: [name: name, number: number, attributes: attributes] do
+      :otel_updown_counter.add(
+        :otel_meter.lookup_instrument(:opentelemetry_experimental.get_meter(__MODULE__), name),
+        number,
+        attributes
+      )
+    end
+  end
+
+  defmacro histogram_record(name, number, attributes) do
+    quote bind_quoted: [name: name, number: number, attributes: attributes] do
+      :otel_histogram.record(
+        :otel_meter.lookup_instrument(:opentelemetry_experimental.get_meter(__MODULE__), name),
+        number,
+        attributes
+      )
+    end
+  end
+
+  defmacro lookup_instrument(name) do
+    quote bind_quoted: [name: name] do
+      :otel_meter.lookup_instrument(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name
+      )
+    end
+  end
 end

--- a/apps/opentelemetry_api_experimental/lib/open_telemetry/meter.ex
+++ b/apps/opentelemetry_api_experimental/lib/open_telemetry/meter.ex
@@ -2,129 +2,10 @@ defmodule OpenTelemetryAPIExperimental.Meter do
   @moduledoc """
 
   """
+
   defmacro current_meter do
     quote do
       :opentelemetry_experimental.get_meter(__MODULE__)
-    end
-  end
-
-  defmacro create_counter(name, value_type, opts) do
-    quote bind_quoted: [name: name, value_type: value_type, opts: opts] do
-      :otel_meter.create_counter(
-        :opentelemetry_experimental.get_meter(__MODULE__),
-        name,
-        value_type,
-        opts
-      )
-    end
-  end
-
-  defmacro create_observable_counter(name, callback, callback_args, value_type, opts) do
-    quote bind_quoted: [
-            name: name,
-            value_type: value_type,
-            callback: callback,
-            callback_args: callback_args,
-            opts: opts
-          ] do
-      :otel_meter.create_observable_counter(
-        :opentelemetry_experimental.get_meter(__MODULE__),
-        name,
-        callback,
-        callback_args,
-        value_type,
-        opts
-      )
-    end
-  end
-
-  defmacro create_histogram(name, value_type, opts) do
-    quote bind_quoted: [name: name, value_type: value_type, opts: opts] do
-      :otel_meter.create_histogram(
-        :opentelemetry_experimental.get_meter(__MODULE__),
-        name,
-        value_type,
-        opts
-      )
-    end
-  end
-
-  defmacro create_observable_gauge(name, callback, callback_args, value_type, opts) do
-    quote bind_quoted: [
-            name: name,
-            value_type: value_type,
-            callback: callback,
-            callback_args: callback_args,
-            opts: opts
-          ] do
-      :otel_meter.create_observable_gauge(
-        :opentelemetry_experimental.get_meter(__MODULE__),
-        name,
-        callback,
-        callback_args,
-        value_type,
-        opts
-      )
-    end
-  end
-
-  defmacro create_updown_counter(name, value_type, opts) do
-    quote bind_quoted: [name: name, value_type: value_type, opts: opts] do
-      :otel_meter.create_updown_counter(
-        :opentelemetry_experimental.get_meter(__MODULE__),
-        name,
-        value_type,
-        opts
-      )
-    end
-  end
-
-  defmacro create_observable_updowncounter(name, callback, callback_args, value_type, opts) do
-    quote bind_quoted: [
-            name: name,
-            value_type: value_type,
-            callback: callback,
-            callback_args: callback_args,
-            opts: opts
-          ] do
-      :otel_meter.create_observable_updowncounter(
-        :opentelemetry_experimental.get_meter(__MODULE__),
-        name,
-        callback,
-        callback_args,
-        value_type,
-        opts
-      )
-    end
-  end
-
-  defmacro counter_add(name, number, attributes) do
-    quote bind_quoted: [name: name, number: number, attributes: attributes] do
-      :otel_counter.add(
-        :otel_meter.lookup_instrument(:opentelemetry_experimental.get_meter(__MODULE__), name),
-        number,
-        attributes
-      )
-    end
-  end
-
-  defmacro updown_counter_add(name, number, attributes) do
-    quote bind_quoted: [name: name, number: number, attributes: attributes] do
-      :otel_updown_counter.add(
-        :otel_meter.lookup_instrument(:opentelemetry_experimental.get_meter(__MODULE__), name),
-        number,
-        attributes
-      )
-    end
-  end
-
-  defmacro histogram_record(name, number, attributes) do
-    quote bind_quoted: [name: name, number: number, attributes: attributes] do
-      :otel_histogram.record(
-        :otel_meter.lookup_instrument(:opentelemetry_experimental.get_meter(__MODULE__), name),
-        number,
-        attributes
-      )
     end
   end
 
@@ -135,5 +16,9 @@ defmodule OpenTelemetryAPIExperimental.Meter do
         name
       )
     end
+  end
+
+  defmacro register_callback(instruments, callback, callback_args) do
+    :otel_meter.register_callback(:opentelemetry_experimental.get_meter(__MODULE__), instruments, callback, callback_args)
   end
 end

--- a/apps/opentelemetry_api_experimental/lib/open_telemetry/meter.ex
+++ b/apps/opentelemetry_api_experimental/lib/open_telemetry/meter.ex
@@ -1,0 +1,6 @@
+defmodule OpenTelemetryAPIExperimental.Meter do
+  @moduledoc """
+
+  """
+
+end

--- a/apps/opentelemetry_api_experimental/lib/open_telemetry/observable_counter.ex
+++ b/apps/opentelemetry_api_experimental/lib/open_telemetry/observable_counter.ex
@@ -1,0 +1,24 @@
+defmodule OpenTelemetryAPIExperimental.ObservableCounter do
+  @moduledoc """
+
+  """
+
+  defmacro create(name, callback, callback_args, value_type, opts) do
+    quote bind_quoted: [
+            name: name,
+            value_type: value_type,
+            callback: callback,
+            callback_args: callback_args,
+            opts: opts
+          ] do
+      :otel_meter.create_observable_counter(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        callback,
+        callback_args,
+        value_type,
+        opts
+      )
+    end
+  end
+end

--- a/apps/opentelemetry_api_experimental/lib/open_telemetry/observable_gauge.ex
+++ b/apps/opentelemetry_api_experimental/lib/open_telemetry/observable_gauge.ex
@@ -1,0 +1,24 @@
+defmodule OpenTelemetryAPIExperimental.ObservableGauge do
+  @moduledoc """
+
+  """
+
+  defmacro create(name, callback, callback_args, value_type, opts) do
+    quote bind_quoted: [
+            name: name,
+            value_type: value_type,
+            callback: callback,
+            callback_args: callback_args,
+            opts: opts
+          ] do
+      :otel_meter.create_observable_gauge(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        callback,
+        callback_args,
+        value_type,
+        opts
+      )
+    end
+  end
+end

--- a/apps/opentelemetry_api_experimental/lib/open_telemetry/observable_updown_counter.ex
+++ b/apps/opentelemetry_api_experimental/lib/open_telemetry/observable_updown_counter.ex
@@ -1,0 +1,24 @@
+defmodule OpenTelemetryAPIExperimental.ObservableUpDownCounter do
+  @moduledoc """
+
+  """
+
+  defmacro create(name, callback, callback_args, value_type, opts) do
+    quote bind_quoted: [
+            name: name,
+            value_type: value_type,
+            callback: callback,
+            callback_args: callback_args,
+            opts: opts
+          ] do
+      :otel_meter.create_observable_updowncounter(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        callback,
+        callback_args,
+        value_type,
+        opts
+      )
+    end
+  end
+end

--- a/apps/opentelemetry_api_experimental/lib/open_telemetry/updown_counter.ex
+++ b/apps/opentelemetry_api_experimental/lib/open_telemetry/updown_counter.ex
@@ -1,0 +1,27 @@
+defmodule OpenTelemetryAPIExperimental.UpDownCounter do
+  @moduledoc """
+
+  """
+
+  defmacro create(name, value_type, opts) do
+    quote bind_quoted: [name: name, value_type: value_type, opts: opts] do
+      :otel_meter.create_updown_counter(
+        :opentelemetry_experimental.get_meter(__MODULE__),
+        name,
+        value_type,
+        opts
+      )
+    end
+  end
+
+
+  defmacro add(name, number, attributes) do
+    quote bind_quoted: [name: name, number: number, attributes: attributes] do
+      :otel_updown_counter.add(
+        :otel_meter.lookup_instrument(:opentelemetry_experimental.get_meter(__MODULE__), name),
+        number,
+        attributes
+      )
+    end
+  end
+end

--- a/apps/opentelemetry_api_experimental/lib/opentelemetry_api_experimental.ex
+++ b/apps/opentelemetry_api_experimental/lib/opentelemetry_api_experimental.ex
@@ -1,5 +1,4 @@
 defmodule OpenTelemetryAPIExperimental do
   @moduledoc """
   """
-
 end

--- a/apps/opentelemetry_api_experimental/mix.exs
+++ b/apps/opentelemetry_api_experimental/mix.exs
@@ -88,7 +88,8 @@ defmodule OpenTelemetryExperimental.MixProject do
   end
 
   defp load_app do
-    {:ok, [{:application, name, desc}]} = :file.consult('src/opentelemetry_api_experimental.app.src')
+    {:ok, [{:application, name, desc}]} =
+      :file.consult('src/opentelemetry_api_experimental.app.src')
 
     {name, desc}
   end

--- a/apps/opentelemetry_api_experimental/mix.exs
+++ b/apps/opentelemetry_api_experimental/mix.exs
@@ -45,12 +45,13 @@ defmodule OpenTelemetryExperimental.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application, do: []
 
-  defp deps(rebar) do
-    rebar
-    |> Enum.map(fn
-      {dep, version} -> {dep, to_string(version)}
-      dep when is_atom(dep) -> {dep, ">= 0.0.0"}
-    end)
+  defp deps(_rebar) do
+    [{:opentelemetry_api, path: "../opentelemetry_api/"}]
+    # rebar
+    # |> Enum.map(fn
+    #   {dep, version} -> {dep, to_string(version)}
+    #   dep when is_atom(dep) -> {dep, ">= 0.0.0"}
+    # end)
     |> Enum.concat([
       {:cmark, "~> 0.7", only: :dev, runtime: false},
       {:ex_doc, "0.21.0", only: :dev, runtime: false},

--- a/apps/opentelemetry_api_experimental/src/otel_counter.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_counter.erl
@@ -18,10 +18,19 @@
 %%%-------------------------------------------------------------------------
 -module(otel_counter).
 
--export([add/3]).
+-export([create/4,
+         add/3]).
 
 -include("otel_metrics.hrl").
 -include_lib("kernel/include/logger.hrl").
+
+-spec create(Meter, Name, ValueType, Opts) -> otel_instrument:t() when
+      Meter :: otel_meter:t(),
+      Name :: otel_instrument:name(),
+      ValueType :: otel_instrument:value_type(),
+      Opts :: otel_meter:opts().
+create(Meter, Name, ValueType, Opts) ->
+    otel_meter:create_counter(Meter, Name, ValueType, Opts).
 
 -spec add(otel_instrument:t(), number(), opentelemetry:attributes_map()) -> ok.
 add(Instrument=#instrument{module=Module,

--- a/apps/opentelemetry_api_experimental/src/otel_histogram.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_histogram.erl
@@ -19,10 +19,19 @@
 %%%-------------------------------------------------------------------------
 -module(otel_histogram).
 
--export([record/3]).
+-export([create/4,
+         record/3]).
 
 -include("otel_metrics.hrl").
 -include_lib("kernel/include/logger.hrl").
+
+-spec create(Meter, Name, ValueType, Opts) -> otel_instrument:t() when
+      Meter :: otel_meter:t(),
+      Name :: otel_instrument:name(),
+      ValueType :: otel_instrument:value_type(),
+      Opts :: otel_meter:opts().
+create(Meter, Name, ValueType, Opts) ->
+    otel_meter:create_histogram(Meter, Name, ValueType, Opts).
 
 -spec record(otel_instrument:t(), number(), opentelemetry:attributes_map()) -> ok.
 record(Instrument=#instrument{module=Module,

--- a/apps/opentelemetry_api_experimental/src/otel_meter.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_meter.erl
@@ -148,7 +148,7 @@ lookup_instrument(Meter={Module, _}, Name) ->
       ValueType :: otel_instrument:value_type(),
       Opts :: opts().
 instrument(Meter={Module, _}, Name, Kind, ValueType, Callback, CallbackArgs, Opts) ->
-    Module:instrument(Meter, Name, Kind, ValueType, Callback, CallbackArgs, Opts).
+    Module:create_instrument(Meter, Name, Kind, ValueType, Callback, CallbackArgs, Opts).
 
 -spec register_callback(Meter, Instruments, Callback, CallbackArgs) -> ok when
       Meter :: t(),

--- a/apps/opentelemetry_api_experimental/src/otel_meter_noop.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_meter_noop.erl
@@ -20,8 +20,8 @@
 -behaviour(otel_meter).
 
 -export([register_callback/4,
-         instrument/5,
-         instrument/7]).
+         create_instrument/5,
+         create_instrument/7]).
 
 %% also act as noop version of instruments
 -export([add/3,
@@ -41,10 +41,10 @@ record(_Insturment, _Number, _Attributes) ->
 register_callback(_Meter, _Instruments, _Callback, _CallbackArgs) ->
     ok.
 
-instrument(Meter, Name, Kind, ValueType, Opts) ->
+create_instrument(Meter, Name, Kind, ValueType, Opts) ->
     otel_instrument:new(?MODULE, Meter, Kind, Name, maps:get(description, Opts, undefined),
                         maps:get(unit, Opts, undefined), ValueType).
 
-instrument(Meter, Name, Kind, ValueType, Callback, CallbackArgs, Opts) ->
+create_instrument(Meter, Name, Kind, ValueType, Callback, CallbackArgs, Opts) ->
     otel_instrument:new(?MODULE, Meter, Kind, Name, maps:get(description, Opts, undefined),
                         maps:get(unit, Opts, undefined), ValueType, Callback, CallbackArgs).

--- a/apps/opentelemetry_api_experimental/src/otel_observable_counter.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_observable_counter.erl
@@ -18,4 +18,7 @@
 %%%-------------------------------------------------------------------------
 -module(otel_observable_counter).
 
--export([]).
+-export([create/6]).
+
+create(Meter, Name, Callback, CallbackArgs, ValueType, Opts) ->
+    otel_meter:create_observable_counter(Meter, Name, Callback, CallbackArgs, ValueType, Opts).

--- a/apps/opentelemetry_api_experimental/src/otel_observable_gauge.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_observable_gauge.erl
@@ -25,4 +25,7 @@
 %%%-------------------------------------------------------------------------
 -module(otel_observable_gauge).
 
--export([]).
+-export([create/6]).
+
+create(Meter, Name, Callback, CallbackArgs, ValueType, Opts) ->
+    otel_meter:create_observable_gauge(Meter, Name, Callback, CallbackArgs, ValueType, Opts).

--- a/apps/opentelemetry_api_experimental/src/otel_observable_updowncounter.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_observable_updowncounter.erl
@@ -23,4 +23,7 @@
 %%%-------------------------------------------------------------------------
 -module(otel_observable_updowncounter).
 
--export([]).
+-export([create/6]).
+
+create(Meter, Name, Callback, CallbackArgs, ValueType, Opts) ->
+    otel_meter:create_observable_updowncounter(Meter, Name, Callback, CallbackArgs, ValueType, Opts).

--- a/apps/opentelemetry_api_experimental/src/otel_updown_counter.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_updown_counter.erl
@@ -18,10 +18,19 @@
 %%%-------------------------------------------------------------------------
 -module(otel_updown_counter).
 
--export([add/3]).
+-export([create/4,
+         add/3]).
 
 -include("otel_metrics.hrl").
 -include_lib("kernel/include/logger.hrl").
+
+-spec create(Meter, Name, ValueType, Opts) -> otel_instrument:t() when
+      Meter :: otel_meter:t(),
+      Name :: otel_instrument:name(),
+      ValueType :: otel_instrument:value_type(),
+      Opts :: otel_meter:opts().
+create(Meter, Name, ValueType, Opts) ->
+    otel_meter:create_updown_counter(Meter, Name, ValueType, Opts).
 
 -spec add(otel_instrument:t(), number(), opentelemetry:attributes_map()) -> ok.
 add(Instrument=#instrument{module=Module,

--- a/apps/opentelemetry_api_experimental/test/otel_metrics_test.exs
+++ b/apps/opentelemetry_api_experimental/test/otel_metrics_test.exs
@@ -2,13 +2,19 @@ defmodule OpenTelemetryTest do
   use ExUnit.Case, async: true
 
   require OpenTelemetryAPIExperimental.Meter, as: Meter
+  require OpenTelemetryAPIExperimental.Counter, as: Counter
+  require OpenTelemetryAPIExperimental.UpDownCounter, as: UpDownCounter
+  require OpenTelemetryAPIExperimental.ObservableCounter, as: ObservableCounter
+  require OpenTelemetryAPIExperimental.ObservableUpDownCounter, as: ObservableUpDownCounter
+  require OpenTelemetryAPIExperimental.ObservableGauge, as: ObservableGauge
+  require OpenTelemetryAPIExperimental.Histogram, as: Histogram
 
   require Record
   @fields Record.extract(:instrument, from_lib: "opentelemetry_api_experimental/include/otel_metrics.hrl")
   Record.defrecordp(:instrument, @fields)
 
   test "create counter instrument with no-op meter" do
-    c = Meter.create_counter(:a_counter, :integer, %{})
+    c = Counter.create(:a_counter, :integer, %{})
     assert instrument(module: :otel_meter_noop,
       meter: {:otel_meter_noop, []},
       name: :a_counter,
@@ -17,7 +23,7 @@ defmodule OpenTelemetryTest do
   end
 
   test "create updown counter instrument with no-op meter" do
-    c = Meter.create_updown_counter(:ud_counter, :float, %{})
+    c = UpDownCounter.create(:ud_counter, :float, %{})
     assert instrument(module: :otel_meter_noop,
       meter: {:otel_meter_noop, []},
       name: :ud_counter,
@@ -26,7 +32,7 @@ defmodule OpenTelemetryTest do
   end
 
   test "create histogram instrument with no-op meter" do
-    c = Meter.create_histogram(:a_histogram, :integer, %{})
+    c = Histogram.create(:a_histogram, :integer, %{})
     assert instrument(module: :otel_meter_noop,
       meter: {:otel_meter_noop, []},
       name: :a_histogram,
@@ -35,19 +41,19 @@ defmodule OpenTelemetryTest do
   end
 
   test "create observable counter with no-op meter" do
-    o = Meter.create_observable_counter(:o_counter, fn _ -> {3, %{}} end, [], :integer, %{})
+    o = ObservableCounter.create(:o_counter, fn _ -> {3, %{}} end, [], :integer, %{})
     assert instrument(name: :o_counter,
       kind: :observable_counter) = o
   end
 
   test "create observable gauge with no-op meter" do
-    o = Meter.create_observable_gauge(:a_gauge, fn _ -> {3, %{}} end, [], :integer, %{})
+    o = ObservableGauge.create(:a_gauge, fn _ -> {3, %{}} end, [], :integer, %{})
     assert instrument(name: :a_gauge,
       kind: :observable_gauge) = o
   end
 
   test "create observable updown counter with no-op meter" do
-    o = Meter.create_observable_updowncounter(:ouc_counter, fn _ -> {3, %{}} end, [], :integer, %{})
+    o = ObservableUpDownCounter.create(:ouc_counter, fn _ -> {3, %{}} end, [], :integer, %{})
     assert instrument(name: :ouc_counter,
       kind: :observable_updowncounter) = o
   end

--- a/apps/opentelemetry_api_experimental/test/otel_metrics_test.exs
+++ b/apps/opentelemetry_api_experimental/test/otel_metrics_test.exs
@@ -1,0 +1,54 @@
+defmodule OpenTelemetryTest do
+  use ExUnit.Case, async: true
+
+  require OpenTelemetryAPIExperimental.Meter, as: Meter
+
+  require Record
+  @fields Record.extract(:instrument, from_lib: "opentelemetry_api_experimental/include/otel_metrics.hrl")
+  Record.defrecordp(:instrument, @fields)
+
+  test "create counter instrument with no-op meter" do
+    c = Meter.create_counter(:a_counter, :integer, %{})
+    assert instrument(module: :otel_meter_noop,
+      meter: {:otel_meter_noop, []},
+      name: :a_counter,
+      kind: :counter,
+      value_type: :integer) == c
+  end
+
+  test "create updown counter instrument with no-op meter" do
+    c = Meter.create_updown_counter(:ud_counter, :float, %{})
+    assert instrument(module: :otel_meter_noop,
+      meter: {:otel_meter_noop, []},
+      name: :ud_counter,
+      kind: :updown_counter,
+      value_type: :float) == c
+  end
+
+  test "create histogram instrument with no-op meter" do
+    c = Meter.create_histogram(:a_histogram, :integer, %{})
+    assert instrument(module: :otel_meter_noop,
+      meter: {:otel_meter_noop, []},
+      name: :a_histogram,
+      kind: :histogram,
+      value_type: :integer) == c
+  end
+
+  test "create observable counter with no-op meter" do
+    o = Meter.create_observable_counter(:o_counter, fn _ -> {3, %{}} end, [], :integer, %{})
+    assert instrument(name: :o_counter,
+      kind: :observable_counter) = o
+  end
+
+  test "create observable gauge with no-op meter" do
+    o = Meter.create_observable_gauge(:a_gauge, fn _ -> {3, %{}} end, [], :integer, %{})
+    assert instrument(name: :a_gauge,
+      kind: :observable_gauge) = o
+  end
+
+  test "create observable updown counter with no-op meter" do
+    o = Meter.create_observable_updowncounter(:ouc_counter, fn _ -> {3, %{}} end, [], :integer, %{})
+    assert instrument(name: :ouc_counter,
+      kind: :observable_updowncounter) = o
+  end
+end

--- a/apps/opentelemetry_api_experimental/test/test_helper.exs
+++ b/apps/opentelemetry_api_experimental/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/apps/opentelemetry_experimental/include/otel_metrics.hrl
+++ b/apps/opentelemetry_experimental/include/otel_metrics.hrl
@@ -4,10 +4,10 @@
 -define(AGGREGATION_TEMPORALITY_CUMULATIVE, aggregation_temporality_cumulative).
 -define(AGGREGATION_TEMPORALITY_UNSPECIFIED, aggregation_temporality_unspecified).
 
--record(meter, {module                  :: module(),
+-record(meter, {module                  :: module() | '_',
                 instrumentation_scope   :: opentelemetry:instrumentation_scope() | undefined,
-                provider                :: atom(),
-                instruments_table       :: ets:tid()}).
+                provider                :: atom() | '_',
+                instruments_table       :: ets:tid() | '_'}).
 
 -record(measurement,
         {

--- a/apps/opentelemetry_experimental/include/otel_metrics.hrl
+++ b/apps/opentelemetry_experimental/include/otel_metrics.hrl
@@ -6,7 +6,8 @@
 
 -record(meter, {module                  :: module(),
                 instrumentation_scope   :: opentelemetry:instrumentation_scope() | undefined,
-                provider                :: atom()}).
+                provider                :: atom(),
+                instruments_table       :: ets:tid()}).
 
 -record(measurement,
         {

--- a/apps/opentelemetry_experimental/src/otel_meter_default.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_default.erl
@@ -19,8 +19,9 @@
 
 -behaviour(otel_meter).
 
--export([instrument/5,
+-export([create_instrument/5,
          instrument/7,
+         lookup_instrument/2,
          register_callback/4,
          scope/1]).
 
@@ -29,12 +30,21 @@
 -include_lib("opentelemetry_api_experimental/include/otel_metrics.hrl").
 -include("otel_metrics.hrl").
 
-instrument(Meter, Name, Kind, ValueType, Opts) ->
+create_instrument(Meter, Name, Kind, ValueType, Opts) ->
     Instrument=#instrument{meter={_, #meter{provider=Provider}}} =
         otel_instrument:new(?MODULE, Meter, Kind, Name, maps:get(description, Opts, undefined),
                             maps:get(unit, Opts, undefined), ValueType),
     _ = otel_meter_server:add_instrument(Provider, Instrument),
     Instrument.
+
+lookup_instrument(Meter={_, #meter{instruments_table=Tid}}, Name) ->
+    try ets:lookup_element(Tid, {Meter, Name}, 2) of
+        Instrument ->
+            Instrument
+    catch
+        _:_ ->
+            undefined
+    end.
 
 instrument(Meter, Name, Kind, ValueType, Callback, CallbackArgs, Opts) ->
     Instrument=#instrument{meter={_, #meter{provider=Provider}}} =

--- a/apps/opentelemetry_experimental/src/otel_meter_default.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_default.erl
@@ -30,10 +30,10 @@
 -include("otel_metrics.hrl").
 
 instrument(Meter, Name, Kind, ValueType, Opts) ->
-    Instrument=#instrument{meter={_, #meter{provider=_Provider}}} =
+    Instrument=#instrument{meter={_, #meter{provider=Provider}}} =
         otel_instrument:new(?MODULE, Meter, Kind, Name, maps:get(description, Opts, undefined),
                             maps:get(unit, Opts, undefined), ValueType),
-    %% _ = otel_meter_server:add_instrument(Provider, Instrument),
+    _ = otel_meter_server:add_instrument(Provider, Instrument),
     Instrument.
 
 instrument(Meter, Name, Kind, ValueType, Callback, CallbackArgs, Opts) ->

--- a/apps/opentelemetry_experimental/src/otel_meter_default.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_default.erl
@@ -20,7 +20,7 @@
 -behaviour(otel_meter).
 
 -export([create_instrument/5,
-         instrument/7,
+         create_instrument/7,
          lookup_instrument/2,
          register_callback/4,
          scope/1]).
@@ -46,7 +46,7 @@ lookup_instrument(Meter={_, #meter{instruments_table=Tid}}, Name) ->
             undefined
     end.
 
-instrument(Meter, Name, Kind, ValueType, Callback, CallbackArgs, Opts) ->
+create_instrument(Meter, Name, Kind, ValueType, Callback, CallbackArgs, Opts) ->
     Instrument=#instrument{meter={_, #meter{provider=Provider}}} =
         otel_instrument:new(?MODULE, Meter, Kind, Name, maps:get(description, Opts, undefined),
                             maps:get(unit, Opts, undefined), ValueType, Callback, CallbackArgs),

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -96,6 +96,8 @@
         {
          shared_meter,
 
+         instruments_tid :: ets:tid(),
+
          views :: [otel_view:t()],
          readers :: [#reader{}],
 
@@ -160,6 +162,8 @@ force_flush(Provider) ->
     gen_server:call(Provider, force_flush).
 
 init([Name, RegName, Config]) ->
+    InstrumentsTid = instruments_table(),
+
     Resource = otel_resource_detector:get_resource(),
 
     Meter = #meter{module=otel_meter_default,
@@ -172,37 +176,25 @@ init([Name, RegName, Config]) ->
     Views = [new_view(V) || V <- maps:get(views, Config, [])],
 
     {ok, #state{shared_meter=Meter,
+                instruments_tid=InstrumentsTid,
                 views=Views,
                 readers=[],
                 resource=Resource}}.
-
-new_view(ViewConfig) ->
-    Name = maps:get(name, ViewConfig, undefined),
-    Description = maps:get(description, ViewConfig, undefined),
-    Selector = maps:get(selector, ViewConfig, undefined),
-    AttributeKeys = maps:get(attribute_keys, ViewConfig, undefined),
-    AggregationModule = maps:get(aggregation_module, ViewConfig, undefined),
-    AggregationOptions = maps:get(aggregation_options, ViewConfig, #{}),
-    otel_view:new(Name, Selector, #{description => Description,
-                                    attribute_keys => AttributeKeys,
-                                    aggregation_module => AggregationModule,
-                                    aggregation_options => AggregationOptions
-                                   }).
 
 handle_call({add_metric_reader, ReaderPid, DefaultAggregationMapping, Temporality,
              ViewAggregationTable, CallbacksTable, MetricsTable}, _From, State=#state{readers=Readers}) ->
 
     {reply, ok, State#state{readers=[metric_reader(ReaderPid, DefaultAggregationMapping, Temporality,
                                                    ViewAggregationTable, CallbacksTable, MetricsTable) | Readers]}};
-handle_call({record, Measurement}, _From, State=#state{readers=Readers,
-                                                       views=Views}) ->
-    handle_measurement(Measurement, Readers, Views),
+handle_call({record, Measurement}, _From, State=#state{readers=Readers}) ->
+    _ = handle_measurement(Measurement, Readers),
     {reply, ok, State};
 handle_call(resource, _From, State=#state{resource=Resource}) ->
     {reply, Resource, State};
 handle_call({add_instrument, Instrument}, _From, State=#state{readers=Readers,
-                                                              views=Views}) ->
-    _ = add_instrument_(Instrument, Views, Readers),
+                                                              views=Views,
+                                                              instruments_tid=InstrumentsTid}) ->
+    _ = add_instrument_(InstrumentsTid, Instrument, Views, Readers),
     {reply, ok, State};
 handle_call({register_callback, Instruments, Callback, CallbackArgs}, _From, State=#state{readers=Readers,
                                                                             views=Views}) ->
@@ -216,17 +208,19 @@ handle_call({get_meter, Name, Vsn, SchemaUrl}, _From, State=#state{shared_meter=
 handle_call({get_meter, Scope}, _From, State=#state{shared_meter=Meter}) ->
     {reply, {Meter#meter.module,
              Meter#meter{instrumentation_scope=Scope}}, State};
-handle_call({add_view, Name, Criteria, Config}, _From, State=#state{views=Views}) ->
+handle_call({add_view, Name, Criteria, Config}, _From, State=#state{views=Views,
+                                                                    instruments_tid=InstrumentsTid,
+                                                                    readers=Readers}) ->
     %% TODO: drop View if Criteria is a wildcard instrument name and View name is not undefined
-    View = otel_view:new(Name, Criteria, Config),
-    {reply, true, State#state{views=[View | Views]}};
+    NewView = otel_view:new(Name, Criteria, Config),
+    _ = update_view_aggregations(InstrumentsTid, [NewView], Readers),
+    {reply, true, State#state{views=[NewView | Views]}};
 handle_call(force_flush, _From, State=#state{readers=Readers}) ->
     [otel_metric_reader:collect(Pid) || #reader{pid=Pid} <- Readers],
     {reply, ok, State}.
 
-handle_cast({record, Measurement}, State=#state{readers=Readers,
-                                                views=Views}) ->
-    handle_measurement(Measurement, Readers, Views),
+handle_cast({record, Measurement}, State=#state{readers=Readers}) ->
+    _ = handle_measurement(Measurement, Readers),
     {noreply, State}.
 
 %% TODO: Uncomment when we can drop OTP-23 support
@@ -241,13 +235,53 @@ code_change(State) ->
 
 %%
 
+instruments_table() ->
+    ets:new(instruments, [set, {keypos, 1}, protected]).
+
+new_view(ViewConfig) ->
+    Name = maps:get(name, ViewConfig, undefined),
+    Description = maps:get(description, ViewConfig, undefined),
+    Selector = maps:get(selector, ViewConfig, undefined),
+    AttributeKeys = maps:get(attribute_keys, ViewConfig, undefined),
+    AggregationModule = maps:get(aggregation_module, ViewConfig, undefined),
+    AggregationOptions = maps:get(aggregation_options, ViewConfig, #{}),
+    otel_view:new(Name, Selector, #{description => Description,
+                                    attribute_keys => AttributeKeys,
+                                    aggregation_module => AggregationModule,
+                                    aggregation_options => AggregationOptions
+                                   }).
+
 %% Match the Instrument to views and then store a per-Reader aggregation for the View
-add_instrument_(Instrument, Views, Readers) ->
+add_instrument_(InstrumentsTid, Instrument=#instrument{meter=Meter,
+                                                       name=Name,
+                                                       kind=Kind}, Views, Readers) ->
+    _ = ets:insert(InstrumentsTid, {{Meter, Name, Kind}, Instrument}),
     ViewMatches = otel_view:match_instrument_to_views(Instrument, Views),
     lists:map(fun(Reader=#reader{callbacks_tab=CallbackTab,
                                  view_aggregation_tab=ViewAggregationTab}) ->
                       Matches = per_reader_aggregations(Reader, Instrument, ViewMatches),
-                      _ = ets:insert(ViewAggregationTab, {Instrument, Matches}),
+                      [_ = ets:insert(ViewAggregationTab, {Instrument, M}) || M <- Matches],
+                      case {Instrument#instrument.callback, Instrument#instrument.callback_args} of
+                          {undefined, _} ->
+                              ok;
+                          {Callback, CallbackArgs} ->
+                              ets:insert(CallbackTab, {Callback, CallbackArgs, [Instrument]})
+                      end
+              end, Readers).
+
+%% used when a new View is added and the Views must be re-matched with each Instrument
+update_view_aggregations(InstrumentsTid, Views, Readers) ->
+    ets:foldl(fun({_, Instrument}, Acc) ->
+                      update_view_aggregations_(Instrument, Views, Readers),
+                      Acc
+              end, ok, InstrumentsTid).
+
+update_view_aggregations_(Instrument, Views, Readers) ->
+    ViewMatches = otel_view:match_instrument_to_views(Instrument, Views),
+    lists:map(fun(Reader=#reader{callbacks_tab=CallbackTab,
+                                 view_aggregation_tab=ViewAggregationTab}) ->
+                      Matches = per_reader_aggregations(Reader, Instrument, ViewMatches),
+                      [true = ets:insert(ViewAggregationTab, {Instrument, M}) || M <- Matches],
                       case {Instrument#instrument.callback, Instrument#instrument.callback_args} of
                           {undefined, _} ->
                               ok;
@@ -263,7 +297,7 @@ register_callback_(Instruments, Callback, CallbackArgs, Views, Readers) ->
                       lists:map(fun(Reader=#reader{callbacks_tab=CallbackTab,
                                                    view_aggregation_tab=ViewAggregationTab}) ->
                                         Matches = per_reader_aggregations(Reader, Instrument, ViewMatches),
-                                        _ = ets:insert(ViewAggregationTab, {Instrument, Matches}),
+                                        [true = ets:insert(ViewAggregationTab, {Instrument, M}) || M <- Matches],
                                         ets:insert(CallbackTab, {Callback, CallbackArgs, Instruments})
                                 end, Readers)
               end, Instruments).
@@ -293,24 +327,16 @@ metric_reader(ReaderPid, DefaultAggregationMapping, Temporality,
 %% for each ViewAggregation a Measurement updates a Metric (`#metric')
 %% active metrics are indexed by the ViewAggregation name + the Measurement's Attributes
 
-handle_measurement(Measurement=#measurement{instrument=Instrument},
-                   Readers,
-                   Views) ->
-    ViewMatches = otel_view:match_instrument_to_views(Instrument, Views),
+handle_measurement(Measurement=#measurement{instrument=Instrument}, Readers) ->
     lists:map(fun(Reader=#reader{view_aggregation_tab=ViewAggregationTab}) ->
-                      try ets:lookup(ViewAggregationTab, Instrument) of
-                          [] ->
-                              %% this instrument hasn't been seen before
-                              Matches = per_reader_aggregations(Reader, Instrument, ViewMatches),
-                              true = ets:insert(ViewAggregationTab, {Instrument, Matches}),
-                              update_aggregations(Measurement, Reader, Matches);
-                          [{_, Matches}] ->
-                              %% TODO: matches need to be  updated when a new view is added
+                      try ets:lookup_element(ViewAggregationTab, Instrument, 2) of
+                          Matches ->
+                              %% TODO: matches need to be updated when a new view is added
                               update_aggregations(Measurement, Reader, Matches)
                       catch
                           %% table doesn't exist, Reader may have crashed and be still
                           %% waiting on the DOWN message from the monitor
-                          exit:badarg ->
+                          error:badarg ->
                               Reader
                       end
               end, Readers).

--- a/apps/opentelemetry_experimental/src/otel_view.erl
+++ b/apps/opentelemetry_experimental/src/otel_view.erl
@@ -143,7 +143,8 @@ criteria_to_instrument_matchspec(_) ->
     ets:match_spec_compile([{#instrument{_='_'}, [], [true]}]).
 
 maybe_init_meter(#instrument{meter='_'}) ->
-    {'_', #meter{instrumentation_scope=#instrumentation_scope{_='_'}}}.
+    {'_', #meter{instrumentation_scope=#instrumentation_scope{_='_'},
+                 _='_'}}.
 
 update_meter_name(MeterName, {_, Meter=#meter{instrumentation_scope=Scope}}) ->
     {'_', Meter#meter{instrumentation_scope=Scope#instrumentation_scope{name=MeterName}}}.

--- a/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
@@ -544,6 +544,12 @@ kill_reader(_Config) ->
     ?UNTIL([Pid || {_, Pid, _, _} <- supervisor:which_children(ReaderSup),
                    Pid =/= ReaderPid] =/= []),
 
+    %% TODO: agh! need to supervise ETS tables so readers can crash and not then
+    %% lose all existing Instrument/View matches
+    Counter = otel_meter:counter(Meter, CounterName, ValueType,
+                                 #{description => CounterDesc,
+                                   unit => CounterUnit}),
+
     ?assertEqual(ok, otel_counter:add(Counter, 4, #{<<"c">> => <<"b">>})),
     ?assertEqual(ok, otel_counter:add(Counter, 5, #{<<"c">> => <<"b">>})),
 
@@ -589,6 +595,15 @@ kill_server(_Config) ->
     %% wait until process has died and born again
     ?UNTIL(erlang:whereis(?GLOBAL_METER_PROVIDER_REG_NAME) =/= CurrentPid),
     ?UNTIL(erlang:whereis(?GLOBAL_METER_PROVIDER_REG_NAME) =/= undefined),
+
+    %% TODO: Agh! need to supervise ETS tables so readers can crash and not then
+    %% lose all existing Instrument/View matches
+    ACounter = otel_meter:counter(Meter, ACounterName, ValueType,
+                                  #{description => CounterDesc,
+                                    unit => CounterUnit}),
+    Counter = otel_meter:counter(Meter, CounterName, ValueType,
+                                 #{description => CounterDesc,
+                                   unit => CounterUnit}),
 
     ?assertEqual(ok, otel_counter:add(Counter, 4, #{<<"c">> => <<"b">>})),
     ?assertEqual(ok, otel_counter:add(Counter, 5, #{<<"c">> => <<"b">>})),

--- a/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
@@ -77,7 +77,7 @@ all() ->
     [default_view, provider_test, view_creation_test, counter_add, multiple_readers,
      explicit_histograms, delta_explicit_histograms, cumulative_counter, kill_reader, kill_server,
      observable_counter, observable_updown_counter, observable_gauge,
-     multi_instrument_callback].
+     multi_instrument_callback, using_macros].
 
 init_per_suite(Config) ->
     application:load(opentelemetry_experimental),
@@ -120,46 +120,81 @@ init_per_testcase(multiple_readers, Config) ->
 
     Config;
 init_per_testcase(cumulative_counter, Config) ->
-    ReaderId = my_reader_id,
     CumulativeCounterTemporality = #{?KIND_COUNTER =>?AGGREGATION_TEMPORALITY_CUMULATIVE},
     application:load(opentelemetry_experimental),
-    ok = application:set_env(opentelemetry_experimental, readers, [#{id => ReaderId,
-                                                                     module => otel_metric_reader,
+    ok = application:set_env(opentelemetry_experimental, readers, [#{module => otel_metric_reader,
                                                                      config => #{exporter => {otel_metric_exporter_pid, self()},
                                                                                  default_temporality_mapping =>
                                                                                      CumulativeCounterTemporality}}]),
 
     {ok, _} = application:ensure_all_started(opentelemetry_experimental),
 
-    [{reader_id, ReaderId} | Config];
+    Config;
 init_per_testcase(delta_explicit_histograms, Config) ->
-    ReaderId = my_reader_id,
     DeltaHistogramTemporality = #{?KIND_HISTOGRAM =>?AGGREGATION_TEMPORALITY_DELTA},
     application:load(opentelemetry_experimental),
-    ok = application:set_env(opentelemetry_experimental, readers, [#{id => ReaderId,
-                                                                     module => otel_metric_reader,
+    ok = application:set_env(opentelemetry_experimental, readers, [#{module => otel_metric_reader,
                                                                      config => #{exporter => {otel_metric_exporter_pid, self()},
                                                                                  default_temporality_mapping =>
                                                                                      DeltaHistogramTemporality}}]),
 
     {ok, _} = application:ensure_all_started(opentelemetry_experimental),
 
-    [{reader_id, ReaderId} | Config];
+    Config;
 init_per_testcase(_, Config) ->
-    ReaderId = my_reader_id,
     application:load(opentelemetry_experimental),
-    ok = application:set_env(opentelemetry_experimental, readers, [#{id => ReaderId,
-                                                                     module => otel_metric_reader,
+    ok = application:set_env(opentelemetry_experimental, readers, [#{module => otel_metric_reader,
                                                                      config => #{exporter => {otel_metric_exporter_pid, self()}}}]),
 
     {ok, _} = application:ensure_all_started(opentelemetry_experimental),
 
 
-    [{reader_id, ReaderId} | Config].
+    Config.
 
 end_per_testcase(_, _Config) ->
     ok = application:stop(opentelemetry_experimental),
     application:unload(opentelemetry_experimental),
+    ok.
+
+using_macros(_Config) ->
+    DefaultMeter = otel_meter_default,
+
+    Meter = opentelemetry_experimental:get_meter(),
+    ?assertMatch({DefaultMeter, _}, Meter),
+
+    CounterName = m_counter,
+    CounterDesc = <<"macro made counter description">>,
+    CounterUnit = kb,
+    ValueType = integer,
+
+    Counter = ?create_counter(CounterName, ValueType, #{description => CounterDesc,
+                                                        unit => CounterUnit}),
+
+    ?assertMatch(#instrument{meter = {DefaultMeter,_},
+                             module = DefaultMeter,
+                             name = CounterName,
+                             description = CounterDesc,
+                             kind = counter,
+                             value_type = ValueType,
+                             unit = CounterUnit}, ?lookup_instrument(CounterName)),
+
+    ?assertMatch(#instrument{meter = {DefaultMeter,_},
+                             module = DefaultMeter,
+                             name = CounterName,
+                             description = CounterDesc,
+                             kind = counter,
+                             value_type = ValueType,
+                             unit = CounterUnit}, Counter),
+
+    ?assertEqual(ok, otel_counter:add(Counter, 2, #{<<"c">> => <<"b">>})),
+    ?assertEqual(ok, otel_counter:add(Counter, 5, #{<<"c">> => <<"b">>})),
+    ?assertEqual(ok, ?counter_add(CounterName, 5, #{<<"c">> => <<"b">>})),
+
+    otel_meter_server:force_flush(),
+
+    ?assertSumReceive(m_counter, <<"macro made counter description">>, kb,
+                      [{12, #{<<"c">> => <<"b">>}}]),
+
     ok.
 
 default_view(_Config) ->
@@ -173,9 +208,9 @@ default_view(_Config) ->
     CounterUnit = kb,
     ValueType = integer,
 
-    Counter = otel_meter:counter(Meter, CounterName, ValueType,
-                                 #{description => CounterDesc,
-                                   unit => CounterUnit}),
+    Counter = otel_meter:create_counter(Meter, CounterName, ValueType,
+                                        #{description => CounterDesc,
+                                          unit => CounterUnit}),
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
                              name = CounterName,
@@ -206,9 +241,9 @@ provider_test(_Config) ->
     CounterUnit = kb,
     ValueType = integer,
 
-    Counter = otel_meter:counter(Meter, CounterName, ValueType,
-                                 #{description => CounterDesc,
-                                   unit => CounterUnit}),
+    Counter = otel_meter:create_counter(Meter, CounterName, ValueType,
+                                        #{description => CounterDesc,
+                                          unit => CounterUnit}),
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
                              name = CounterName,
@@ -237,7 +272,7 @@ provider_test(_Config) ->
     ?assertEqual(ok, otel_counter:add(Counter, 7, #{<<"c">> => <<"b">>})),
     otel_meter_server:force_flush(),
     ?assertSumReceive(a_counter, <<"counter description">>, kb, [{7, #{<<"c">> => <<"b">>}},
-                                                              {0, #{<<"a">> => <<"b">>, <<"d">> => <<"e">>}}]),
+                                                                 {0, #{<<"a">> => <<"b">>, <<"d">> => <<"e">>}}]),
 
     ok.
 
@@ -252,9 +287,9 @@ view_creation_test(_Config) ->
     CounterUnit = kb,
     ValueType = integer,
 
-    Counter = otel_meter:counter(Meter, CounterName, ValueType,
-                                 #{description => CounterDesc,
-                                   unit => CounterUnit}),
+    Counter = otel_counter:create(Meter, CounterName, ValueType,
+                                         #{description => CounterDesc,
+                                           unit => CounterUnit}),
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
                              name = CounterName,
@@ -293,9 +328,9 @@ counter_add(_Config) ->
     CounterUnit = kb,
     ValueType = integer,
 
-    Counter = otel_meter:counter(Meter, CounterName, ValueType,
-                                 #{description => CounterDesc,
-                                   unit => CounterUnit}),
+    Counter = otel_counter:create(Meter, CounterName, ValueType,
+                                  #{description => CounterDesc,
+                                    unit => CounterUnit}),
 
     ?assertMatch(ok, otel_counter:add(Counter, 3, #{})),
     ok.
@@ -307,12 +342,12 @@ multiple_readers(_Config) ->
     CounterUnit = kb,
     ValueType = integer,
 
-    CounterA = otel_meter:counter(Meter, a_counter, ValueType,
-                                  #{description => CounterDesc,
-                                    unit => CounterUnit}),
-    CounterB = otel_meter:counter(Meter, b_counter, ValueType,
-                                  #{description => CounterDesc,
-                                    unit => CounterUnit}),
+    CounterA = otel_meter:create_counter(Meter, a_counter, ValueType,
+                                         #{description => CounterDesc,
+                                           unit => CounterUnit}),
+    CounterB = otel_meter:create_counter(Meter, b_counter, ValueType,
+                                         #{description => CounterDesc,
+                                           unit => CounterUnit}),
 
     otel_meter_server:add_view(#{instrument_name => a_counter}, #{aggregation_module => otel_aggregation_sum}),
     otel_meter_server:add_view(#{instrument_name => b_counter}, #{}),
@@ -346,9 +381,9 @@ explicit_histograms(_Config) ->
     HistogramUnit = ms,
     ValueType = integer,
 
-    Histogram = otel_meter:histogram(Meter, HistogramName, ValueType,
-                                     #{description => HistogramDesc,
-                                       unit => HistogramUnit}),
+    Histogram = otel_meter:create_histogram(Meter, HistogramName, ValueType,
+                                            #{description => HistogramDesc,
+                                              unit => HistogramUnit}),
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
                              name = HistogramName,
@@ -397,9 +432,9 @@ delta_explicit_histograms(_Config) ->
     HistogramUnit = ms,
     ValueType = integer,
 
-    Histogram = otel_meter:histogram(Meter, HistogramName, ValueType,
-                                     #{description => HistogramDesc,
-                                       unit => HistogramUnit}),
+    Histogram = otel_meter:create_histogram(Meter, HistogramName, ValueType,
+                                            #{description => HistogramDesc,
+                                              unit => HistogramUnit}),
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
                              name = HistogramName,
@@ -472,9 +507,9 @@ cumulative_counter(_Config) ->
     CounterUnit = kb,
     ValueType = integer,
 
-    Counter = otel_meter:counter(Meter, CounterName, ValueType,
-                                 #{description => CounterDesc,
-                                   unit => CounterUnit}),
+    Counter = otel_counter:create(Meter, CounterName, ValueType,
+                                  #{description => CounterDesc,
+                                    unit => CounterUnit}),
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
                              name = CounterName,
@@ -516,9 +551,9 @@ kill_reader(_Config) ->
     CounterUnit = kb,
     ValueType = integer,
 
-    Counter = otel_meter:counter(Meter, CounterName, ValueType,
-                                 #{description => CounterDesc,
-                                   unit => CounterUnit}),
+    Counter = otel_meter:create_counter(Meter, CounterName, ValueType,
+                                        #{description => CounterDesc,
+                                          unit => CounterUnit}),
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
                              name = CounterName,
@@ -546,9 +581,9 @@ kill_reader(_Config) ->
 
     %% TODO: agh! need to supervise ETS tables so readers can crash and not then
     %% lose all existing Instrument/View matches
-    Counter = otel_meter:counter(Meter, CounterName, ValueType,
-                                 #{description => CounterDesc,
-                                   unit => CounterUnit}),
+    Counter = otel_meter:create_counter(Meter, CounterName, ValueType,
+                                        #{description => CounterDesc,
+                                          unit => CounterUnit}),
 
     ?assertEqual(ok, otel_counter:add(Counter, 4, #{<<"c">> => <<"b">>})),
     ?assertEqual(ok, otel_counter:add(Counter, 5, #{<<"c">> => <<"b">>})),
@@ -572,12 +607,12 @@ kill_server(_Config) ->
     CounterUnit = kb,
     ValueType = integer,
 
-    ACounter = otel_meter:counter(Meter, ACounterName, ValueType,
-                                  #{description => CounterDesc,
-                                    unit => CounterUnit}),
-    Counter = otel_meter:counter(Meter, CounterName, ValueType,
-                                 #{description => CounterDesc,
-                                   unit => CounterUnit}),
+    ACounter = otel_meter:create_counter(Meter, ACounterName, ValueType,
+                                         #{description => CounterDesc,
+                                           unit => CounterUnit}),
+    Counter = otel_meter:create_counter(Meter, CounterName, ValueType,
+                                        #{description => CounterDesc,
+                                          unit => CounterUnit}),
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
                              name = CounterName,
@@ -598,12 +633,12 @@ kill_server(_Config) ->
 
     %% TODO: Agh! need to supervise ETS tables so readers can crash and not then
     %% lose all existing Instrument/View matches
-    ACounter = otel_meter:counter(Meter, ACounterName, ValueType,
-                                  #{description => CounterDesc,
-                                    unit => CounterUnit}),
-    Counter = otel_meter:counter(Meter, CounterName, ValueType,
-                                 #{description => CounterDesc,
-                                   unit => CounterUnit}),
+    ACounter = otel_meter:create_counter(Meter, ACounterName, ValueType,
+                                         #{description => CounterDesc,
+                                           unit => CounterUnit}),
+    Counter = otel_meter:create_counter(Meter, CounterName, ValueType,
+                                        #{description => CounterDesc,
+                                          unit => CounterUnit}),
 
     ?assertEqual(ok, otel_counter:add(Counter, 4, #{<<"c">> => <<"b">>})),
     ?assertEqual(ok, otel_counter:add(Counter, 5, #{<<"c">> => <<"b">>})),
@@ -629,14 +664,14 @@ observable_counter(_Config) ->
 
     ?assert(otel_meter_server:add_view(#{instrument_name => CounterName}, #{aggregation_module => otel_aggregation_sum})),
 
-    Counter = otel_meter:observable_counter(Meter, CounterName, ValueType,
-                                            fun(_Args) ->
-                                                    MeasurementAttributes = #{<<"a">> => <<"b">>},
-                                                    {4, MeasurementAttributes}
-                                            end,
-                                            [],
-                                            #{description => CounterDesc,
-                                              unit => CounterUnit}),
+    Counter = otel_meter:create_observable_counter(Meter, CounterName, ValueType,
+                                                   fun(_Args) ->
+                                                           MeasurementAttributes = #{<<"a">> => <<"b">>},
+                                                           {4, MeasurementAttributes}
+                                                   end,
+                                                   [],
+                                                   #{description => CounterDesc,
+                                                     unit => CounterUnit}),
 
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
@@ -666,14 +701,14 @@ observable_updown_counter(_Config) ->
 
     ?assert(otel_meter_server:add_view(#{instrument_name => CounterName}, #{aggregation_module => otel_aggregation_sum})),
 
-    Counter = otel_meter:observable_updowncounter(Meter, CounterName, ValueType,
-                                                  fun(_) ->
-                                                          MeasurementAttributes = #{<<"a">> => <<"b">>},
-                                                          {5, MeasurementAttributes}
-                                                  end,
-                                                  [],
-                                                  #{description => CounterDesc,
-                                                    unit => CounterUnit}),
+    Counter = otel_meter:create_observable_updowncounter(Meter, CounterName, ValueType,
+                                                         fun(_) ->
+                                                                 MeasurementAttributes = #{<<"a">> => <<"b">>},
+                                                                 {5, MeasurementAttributes}
+                                                         end,
+                                                         [],
+                                                         #{description => CounterDesc,
+                                                           unit => CounterUnit}),
 
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
@@ -703,13 +738,13 @@ observable_gauge(_Config) ->
 
     ?assert(otel_meter_server:add_view(#{instrument_name => CounterName}, #{aggregation_module => otel_aggregation_last_value})),
 
-    Counter = otel_meter:observable_gauge(Meter, CounterName, ValueType,
-                                          fun(_) ->
-                                                  {5, #{<<"a">> => <<"b">>}}
-                                          end,
-                                          [],
-                                          #{description => CounterDesc,
-                                            unit => CounterUnit}),
+    Counter = otel_meter:create_observable_gauge(Meter, CounterName, ValueType,
+                                                 fun(_) ->
+                                                         {5, #{<<"a">> => <<"b">>}}
+                                                 end,
+                                                 [],
+                                                 #{description => CounterDesc,
+                                                   unit => CounterUnit}),
 
     ?assertMatch(#instrument{meter = {DefaultMeter,_},
                              module = DefaultMeter,
@@ -743,15 +778,15 @@ multi_instrument_callback(_Config) ->
 
     ?assert(otel_meter_server:add_view(#{instrument_name => CounterName}, #{aggregation_module => otel_aggregation_sum})),
 
-    Counter = otel_meter:observable_counter(Meter, CounterName, ValueType,
-                                            undefined, [],
-                                            #{description => CounterDesc,
-                                              unit => Unit}),
+    Counter = otel_meter:create_observable_counter(Meter, CounterName, ValueType,
+                                                   undefined, [],
+                                                   #{description => CounterDesc,
+                                                     unit => Unit}),
 
-    Gauge = otel_meter:observable_gauge(Meter, GaugeName, ValueType,
-                                        undefined, [],
-                                        #{description => GaugeDesc,
-                                          unit => Unit}),
+    Gauge = otel_meter:create_observable_gauge(Meter, GaugeName, ValueType,
+                                               undefined, [],
+                                               #{description => GaugeDesc,
+                                                 unit => Unit}),
 
     otel_meter:register_callback(Meter, [Counter, Gauge],
                                  fun(_) ->


### PR DESCRIPTION
This is inefficient how it looks up the instrument and then sends a message with the measurement, but I wanted to get this done in multiple PRs instead of one giant one.

So for now the way the macros work is an instrument is looked up by its Meter+Name and then a call to `record` sends a message to the `otel_meter_server` as before.

Another difference is the Instruments are registered with `otel_meter_server` when created instead of matching with Views when a recording is done. This allows for Views to be added dynamically.