### PR TITLE
inefficient use of matchspec for view matching

### DIFF
--- a/apps/opentelemetry_api/include/opentelemetry.hrl
+++ b/apps/opentelemetry_api/include/opentelemetry.hrl
@@ -42,9 +42,9 @@
 
 %% Holds information about the instrumentation scope specified when
 %% getting a Tracer from the TracerProvider.
--record(instrumentation_scope, {name       :: unicode:unicode_binary() | undefined,
-                                version    :: unicode:unicode_binary() | undefined,
-                                schema_url :: uri_string:uri_string() | undefined}).
+-record(instrumentation_scope, {name       :: unicode:unicode_binary() | undefined | '_',
+                                version    :: unicode:unicode_binary() | undefined | '_',
+                                schema_url :: uri_string:uri_string() | undefined | '_'}).
 
 -record(span_ctx, {
           %% 128 bit int trace id

--- a/apps/opentelemetry_api_experimental/include/otel_metrics.hrl
+++ b/apps/opentelemetry_api_experimental/include/otel_metrics.hrl
@@ -1,12 +1,12 @@
--record(instrument, {module        :: module(),
-                     meter         :: otel_meter:t(),
-                     name          :: otel_instrument:name(),
-                     description   :: otel_instrument:description() | undefined,
-                     kind          :: otel_instrument:kind(),
-                     value_type    :: otel_instrument:value_type(),
-                     unit          :: otel_instrument:unit() | undefined,
-                     callback      :: otel_instrument:callback() | undefined,
-                     callback_args :: term() | undefined}).
+-record(instrument, {module        :: module() | '_',
+                     meter         :: otel_meter:t() | '_',
+                     name          :: otel_instrument:name() | '_',
+                     description   :: otel_instrument:description() | undefined | '_',
+                     kind          :: otel_instrument:kind() | '_',
+                     value_type    :: otel_instrument:value_type() | '_',
+                     unit          :: otel_instrument:unit() | undefined | '_',
+                     callback      :: otel_instrument:callback() | undefined | '_',
+                     callback_args :: term() | undefined | '_'}).
 
 -define(VALUE_TYPE_INTEGER, integer).
 -define(VALUE_TYPE_FLOAT, float).

--- a/apps/opentelemetry_experimental/src/otel_view.hrl
+++ b/apps/opentelemetry_experimental/src/otel_view.hrl
@@ -1,19 +1,6 @@
-
--record(selection,
-        {instrument_name = '_' :: otel_instrument:name() | '_' | undefined,
-         instrument_kind = '_' :: otel_instrument:kind() | '_',
-         meter_name = '_'      :: unicode:unicode_binary() | undefined | '_',
-         meter_version = '_'   :: unicode:unicode_binary() | undefined | '_',
-         schema_url = '_'      :: unicode:unicode_binary() | undefined | '_'}).
-
 -record(view,
         {name                    :: otel_instrument:name() | '_' | undefined,
-         selection               :: #selection{} | undefined,
-         %% instrument_kind      :: otel_instrument:kind(),
-         %% instrument_name      :: otel_instrument:name(),
-         %% meter_name           :: otel_meter:name(),
-         %% meter_version        :: otel_meter:version(),
-         %% meter_schema_url     :: otel_meter:schema_url(),
+         instrument_matchspec    :: ets:compiled_match_spec() | undefined,
          description             :: unicode:unicode_binary() | undefined,
          attribute_keys          :: [opentelemetry:attribute_key()] | undefined,
          aggregation_module      :: module() | undefined,


### PR DESCRIPTION
This patch uses ets:match_spec_run to compare a single View against a single Instrument. This is to be the smallest possible change when moving to use of a matchspec. The more efficient version will come with running the matchspec against the Instruments table to find matches. Though for new Instruments the inefficient version will remain.