### PR TITLE
otel_span:set_status support for status code

### DIFF
--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -288,16 +288,18 @@ record_exception(SpanCtx, Class, Term, Message, Stacktrace, Attributes) when is_
 record_exception(_, _, _, _, _, _) ->
     false.
 
--spec set_status(SpanCtx, Status) -> boolean() when
-      Status :: opentelemetry:status() | undefined,
+-spec set_status(SpanCtx, StatusOrCode) -> boolean() when
+      StatusOrCode :: opentelemetry:status() | undefined | opentelemetry:status_code(),
       SpanCtx :: opentelemetry:span_ctx().
-set_status(SpanCtx=#span_ctx{span_sdk={Module, _}}, Status) when ?is_recording(SpanCtx) ->
-    Module:set_status(SpanCtx, Status);
 set_status(SpanCtx=#span_ctx{span_sdk={Module, _}}, Code) when ?is_recording(SpanCtx) andalso
                                                                (Code =:= ?OTEL_STATUS_UNSET orelse
                                                                 Code =:= ?OTEL_STATUS_OK orelse
                                                                 Code =:= ?OTEL_STATUS_ERROR)->
     Module:set_status(SpanCtx, opentelemetry:status(Code));
+set_status(SpanCtx=#span_ctx{span_sdk={Module, _}}, undefined) ->
+    Module:set_status(SpanCtx, opentelemetry:status(?OTEL_STATUS_UNSET));
+set_status(SpanCtx=#span_ctx{span_sdk={Module, _}}, Status) when ?is_recording(SpanCtx) ->
+    Module:set_status(SpanCtx, Status);
 set_status(_, _) ->
     false.
 

--- a/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
+++ b/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
@@ -210,12 +210,14 @@ update_span_data(_Config) ->
     UnsetStatus = opentelemetry:status(?OTEL_STATUS_UNSET),
     ?assertMatch(#status{code = ?OTEL_STATUS_UNSET, message = <<"">>}, UnsetStatus),
 
-    Status = opentelemetry:status(?OTEL_STATUS_OK, <<"This is Ok">>),
-    Status = opentelemetry:status(?OTEL_STATUS_OK),
-    ?assertMatch(#status{code = ?OTEL_STATUS_OK, message = <<"">>}, Status),
+    OkStatus = opentelemetry:status(?OTEL_STATUS_OK, <<"This is Ok">>),
+    OkStatus = opentelemetry:status(?OTEL_STATUS_OK),
+    ?assertMatch(#status{code = ?OTEL_STATUS_OK, message = <<"">>}, OkStatus),
 
-    otel_span:set_status(SpanCtx1, Status),
+    otel_span:set_status(SpanCtx1, UnsetStatus),
+    otel_span:set_status(SpanCtx1, undefined),
     otel_span:set_status(SpanCtx1, ?OTEL_STATUS_ERROR, <<"this is not ok">>),
+    otel_span:set_status(SpanCtx1, ?OTEL_STATUS_OK),
     otel_span:add_events(SpanCtx1, Events),
 
     ?assertMatch(SpanCtx1, ?current_span_ctx),


### PR DESCRIPTION
The ?set_status macro in otel_tracer.hrl indicates that otel_span:set_status/1 allows you to provide both a opentelemetry:status() or a opentelemetry:status_code()

This commit fixes the opentelemetry:status_code() case

Also, since the typing already supports undefined, translate it to UNSET