### PR TITLE
Using opentelemetry_semantic_conventions for record_exception

### DIFF
--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -29,6 +29,8 @@ defmodule OpenTelemetry.Span do
   - A Status (`t:OpenTelemetry.status/0`)
   """
 
+  require OpenTelemetry.SemanticConventions.Trace
+
   @type start_opts() :: :otel_span.start_opts()
 
   @doc """
@@ -137,9 +139,10 @@ defmodule OpenTelemetry.Span do
     exception_type = to_string(exception.__struct__)
 
     exception_attributes = [
-      {"exception.type", exception_type},
-      {"exception.message", Exception.message(exception)},
-      {"exception.stacktrace", Exception.format_stacktrace(trace)}
+      {OpenTelemetry.SemanticConventions.Trace.exception_type(), exception_type},
+      {OpenTelemetry.SemanticConventions.Trace.exception_message(), Exception.message(exception)},
+      {OpenTelemetry.SemanticConventions.Trace.exception_stacktrace(),
+       Exception.format_stacktrace(trace)}
     ]
 
     add_event(span_ctx, "exception", exception_attributes ++ attributes)

--- a/apps/opentelemetry_api/mix.exs
+++ b/apps/opentelemetry_api/mix.exs
@@ -11,6 +11,7 @@ defmodule OpenTelemetry.MixProject do
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: [
+        {:opentelemetry_semantic_conventions, "~> 0.2"},
         {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
         {:covertool, ">= 0.0.0", only: :test}
       ],

--- a/apps/opentelemetry_api/mix.lock
+++ b/apps/opentelemetry_api/mix.lock
@@ -11,4 +11,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.2", "dc72dfe17eb240552857465cc00cce390960d9a0c055c4ccd38b70629227e97c", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "fd23ae48d09b32eff49d4ced2b43c9f086d402ee4fd4fcb2d7fad97fa8823e75"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.2", "b99ca56bbce410e9d5ee4f9155a212e942e224e259c7ebbf8f2c86ac21d4fa3c", [:mix], [], "hexpm", "98d51bd64d5f6a2a9c6bb7586ee8129e27dfaab1140b5a4753f24dac0ba27d2f"},
+  "opentelemetry_semantic_conventions": {:hex, :opentelemetry_semantic_conventions, "0.2.0", "b67fe459c2938fcab341cb0951c44860c62347c005ace1b50f8402576f241435", [:mix, :rebar3], [], "hexpm", "d61fa1f5639ee8668d74b527e6806e0503efc55a42db7b5f39939d84c07d6895"},
 }

--- a/apps/opentelemetry_api/rebar.config
+++ b/apps/opentelemetry_api/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
-{deps, []}.
+{deps, [{opentelemetry_semantic_conventions, "~> 0.2"}]}.
 
 {profiles,
  [{docs, [{edoc_opts,

--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -42,6 +42,7 @@
          end_span/2]).
 
 -include("opentelemetry.hrl").
+-include_lib("opentelemetry_semantic_conventions/include/trace.hrl").
 
 -define(is_recording(SpanCtx), SpanCtx =/= undefined andalso SpanCtx#span_ctx.is_recording =:= true).
 -define(is_allowed_key(Key), is_atom(Key) orelse (is_binary(Key) andalso Key =/= <<"">>)).
@@ -263,8 +264,8 @@ record_exception(SpanCtx, Class, Term, Stacktrace, Attributes) when is_list(Attr
 record_exception(SpanCtx, Class, Term, Stacktrace, Attributes) when is_map(Attributes) ->
     {ok, ExceptionType} = otel_utils:format_binary_string("~0tP:~0tP", [Class, 10, Term, 10], [{chars_limit, 50}]),
     {ok, StacktraceString} = otel_utils:format_binary_string("~0tP", [Stacktrace, 10], [{chars_limit, 50}]),
-    ExceptionAttributes = #{<<"exception.type">> => ExceptionType,
-                            <<"exception.stacktrace">> => StacktraceString},
+    ExceptionAttributes = #{?EXCEPTION_TYPE => ExceptionType,
+                            ?EXCEPTION_STACKTRACE => StacktraceString},
     add_event(SpanCtx, <<"exception">>, maps:merge(ExceptionAttributes, Attributes));
 record_exception(_, _, _, _, _) ->
     false.
@@ -281,9 +282,9 @@ record_exception(SpanCtx, Class, Term, Message, Stacktrace, Attributes) when is_
 record_exception(SpanCtx, Class, Term, Message, Stacktrace, Attributes) when is_map(Attributes) ->
     {ok, ExceptionType} = otel_utils:format_binary_string("~0tP:~0tP", [Class, 10, Term, 10], [{chars_limit, 50}]),
     {ok, StacktraceString} = otel_utils:format_binary_string("~0tP", [Stacktrace, 10], [{chars_limit, 50}]),
-    ExceptionAttributes = #{<<"exception.type">> => ExceptionType,
-                            <<"exception.stacktrace">> => StacktraceString,
-                            <<"exception.message">> => Message},
+    ExceptionAttributes = #{?EXCEPTION_TYPE => ExceptionType,
+                            ?EXCEPTION_STACKTRACE => StacktraceString,
+                            ?EXCEPTION_MESSAGE => Message},
     add_event(SpanCtx, <<"exception">>, maps:merge(ExceptionAttributes, Attributes));
 record_exception(_, _, _, _, _, _) ->
     false.


### PR DESCRIPTION
Use constant from opentelemetry_semantic_conventions in record_exception instead of binary (or string in Elixir). This changes apply to both Erlang and Elixir API.