### PR TITLE
Move is_monotonic check to the SDK

### DIFF
--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -868,9 +868,9 @@ record_exception_works(Config) ->
             otel_span:end_span(SpanCtx),
             [Span] = assert_exported(Tid, SpanCtx),
             [Event] = otel_events:list(Span#span.events),
-            ?assertEqual(<<"exception">>, Event#event.name),
-            ?assertEqual(#{<<"exception.type">> => <<"throw:my_error">>,
-                           <<"exception.stacktrace">> => list_to_binary(io_lib:format("~p", [Stacktrace], [{chars_limit, 50}])),
+            ?assertEqual(exception, Event#event.name),
+            ?assertEqual(#{'exception.type' => <<"throw:my_error">>,
+                           'exception.stacktrace' => list_to_binary(io_lib:format("~p", [Stacktrace], [{chars_limit, 50}])),
                            <<"some-attribute">> => <<"value">>},
                          otel_attributes:map(Event#event.attributes)),
             ok
@@ -888,10 +888,10 @@ record_exception_with_message_works(Config) ->
             otel_span:end_span(SpanCtx),
             [Span] = assert_exported(Tid, SpanCtx),
             [Event] = otel_events:list(Span#span.events),
-            ?assertEqual(<<"exception">>, Event#event.name),
-            ?assertEqual(#{<<"exception.type">> => <<"throw:my_error">>,
-                           <<"exception.stacktrace">> => list_to_binary(io_lib:format("~p", [Stacktrace], [{chars_limit, 50}])),
-                           <<"exception.message">> => <<"My message">>,
+            ?assertEqual(exception, Event#event.name),
+            ?assertEqual(#{'exception.type' => <<"throw:my_error">>,
+                           'exception.stacktrace' => list_to_binary(io_lib:format("~p", [Stacktrace], [{chars_limit, 50}])),
+                           'exception.message' => <<"My message">>,
                            <<"some-attribute">> => <<"value">>},
                          otel_attributes:map(Event#event.attributes)
                         ),
@@ -916,7 +916,7 @@ dropped_attributes(Config) ->
 
 truncated_binary_attributes(_Config) ->
     InfinityLengthAttributes = otel_attributes:new(#{<<"attr-1">> => <<"abcde">>,
-                                                   <<"attr-2">> => [<<"a">>, <<"abcde">>, <<"abcde">>]},
+                                                     <<"attr-2">> => [<<"a">>, <<"abcde">>, <<"abcde">>]},
                                                  128, infinity),
 
     %% when length limit is inifinity

--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -266,7 +266,7 @@ record_exception(SpanCtx, Class, Term, Stacktrace, Attributes) when is_map(Attri
     {ok, StacktraceString} = otel_utils:format_binary_string("~0tP", [Stacktrace, 10], [{chars_limit, 50}]),
     ExceptionAttributes = #{?EXCEPTION_TYPE => ExceptionType,
                             ?EXCEPTION_STACKTRACE => StacktraceString},
-    add_event(SpanCtx, <<"exception">>, maps:merge(ExceptionAttributes, Attributes));
+    add_event(SpanCtx, 'exception', maps:merge(ExceptionAttributes, Attributes));
 record_exception(_, _, _, _, _) ->
     false.
 
@@ -285,7 +285,7 @@ record_exception(SpanCtx, Class, Term, Message, Stacktrace, Attributes) when is_
     ExceptionAttributes = #{?EXCEPTION_TYPE => ExceptionType,
                             ?EXCEPTION_STACKTRACE => StacktraceString,
                             ?EXCEPTION_MESSAGE => Message},
-    add_event(SpanCtx, <<"exception">>, maps:merge(ExceptionAttributes, Attributes));
+    add_event(SpanCtx, 'exception', maps:merge(ExceptionAttributes, Attributes));
 record_exception(_, _, _, _, _, _) ->
     false.
 

--- a/apps/opentelemetry_api_experimental/src/otel_counter.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_counter.erl
@@ -33,16 +33,9 @@ create(Meter, Name, Opts) ->
     otel_meter:create_counter(Meter, Name, Opts).
 
 -spec add(otel_meter:t(), otel_instrument:name(), number(), opentelemetry:attributes_map()) -> ok.
-add(Meter, Name, Number, Attributes) when Number >= 0 ->
-    otel_meter:record(Meter, Name, Number, Attributes);
-add(_, Name, _, _) ->
-    ?LOG_INFO("Counter instrument ~p does not support negative values.", [Name]),
-    ok.
+add(Meter, Name, Number, Attributes) ->
+    otel_meter:record(Meter, Name, Number, Attributes).
 
 -spec add(otel_instrument:t(), number(), opentelemetry:attributes_map()) -> ok.
-add(Instrument=#instrument{module=Module}, Number, Attributes)
-  when Number >= 0 ->
-    Module:record(Instrument, Number, Attributes);
-add(#instrument{name=Name},  _, _) ->
-    ?LOG_INFO("Counter instrument ~p does not support negative values.", [Name]),
-    ok.
+add(Instrument=#instrument{module=Module}, Number, Attributes) ->
+    Module:record(Instrument, Number, Attributes).

--- a/apps/opentelemetry_api_experimental/src/otel_instrument.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_instrument.erl
@@ -68,5 +68,7 @@ is_monotonic(#instrument{kind=?KIND_COUNTER}) ->
     true;
 is_monotonic(#instrument{kind=?KIND_OBSERVABLE_COUNTER}) ->
     true;
+is_monotonic(#instrument{kind=?KIND_HISTOGRAM}) ->
+    true;
 is_monotonic(_) ->
     false.

--- a/apps/opentelemetry_experimental/src/otel_aggregation.erl
+++ b/apps/opentelemetry_experimental/src/otel_aggregation.erl
@@ -26,9 +26,11 @@
               options/0,
               temporality/0]).
 
--callback init(Key, Options) -> Aggregation when
-      Key :: key(),
-      Options :: options(),
+%% Returns the aggregation's record as it is seen and updated by
+%% the aggregation module in the metrics table.
+-callback init(ViewAggregation, Attributes) -> Aggregation when
+      ViewAggregation :: #view_aggregation{},
+      Attributes :: opentelemetry:attributes_map(),
       Aggregation :: t().
 
 -callback aggregate(Table, ViewAggregation, Value, Attributes) -> boolean() when
@@ -37,18 +39,14 @@
       Value :: number(),
       Attributes :: opentelemetry:attributes_map().
 
--callback checkpoint(Table, Name, ReaderId, Temporality, CollectionStartTime) -> ok when
+-callback checkpoint(Table, ViewAggregation, CollectionStartTime) -> ok when
       Table :: ets:table(),
-      Name :: atom(),
-      ReaderId :: reference(),
-      Temporality :: temporality(),
+      ViewAggregation :: #view_aggregation{},
       CollectionStartTime :: integer().
 
--callback collect(Table, Name, ReaderId, Temporality, CollectionStartTime) -> [tuple()] when
+-callback collect(Table, ViewAggregation, CollectionStartTime) -> [tuple()] when
       Table :: ets:table(),
-      Name :: atom(),
-      ReaderId :: reference(),
-      Temporality :: temporality(),
+      ViewAggregation :: #view_aggregation{},
       CollectionStartTime :: integer().
 
 maybe_init_aggregate(MetricsTab, ViewAggregation=#view_aggregation{aggregation_module=AggregationModule},

--- a/apps/opentelemetry_experimental/src/otel_aggregation_drop.erl
+++ b/apps/opentelemetry_experimental/src/otel_aggregation_drop.erl
@@ -4,8 +4,8 @@
 
 -export([init/2,
          aggregate/4,
-         checkpoint/5,
-         collect/5]).
+         checkpoint/3,
+         collect/3]).
 
 -include("otel_metrics.hrl").
 
@@ -19,8 +19,8 @@ init(_, _) ->
 aggregate(_, _, _, _) ->
     true.
 
-checkpoint(_, _, _, _, _) ->
+checkpoint(_, _, _) ->
     ok.
 
-collect(_, _, _, _, _) ->
+collect(_, _, _) ->
     [].

--- a/apps/opentelemetry_experimental/src/otel_aggregation_sum.erl
+++ b/apps/opentelemetry_experimental/src/otel_aggregation_sum.erl
@@ -26,18 +26,26 @@
 
 -include("otel_metrics.hrl").
 -include_lib("opentelemetry_api_experimental/include/otel_metrics.hrl").
+-include("otel_view.hrl").
 
 -type t() :: #sum_aggregation{}.
 
 -export_type([t/0]).
 
-init(Key, _) ->
+init(#view_aggregation{name=Name,
+                       reader=ReaderId}, Attributes) ->
+    Key = {Name, Attributes, ReaderId},
     #sum_aggregation{key=Key,
                      start_time_unix_nano=erlang:system_time(nanosecond),
                      int_value=0,
                      float_value=0.0}.
 
-aggregate(Tab, Key, Value, _Options) when is_integer(Value) ->
+aggregate(Tab, #view_aggregation{name=Name,
+                                 reader=ReaderId,
+                                 is_monotonic=IsMonotonic}, Value, Attributes)
+  when is_integer(Value) andalso
+       ((IsMonotonic andalso Value >= 0) orelse not IsMonotonic) ->
+    Key = {Name, Attributes, ReaderId},
     try
         _ = ets:update_counter(Tab, Key, {#sum_aggregation.int_value, Value}),
         true
@@ -53,7 +61,11 @@ aggregate(Tab, Key, Value, _Options) when is_integer(Value) ->
             %% true
             false
     end;
-aggregate(Tab, Key, Value, _) ->
+aggregate(Tab, #view_aggregation{name=Name,
+                                 reader=ReaderId,
+                                 is_monotonic=IsMonotonic}, Value, Attributes)
+  when (IsMonotonic andalso Value >= 0.0) orelse not IsMonotonic ->
+    Key = {Name, Attributes, ReaderId},
     MS = [{#sum_aggregation{key=Key,
                             start_time_unix_nano='$1',
                             checkpoint='$2',
@@ -65,7 +77,10 @@ aggregate(Tab, Key, Value, _) ->
                               checkpoint='$2',
                               int_value='$3',
                               float_value={'+', '$4', {const, Value}}}}]}],
-    1 =:= ets:select_replace(Tab, MS).
+    1 =:= ets:select_replace(Tab, MS);
+aggregate(_Tab, #view_aggregation{name=_Name,
+                                  is_monotonic=_IsMonotonic}, _Value, _) ->
+    false.
 
 -dialyzer({nowarn_function, checkpoint/5}).
 checkpoint(Tab, Name, ReaderPid, ?AGGREGATION_TEMPORALITY_DELTA, CollectionStartNano) ->

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -388,11 +388,8 @@ handle_measurement(Meter, Name, Number, Attributes, ViewAggregationsTab, Metrics
     update_aggregations(Number, Attributes, Matches, MetricsTab).
 
 update_aggregations(Value, Attributes, ViewAggregations, MetricsTab) ->
-    lists:foreach(fun(#view_aggregation{name=Name,
-                                        reader=ReaderId,
-                                        aggregation_module=AggregationModule,
-                                        aggregation_options=Options}) ->
-                          otel_aggregation:maybe_init_aggregate(MetricsTab, AggregationModule, {Name, Attributes, ReaderId}, Value, Options);
+    lists:foreach(fun(ViewAggregation=#view_aggregation{}) ->
+                          otel_aggregation:maybe_init_aggregate(MetricsTab, ViewAggregation, Value, Attributes);
                      (_) ->
                           ok
                   end, ViewAggregations).

--- a/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
@@ -348,8 +348,8 @@ provider_test(_Config) ->
 
     otel_meter_server:force_flush(),
 
-    ?assertSumReceive(a_counter, <<"counter description">>, kb, [{16.0, #{<<"c">> => <<"b">>}}]),
-    ?assertSumReceive(view_c, <<"counter description">>, kb, [{16.0, #{<<"c">> => <<"b">>}}]),
+    ?assertSumReceive(a_counter, <<"counter description">>, kb, [{6.0, #{<<"c">> => <<"b">>}}]),
+    ?assertSumReceive(view_c, <<"counter description">>, kb, [{6.0, #{<<"c">> => <<"b">>}}]),
 
     %% sum agg is default delta temporality so counter will reset
     ?assertEqual(ok, otel_counter:add(Counter, 7, #{<<"c">> => <<"b">>})),

--- a/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
@@ -274,7 +274,7 @@ float_histogram(_Config) ->
                                          min=Min,
                                          max=Max,
                                          sum=Sum}  <- Datapoints],
-            ?assertEqual([], [{#{<<"c">> => <<"b">>}, {0,1,1,2,0,0,0,0,0,0}, 5, 10.3, 31.1}]
+            ?assertEqual([], [{#{<<"c">> => <<"b">>}, [0,1,1,2,0,0,0,0,0,0], 5, 10.3, 31.1}]
                          -- AttributeBuckets, AttributeBuckets)
     after
         5000 ->
@@ -348,8 +348,8 @@ provider_test(_Config) ->
 
     otel_meter_server:force_flush(),
 
-    ?assertSumReceive(a_counter, <<"counter description">>, kb, [{6.0, #{<<"c">> => <<"b">>}}]),
-    ?assertSumReceive(view_c, <<"counter description">>, kb, [{6.0, #{<<"c">> => <<"b">>}}]),
+    ?assertSumReceive(a_counter, <<"counter description">>, kb, [{16.0, #{<<"c">> => <<"b">>}}]),
+    ?assertSumReceive(view_c, <<"counter description">>, kb, [{16.0, #{<<"c">> => <<"b">>}}]),
 
     %% sum agg is default delta temporality so counter will reset
     ?assertEqual(ok, otel_counter:add(Counter, 7, #{<<"c">> => <<"b">>})),

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -509,8 +509,8 @@ verify_export(Config) ->
     ?assertMatch([#{spans := [_, _]}],
                  otel_otlp_traces:to_proto_by_instrumentation_scope(Tid)),
     Resource = otel_resource_env_var:get_resource([]),
-    ?assertEqual(otel_attributes:new([{<<"service.name">>,<<"my-test-service">>},
-                                      {<<"service.version">>,<<"98da75ea6d38724743bf42b45565049238d86b3f">>}], 128, 255), otel_resource:attributes(Resource)),
+    ?assertEqual(otel_attributes:new([{'service.name',<<"my-test-service">>},
+                                      {'service.version',<<"98da75ea6d38724743bf42b45565049238d86b3f">>}], 128, 255), otel_resource:attributes(Resource)),
     ?assertMatch(ok, opentelemetry_exporter:export(traces, Tid, Resource, State)),
 
     ok.


### PR DESCRIPTION
The API needs to not log about bad data to instruments, this removes a check on counters being positive measurements.

It does so by changing the SDK's aggregation api to accept a `#view_aggregation{}` which contains `is_monotonic`.

I'm not ready to call this api of the SDK done, but a good step for a PR.