### PR TITLE
bump api, sdk, exporter versions to beta releases

### DIFF
--- a/apps/opentelemetry/rebar.config
+++ b/apps/opentelemetry/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
-{deps, [{opentelemetry_api, "~> 1.1"}]}.
+{deps, [{opentelemetry_api, "~> 1.2.0-beta"}]}.
 
 {profiles,
  [{docs, [{edoc_opts,

--- a/apps/opentelemetry_api/src/opentelemetry_api.app.src
+++ b/apps/opentelemetry_api/src/opentelemetry_api.app.src
@@ -1,6 +1,6 @@
 {application, opentelemetry_api,
  [{description, "OpenTelemetry API"},
-  {vsn, "1.1.1"},
+  {vsn, "1.2.0-beta"},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/opentelemetry_exporter/rebar.config
+++ b/apps/opentelemetry_exporter/rebar.config
@@ -1,8 +1,8 @@
 {erl_opts, [debug_info]}.
 {deps, [{grpcbox, ">= 0.0.0"},
         {tls_certificate_check, "~> 1.11"},
-        {opentelemetry, "~> 1.1"},
-        {opentelemetry_api, "~> 1.1"}]}.
+        {opentelemetry, "~> 1.2.0-beta"},
+        {opentelemetry_api, "~> 1.3.0-beta"}]}.
 
 {grpc, [{protos, ["opentelemetry-proto/opentelemetry/proto/collector/trace/v1",
                   "opentelemetry-proto/opentelemetry/proto/collector/metrics/v1",

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.app.src
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.app.src
@@ -1,6 +1,6 @@
 {application, opentelemetry_exporter,
  [{description, "OpenTelemetry Protocol Exporter"},
-  {vsn, "1.2.2"},
+  {vsn, "1.3.0-beta"},
   {registered, []},
   {applications,
    [kernel,

--- a/docs.sh
+++ b/docs.sh
@@ -9,9 +9,9 @@ set -e
 
 rebar3 compile
 rebar3 edoc
-sdk_version=1.1.2
-api_version=1.1.1
-otlp_version=1.2.1
+sdk_version=1.2.0-beta
+api_version=1.2.0-beta
+otlp_version=1.3.0-beta
 zipkin_version=1.1.0
 semconv_version=0.2.0
 


### PR DESCRIPTION
Because of the large changes to support multiple tracer providers and batch processors I think it makes sense to release as a beta first.

The only concern I have is getting people to use it so we can then release the stable releases..