### PR TITLE
Have set_status check is_recording in all cases

### DIFF
--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -297,7 +297,7 @@ set_status(SpanCtx=#span_ctx{span_sdk={Module, _}}, Code) when ?is_recording(Spa
                                                                 Code =:= ?OTEL_STATUS_OK orelse
                                                                 Code =:= ?OTEL_STATUS_ERROR)->
     Module:set_status(SpanCtx, opentelemetry:status(Code));
-set_status(SpanCtx=#span_ctx{span_sdk={Module, _}}, undefined) ->
+set_status(SpanCtx=#span_ctx{span_sdk={Module, _}}, undefined) when ?is_recording(SpanCtx) ->
     Module:set_status(SpanCtx, opentelemetry:status(?OTEL_STATUS_UNSET));
 set_status(SpanCtx=#span_ctx{span_sdk={Module, _}}, Status) when ?is_recording(SpanCtx) ->
     Module:set_status(SpanCtx, Status);


### PR DESCRIPTION
Very minor: ?is_recording macro is missing when setting status as undefined (noticed when reading the code again from https://github.com/open-telemetry/opentelemetry-erlang/pull/519) 