### PR TITLE
Elixir semcomv: use functions instead of macros

### DIFF
--- a/apps/opentelemetry_semantic_conventions/README.md
+++ b/apps/opentelemetry_semantic_conventions/README.md
@@ -24,6 +24,5 @@ You can then use the macros for the attribute keys:
 You could also use `OpenTelemetry.SemanticConventions.Logs`, `OpenTelemetry.SemanticConventions.Resource` or
 `OpenTelemetry.SemanticConventions.Trace` modules.
 
-    iex> require OpenTelemetry.SemanticConventions.Logs
-    ...> OpenTelemetry.SemanticConventions.Logs.event_name()
+    iex> OpenTelemetry.SemanticConventions.Logs.event_name()
     :"event.name"

--- a/apps/opentelemetry_semantic_conventions/lib/open_telemetry/semantic_conventions/logs.ex
+++ b/apps/opentelemetry_semantic_conventions/lib/open_telemetry/semantic_conventions/logs.ex
@@ -2,27 +2,23 @@ defmodule OpenTelemetry.SemanticConventions.Logs do
   @doc """
   The schema url for telemetry resources.
 
-      iex> require OpenTelemetry.SemanticConventions.Logs
-      ...> OpenTelemetry.SemanticConventions.Logs.logs_schema_url()
+      iex> OpenTelemetry.SemanticConventions.Logs.logs_schema_url()
       "https://opentelemetry.io/schemas/1.13.0"
   """
   @spec logs_schema_url :: String.t()
-  defmacro logs_schema_url do
+  def logs_schema_url do
     "https://opentelemetry.io/schemas/1.13.0"
   end
-
   @doc """
   The name identifies the event
 
-      iex> require OpenTelemetry.SemanticConventions.Logs
-      ...> OpenTelemetry.SemanticConventions.Logs.event_name()
+      iex> OpenTelemetry.SemanticConventions.Logs.event_name()
       :"event.name"
   """
   @spec event_name :: :"event.name"
-  defmacro event_name do
+  def event_name do
     :"event.name"
   end
-
   @doc """
   The domain identifies the context in which an event happened. An event name is unique only within a domain
 
@@ -32,12 +28,11 @@ defmodule OpenTelemetry.SemanticConventions.Logs do
   `event.domain`, so this allows for two events in different domains to
   have same `event.name`, yet be unrelated events
 
-      iex> require OpenTelemetry.SemanticConventions.Logs
-      ...> OpenTelemetry.SemanticConventions.Logs.event_domain()
+      iex> OpenTelemetry.SemanticConventions.Logs.event_domain()
       :"event.domain"
   """
   @spec event_domain :: :"event.domain"
-  defmacro event_domain do
+  def event_domain do
     :"event.domain"
   end
 end

--- a/apps/opentelemetry_semantic_conventions/lib/open_telemetry/semantic_conventions/resource.ex
+++ b/apps/opentelemetry_semantic_conventions/lib/open_telemetry/semantic_conventions/resource.ex
@@ -2,15 +2,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
   @doc """
   The schema url for telemetry resources.
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.resource_schema_url()
+      iex> OpenTelemetry.SemanticConventions.Resource.resource_schema_url()
       "https://opentelemetry.io/schemas/1.13.0"
   """
   @spec resource_schema_url :: String.t()
-  defmacro resource_schema_url do
+  def resource_schema_url do
     "https://opentelemetry.io/schemas/1.13.0"
   end
-
   @doc """
   Array of brand name and version separated by a space
 
@@ -18,15 +16,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (navigator.userAgentData.brands)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.browser_brands()
+      iex> OpenTelemetry.SemanticConventions.Resource.browser_brands()
       :"browser.brands"
   """
   @spec browser_brands :: :"browser.brands"
-  defmacro browser_brands do
+  def browser_brands do
     :"browser.brands"
   end
-
   @doc """
   The platform on which the browser is running
 
@@ -35,15 +31,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
   This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (navigator.userAgentData.platform). If unavailable, the legacy `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the values to be consistent.
   The list of possible values is defined in the [W3C User-Agent Client Hints specification](https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform). Note that some (but not all) of these values can overlap with values in the [os.type and os.name attributes](./os.md). However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.browser_platform()
+      iex> OpenTelemetry.SemanticConventions.Resource.browser_platform()
       :"browser.platform"
   """
   @spec browser_platform :: :"browser.platform"
-  defmacro browser_platform do
+  def browser_platform do
     :"browser.platform"
   end
-
   @doc """
   Full user-agent string provided by the browser
 
@@ -51,39 +45,33 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   The user-agent value SHOULD be provided only from browsers that do not have a mechanism to retrieve brands and platform individually from the User-Agent Client Hints API. To retrieve the value, the legacy `navigator.userAgent` API can be used
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.browser_user_agent()
+      iex> OpenTelemetry.SemanticConventions.Resource.browser_user_agent()
       :"browser.user_agent"
   """
   @spec browser_user_agent :: :"browser.user_agent"
-  defmacro browser_user_agent do
+  def browser_user_agent do
     :"browser.user_agent"
   end
-
   @doc """
   Name of the cloud provider
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.cloud_provider()
+      iex> OpenTelemetry.SemanticConventions.Resource.cloud_provider()
       :"cloud.provider"
   """
   @spec cloud_provider :: :"cloud.provider"
-  defmacro cloud_provider do
+  def cloud_provider do
     :"cloud.provider"
   end
-
   @doc """
   The cloud account ID the resource is assigned to
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.cloud_account_id()
+      iex> OpenTelemetry.SemanticConventions.Resource.cloud_account_id()
       :"cloud.account.id"
   """
   @spec cloud_account_id :: :"cloud.account.id"
-  defmacro cloud_account_id do
+  def cloud_account_id do
     :"cloud.account.id"
   end
-
   @doc """
   The geographical region the resource is running
 
@@ -91,15 +79,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://intl.cloud.tencent.com/document/product/213/6091)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.cloud_region()
+      iex> OpenTelemetry.SemanticConventions.Resource.cloud_region()
       :"cloud.region"
   """
   @spec cloud_region :: :"cloud.region"
-  defmacro cloud_region do
+  def cloud_region do
     :"cloud.region"
   end
-
   @doc """
   Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running
 
@@ -107,15 +93,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   Availability zones are called "zones" on Alibaba Cloud and Google Cloud
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.cloud_availability_zone()
+      iex> OpenTelemetry.SemanticConventions.Resource.cloud_availability_zone()
       :"cloud.availability_zone"
   """
   @spec cloud_availability_zone :: :"cloud.availability_zone"
-  defmacro cloud_availability_zone do
+  def cloud_availability_zone do
     :"cloud.availability_zone"
   end
-
   @doc """
   The cloud platform in use
 
@@ -123,99 +107,83 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   The prefix of the service SHOULD match the one specified in `cloud.provider`
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.cloud_platform()
+      iex> OpenTelemetry.SemanticConventions.Resource.cloud_platform()
       :"cloud.platform"
   """
   @spec cloud_platform :: :"cloud.platform"
-  defmacro cloud_platform do
+  def cloud_platform do
     :"cloud.platform"
   end
-
   @doc """
   The Amazon Resource Name (ARN) of an [ECS container instance](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_ecs_container_arn()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_ecs_container_arn()
       :"aws.ecs.container.arn"
   """
   @spec aws_ecs_container_arn :: :"aws.ecs.container.arn"
-  defmacro aws_ecs_container_arn do
+  def aws_ecs_container_arn do
     :"aws.ecs.container.arn"
   end
-
   @doc """
   The ARN of an [ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_ecs_cluster_arn()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_ecs_cluster_arn()
       :"aws.ecs.cluster.arn"
   """
   @spec aws_ecs_cluster_arn :: :"aws.ecs.cluster.arn"
-  defmacro aws_ecs_cluster_arn do
+  def aws_ecs_cluster_arn do
     :"aws.ecs.cluster.arn"
   end
-
   @doc """
   The [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) for an ECS task
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_ecs_launchtype()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_ecs_launchtype()
       :"aws.ecs.launchtype"
   """
   @spec aws_ecs_launchtype :: :"aws.ecs.launchtype"
-  defmacro aws_ecs_launchtype do
+  def aws_ecs_launchtype do
     :"aws.ecs.launchtype"
   end
-
   @doc """
   The ARN of an [ECS task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_ecs_task_arn()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_ecs_task_arn()
       :"aws.ecs.task.arn"
   """
   @spec aws_ecs_task_arn :: :"aws.ecs.task.arn"
-  defmacro aws_ecs_task_arn do
+  def aws_ecs_task_arn do
     :"aws.ecs.task.arn"
   end
-
   @doc """
   The task definition family this task definition is a member of
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_ecs_task_family()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_ecs_task_family()
       :"aws.ecs.task.family"
   """
   @spec aws_ecs_task_family :: :"aws.ecs.task.family"
-  defmacro aws_ecs_task_family do
+  def aws_ecs_task_family do
     :"aws.ecs.task.family"
   end
-
   @doc """
   The revision for this task definition
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_ecs_task_revision()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_ecs_task_revision()
       :"aws.ecs.task.revision"
   """
   @spec aws_ecs_task_revision :: :"aws.ecs.task.revision"
-  defmacro aws_ecs_task_revision do
+  def aws_ecs_task_revision do
     :"aws.ecs.task.revision"
   end
-
   @doc """
   The ARN of an EKS cluster
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_eks_cluster_arn()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_eks_cluster_arn()
       :"aws.eks.cluster.arn"
   """
   @spec aws_eks_cluster_arn :: :"aws.eks.cluster.arn"
-  defmacro aws_eks_cluster_arn do
+  def aws_eks_cluster_arn do
     :"aws.eks.cluster.arn"
   end
-
   @doc """
   The name(s) of the AWS log group(s) an application is writing to
 
@@ -223,15 +191,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   Multiple log groups must be supported for cases like multi-container applications, where a single application has sidecar containers, and each write to their own log group
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_log_group_names()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_log_group_names()
       :"aws.log.group.names"
   """
   @spec aws_log_group_names :: :"aws.log.group.names"
-  defmacro aws_log_group_names do
+  def aws_log_group_names do
     :"aws.log.group.names"
   end
-
   @doc """
   The Amazon Resource Name(s) (ARN) of the AWS log group(s)
 
@@ -239,27 +205,23 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   See the [log group ARN format documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_log_group_arns()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_log_group_arns()
       :"aws.log.group.arns"
   """
   @spec aws_log_group_arns :: :"aws.log.group.arns"
-  defmacro aws_log_group_arns do
+  def aws_log_group_arns do
     :"aws.log.group.arns"
   end
-
   @doc """
   The name(s) of the AWS log stream(s) an application is writing to
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_log_stream_names()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_log_stream_names()
       :"aws.log.stream.names"
   """
   @spec aws_log_stream_names :: :"aws.log.stream.names"
-  defmacro aws_log_stream_names do
+  def aws_log_stream_names do
     :"aws.log.stream.names"
   end
-
   @doc """
   The ARN(s) of the AWS log stream(s)
 
@@ -267,87 +229,73 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   See the [log stream ARN format documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format). One log group can contain several log streams, so these ARNs necessarily identify both a log group and a log stream
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.aws_log_stream_arns()
+      iex> OpenTelemetry.SemanticConventions.Resource.aws_log_stream_arns()
       :"aws.log.stream.arns"
   """
   @spec aws_log_stream_arns :: :"aws.log.stream.arns"
-  defmacro aws_log_stream_arns do
+  def aws_log_stream_arns do
     :"aws.log.stream.arns"
   end
-
   @doc """
   Container name used by container runtime
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.container_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.container_name()
       :"container.name"
   """
   @spec container_name :: :"container.name"
-  defmacro container_name do
+  def container_name do
     :"container.name"
   end
-
   @doc """
   Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.container_id()
+      iex> OpenTelemetry.SemanticConventions.Resource.container_id()
       :"container.id"
   """
   @spec container_id :: :"container.id"
-  defmacro container_id do
+  def container_id do
     :"container.id"
   end
-
   @doc """
   The container runtime managing this container
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.container_runtime()
+      iex> OpenTelemetry.SemanticConventions.Resource.container_runtime()
       :"container.runtime"
   """
   @spec container_runtime :: :"container.runtime"
-  defmacro container_runtime do
+  def container_runtime do
     :"container.runtime"
   end
-
   @doc """
   Name of the image the container was built on
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.container_image_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.container_image_name()
       :"container.image.name"
   """
   @spec container_image_name :: :"container.image.name"
-  defmacro container_image_name do
+  def container_image_name do
     :"container.image.name"
   end
-
   @doc """
   Container image tag
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.container_image_tag()
+      iex> OpenTelemetry.SemanticConventions.Resource.container_image_tag()
       :"container.image.tag"
   """
   @spec container_image_tag :: :"container.image.tag"
-  defmacro container_image_tag do
+  def container_image_tag do
     :"container.image.tag"
   end
-
   @doc """
   Name of the [deployment environment](https://en.wikipedia.org/wiki/Deployment_environment) (aka deployment tier)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.deployment_environment()
+      iex> OpenTelemetry.SemanticConventions.Resource.deployment_environment()
       :"deployment.environment"
   """
   @spec deployment_environment :: :"deployment.environment"
-  defmacro deployment_environment do
+  def deployment_environment do
     :"deployment.environment"
   end
-
   @doc """
   A unique identifier representing the device
 
@@ -355,15 +303,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   The device identifier MUST only be defined using the values outlined below. This value is not an advertising identifier and MUST NOT be used as such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids) on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.device_id()
+      iex> OpenTelemetry.SemanticConventions.Resource.device_id()
       :"device.id"
   """
   @spec device_id :: :"device.id"
-  defmacro device_id do
+  def device_id do
     :"device.id"
   end
-
   @doc """
   The model identifier for the device
 
@@ -371,15 +317,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   It's recommended this value represents a machine readable version of the model identifier rather than the market or consumer-friendly name of the device
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.device_model_identifier()
+      iex> OpenTelemetry.SemanticConventions.Resource.device_model_identifier()
       :"device.model.identifier"
   """
   @spec device_model_identifier :: :"device.model.identifier"
-  defmacro device_model_identifier do
+  def device_model_identifier do
     :"device.model.identifier"
   end
-
   @doc """
   The marketing name for the device model
 
@@ -387,15 +331,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   It's recommended this value represents a human readable version of the device model rather than a machine readable alternative
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.device_model_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.device_model_name()
       :"device.model.name"
   """
   @spec device_model_name :: :"device.model.name"
-  defmacro device_model_name do
+  def device_model_name do
     :"device.model.name"
   end
-
   @doc """
   The name of the device manufacturer
 
@@ -403,15 +345,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps SHOULD hardcode the value `Apple`
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.device_manufacturer()
+      iex> OpenTelemetry.SemanticConventions.Resource.device_manufacturer()
       :"device.manufacturer"
   """
   @spec device_manufacturer :: :"device.manufacturer"
-  defmacro device_manufacturer do
+  def device_manufacturer do
     :"device.manufacturer"
   end
-
   @doc """
   The name of the single function that this runtime instance executes
 
@@ -422,11 +362,11 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
   function (which may be stored in the
   [`code.namespace`/`code.function`](../../trace/semantic_conventions/span-general.md#source-code-attributes)
   span attributes).
-
+  
   For some cloud providers, the above definition is ambiguous. The following
   definition of function name MUST be used for this attribute
   (and consequently the span name) for the listed cloud providers/products:
-
+  
   * **Azure:**  The full name `<FUNCAPP>/<FUNC>`, i.e., function app name
     followed by a forward slash followed by the function name (this form
     can also be seen in the resource JSON for the function).
@@ -434,15 +374,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
     app can host multiple functions that would usually share
     a TracerProvider (see also the `faas.id` attribute)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.faas_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.faas_name()
       :"faas.name"
   """
   @spec faas_name :: :"faas.name"
-  defmacro faas_name do
+  def faas_name do
     :"faas.name"
   end
-
   @doc """
   The unique ID of the single function that this runtime instance executes
 
@@ -450,9 +388,9 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   On some cloud providers, it may not be possible to determine the full ID at startup,
   so consider setting `faas.id` as a span attribute instead.
-
+  
   The exact value to use for `faas.id` depends on the cloud provider:
-
+  
   * **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
     Take care not to use the "invoked ARN" directly but replace any
     [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html)
@@ -465,22 +403,20 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
     This means that a span attribute MUST be used, as an Azure function app can host multiple functions that would usually share
     a TracerProvider
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.faas_id()
+      iex> OpenTelemetry.SemanticConventions.Resource.faas_id()
       :"faas.id"
   """
   @spec faas_id :: :"faas.id"
-  defmacro faas_id do
+  def faas_id do
     :"faas.id"
   end
-
   @doc """
   The immutable version of the function being executed
 
   ### Notes
 
   Depending on the cloud provider and platform, use:
-
+  
   * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
     (an integer represented as a decimal string).
   * **Google Cloud Run:** The [revision](https://cloud.google.com/run/docs/managing/revisions)
@@ -489,15 +425,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
     [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
   * **Azure Functions:** Not applicable. Do not set this attribute
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.faas_version()
+      iex> OpenTelemetry.SemanticConventions.Resource.faas_version()
       :"faas.version"
   """
   @spec faas_version :: :"faas.version"
-  defmacro faas_version do
+  def faas_version do
     :"faas.version"
   end
-
   @doc """
   The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version
 
@@ -505,15 +439,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   * **AWS Lambda:** Use the (full) log stream name
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.faas_instance()
+      iex> OpenTelemetry.SemanticConventions.Resource.faas_instance()
       :"faas.instance"
   """
   @spec faas_instance :: :"faas.instance"
-  defmacro faas_instance do
+  def faas_instance do
     :"faas.instance"
   end
-
   @doc """
   The amount of memory available to the serverless function in MiB
 
@@ -521,519 +453,433 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.faas_max_memory()
+      iex> OpenTelemetry.SemanticConventions.Resource.faas_max_memory()
       :"faas.max_memory"
   """
   @spec faas_max_memory :: :"faas.max_memory"
-  defmacro faas_max_memory do
+  def faas_max_memory do
     :"faas.max_memory"
   end
-
   @doc """
   Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.host_id()
+      iex> OpenTelemetry.SemanticConventions.Resource.host_id()
       :"host.id"
   """
   @spec host_id :: :"host.id"
-  defmacro host_id do
+  def host_id do
     :"host.id"
   end
-
   @doc """
   Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.host_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.host_name()
       :"host.name"
   """
   @spec host_name :: :"host.name"
-  defmacro host_name do
+  def host_name do
     :"host.name"
   end
-
   @doc """
   Type of host. For Cloud, this must be the machine type
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.host_type()
+      iex> OpenTelemetry.SemanticConventions.Resource.host_type()
       :"host.type"
   """
   @spec host_type :: :"host.type"
-  defmacro host_type do
+  def host_type do
     :"host.type"
   end
-
   @doc """
   The CPU architecture the host system is running on
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.host_arch()
+      iex> OpenTelemetry.SemanticConventions.Resource.host_arch()
       :"host.arch"
   """
   @spec host_arch :: :"host.arch"
-  defmacro host_arch do
+  def host_arch do
     :"host.arch"
   end
-
   @doc """
   Name of the VM image or OS install the host was instantiated from
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.host_image_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.host_image_name()
       :"host.image.name"
   """
   @spec host_image_name :: :"host.image.name"
-  defmacro host_image_name do
+  def host_image_name do
     :"host.image.name"
   end
-
   @doc """
   VM image ID. For Cloud, this value is from the provider
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.host_image_id()
+      iex> OpenTelemetry.SemanticConventions.Resource.host_image_id()
       :"host.image.id"
   """
   @spec host_image_id :: :"host.image.id"
-  defmacro host_image_id do
+  def host_image_id do
     :"host.image.id"
   end
-
   @doc """
   The version string of the VM image as defined in [Version Attributes](README.md#version-attributes)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.host_image_version()
+      iex> OpenTelemetry.SemanticConventions.Resource.host_image_version()
       :"host.image.version"
   """
   @spec host_image_version :: :"host.image.version"
-  defmacro host_image_version do
+  def host_image_version do
     :"host.image.version"
   end
-
   @doc """
   The name of the cluster
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_cluster_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_cluster_name()
       :"k8s.cluster.name"
   """
   @spec k8s_cluster_name :: :"k8s.cluster.name"
-  defmacro k8s_cluster_name do
+  def k8s_cluster_name do
     :"k8s.cluster.name"
   end
-
   @doc """
   The name of the Node
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_node_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_node_name()
       :"k8s.node.name"
   """
   @spec k8s_node_name :: :"k8s.node.name"
-  defmacro k8s_node_name do
+  def k8s_node_name do
     :"k8s.node.name"
   end
-
   @doc """
   The UID of the Node
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_node_uid()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_node_uid()
       :"k8s.node.uid"
   """
   @spec k8s_node_uid :: :"k8s.node.uid"
-  defmacro k8s_node_uid do
+  def k8s_node_uid do
     :"k8s.node.uid"
   end
-
   @doc """
   The name of the namespace that the pod is running in
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_namespace_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_namespace_name()
       :"k8s.namespace.name"
   """
   @spec k8s_namespace_name :: :"k8s.namespace.name"
-  defmacro k8s_namespace_name do
+  def k8s_namespace_name do
     :"k8s.namespace.name"
   end
-
   @doc """
   The UID of the Pod
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_pod_uid()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_pod_uid()
       :"k8s.pod.uid"
   """
   @spec k8s_pod_uid :: :"k8s.pod.uid"
-  defmacro k8s_pod_uid do
+  def k8s_pod_uid do
     :"k8s.pod.uid"
   end
-
   @doc """
   The name of the Pod
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_pod_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_pod_name()
       :"k8s.pod.name"
   """
   @spec k8s_pod_name :: :"k8s.pod.name"
-  defmacro k8s_pod_name do
+  def k8s_pod_name do
     :"k8s.pod.name"
   end
-
   @doc """
   The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_container_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_container_name()
       :"k8s.container.name"
   """
   @spec k8s_container_name :: :"k8s.container.name"
-  defmacro k8s_container_name do
+  def k8s_container_name do
     :"k8s.container.name"
   end
-
   @doc """
   Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_container_restart_count()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_container_restart_count()
       :"k8s.container.restart_count"
   """
   @spec k8s_container_restart_count :: :"k8s.container.restart_count"
-  defmacro k8s_container_restart_count do
+  def k8s_container_restart_count do
     :"k8s.container.restart_count"
   end
-
   @doc """
   The UID of the ReplicaSet
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_replicaset_uid()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_replicaset_uid()
       :"k8s.replicaset.uid"
   """
   @spec k8s_replicaset_uid :: :"k8s.replicaset.uid"
-  defmacro k8s_replicaset_uid do
+  def k8s_replicaset_uid do
     :"k8s.replicaset.uid"
   end
-
   @doc """
   The name of the ReplicaSet
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_replicaset_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_replicaset_name()
       :"k8s.replicaset.name"
   """
   @spec k8s_replicaset_name :: :"k8s.replicaset.name"
-  defmacro k8s_replicaset_name do
+  def k8s_replicaset_name do
     :"k8s.replicaset.name"
   end
-
   @doc """
   The UID of the Deployment
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_deployment_uid()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_deployment_uid()
       :"k8s.deployment.uid"
   """
   @spec k8s_deployment_uid :: :"k8s.deployment.uid"
-  defmacro k8s_deployment_uid do
+  def k8s_deployment_uid do
     :"k8s.deployment.uid"
   end
-
   @doc """
   The name of the Deployment
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_deployment_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_deployment_name()
       :"k8s.deployment.name"
   """
   @spec k8s_deployment_name :: :"k8s.deployment.name"
-  defmacro k8s_deployment_name do
+  def k8s_deployment_name do
     :"k8s.deployment.name"
   end
-
   @doc """
   The UID of the StatefulSet
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_statefulset_uid()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_statefulset_uid()
       :"k8s.statefulset.uid"
   """
   @spec k8s_statefulset_uid :: :"k8s.statefulset.uid"
-  defmacro k8s_statefulset_uid do
+  def k8s_statefulset_uid do
     :"k8s.statefulset.uid"
   end
-
   @doc """
   The name of the StatefulSet
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_statefulset_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_statefulset_name()
       :"k8s.statefulset.name"
   """
   @spec k8s_statefulset_name :: :"k8s.statefulset.name"
-  defmacro k8s_statefulset_name do
+  def k8s_statefulset_name do
     :"k8s.statefulset.name"
   end
-
   @doc """
   The UID of the DaemonSet
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_daemonset_uid()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_daemonset_uid()
       :"k8s.daemonset.uid"
   """
   @spec k8s_daemonset_uid :: :"k8s.daemonset.uid"
-  defmacro k8s_daemonset_uid do
+  def k8s_daemonset_uid do
     :"k8s.daemonset.uid"
   end
-
   @doc """
   The name of the DaemonSet
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_daemonset_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_daemonset_name()
       :"k8s.daemonset.name"
   """
   @spec k8s_daemonset_name :: :"k8s.daemonset.name"
-  defmacro k8s_daemonset_name do
+  def k8s_daemonset_name do
     :"k8s.daemonset.name"
   end
-
   @doc """
   The UID of the Job
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_job_uid()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_job_uid()
       :"k8s.job.uid"
   """
   @spec k8s_job_uid :: :"k8s.job.uid"
-  defmacro k8s_job_uid do
+  def k8s_job_uid do
     :"k8s.job.uid"
   end
-
   @doc """
   The name of the Job
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_job_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_job_name()
       :"k8s.job.name"
   """
   @spec k8s_job_name :: :"k8s.job.name"
-  defmacro k8s_job_name do
+  def k8s_job_name do
     :"k8s.job.name"
   end
-
   @doc """
   The UID of the CronJob
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_cronjob_uid()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_cronjob_uid()
       :"k8s.cronjob.uid"
   """
   @spec k8s_cronjob_uid :: :"k8s.cronjob.uid"
-  defmacro k8s_cronjob_uid do
+  def k8s_cronjob_uid do
     :"k8s.cronjob.uid"
   end
-
   @doc """
   The name of the CronJob
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.k8s_cronjob_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.k8s_cronjob_name()
       :"k8s.cronjob.name"
   """
   @spec k8s_cronjob_name :: :"k8s.cronjob.name"
-  defmacro k8s_cronjob_name do
+  def k8s_cronjob_name do
     :"k8s.cronjob.name"
   end
-
   @doc """
   The operating system type
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.os_type()
+      iex> OpenTelemetry.SemanticConventions.Resource.os_type()
       :"os.type"
   """
   @spec os_type :: :"os.type"
-  defmacro os_type do
+  def os_type do
     :"os.type"
   end
-
   @doc """
   Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.os_description()
+      iex> OpenTelemetry.SemanticConventions.Resource.os_description()
       :"os.description"
   """
   @spec os_description :: :"os.description"
-  defmacro os_description do
+  def os_description do
     :"os.description"
   end
-
   @doc """
   Human readable operating system name
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.os_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.os_name()
       :"os.name"
   """
   @spec os_name :: :"os.name"
-  defmacro os_name do
+  def os_name do
     :"os.name"
   end
-
   @doc """
   The version string of the operating system as defined in [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.os_version()
+      iex> OpenTelemetry.SemanticConventions.Resource.os_version()
       :"os.version"
   """
   @spec os_version :: :"os.version"
-  defmacro os_version do
+  def os_version do
     :"os.version"
   end
-
   @doc """
   Process identifier (PID)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_pid()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_pid()
       :"process.pid"
   """
   @spec process_pid :: :"process.pid"
-  defmacro process_pid do
+  def process_pid do
     :"process.pid"
   end
-
   @doc """
   Parent Process identifier (PID)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_parent_pid()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_parent_pid()
       :"process.parent_pid"
   """
   @spec process_parent_pid :: :"process.parent_pid"
-  defmacro process_parent_pid do
+  def process_parent_pid do
     :"process.parent_pid"
   end
-
   @doc """
   The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_executable_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_executable_name()
       :"process.executable.name"
   """
   @spec process_executable_name :: :"process.executable.name"
-  defmacro process_executable_name do
+  def process_executable_name do
     :"process.executable.name"
   end
-
   @doc """
   The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_executable_path()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_executable_path()
       :"process.executable.path"
   """
   @spec process_executable_path :: :"process.executable.path"
-  defmacro process_executable_path do
+  def process_executable_path do
     :"process.executable.path"
   end
-
   @doc """
   The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_command()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_command()
       :"process.command"
   """
   @spec process_command :: :"process.command"
-  defmacro process_command do
+  def process_command do
     :"process.command"
   end
-
   @doc """
   The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_command_line()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_command_line()
       :"process.command_line"
   """
   @spec process_command_line :: :"process.command_line"
-  defmacro process_command_line do
+  def process_command_line do
     :"process.command_line"
   end
-
   @doc """
   All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_command_args()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_command_args()
       :"process.command_args"
   """
   @spec process_command_args :: :"process.command_args"
-  defmacro process_command_args do
+  def process_command_args do
     :"process.command_args"
   end
-
   @doc """
   The username of the user that owns the process
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_owner()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_owner()
       :"process.owner"
   """
   @spec process_owner :: :"process.owner"
-  defmacro process_owner do
+  def process_owner do
     :"process.owner"
   end
-
   @doc """
   The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_runtime_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_runtime_name()
       :"process.runtime.name"
   """
   @spec process_runtime_name :: :"process.runtime.name"
-  defmacro process_runtime_name do
+  def process_runtime_name do
     :"process.runtime.name"
   end
-
   @doc """
   The version of the runtime of this process, as returned by the runtime without modification
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_runtime_version()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_runtime_version()
       :"process.runtime.version"
   """
   @spec process_runtime_version :: :"process.runtime.version"
-  defmacro process_runtime_version do
+  def process_runtime_version do
     :"process.runtime.version"
   end
-
   @doc """
   An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.process_runtime_description()
+      iex> OpenTelemetry.SemanticConventions.Resource.process_runtime_description()
       :"process.runtime.description"
   """
   @spec process_runtime_description :: :"process.runtime.description"
-  defmacro process_runtime_description do
+  def process_runtime_description do
     :"process.runtime.description"
   end
-
   @doc """
   Logical name of the service
 
@@ -1041,15 +887,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.service_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.service_name()
       :"service.name"
   """
   @spec service_name :: :"service.name"
-  defmacro service_name do
+  def service_name do
     :"service.name"
   end
-
   @doc """
   A namespace for `service.name`
 
@@ -1057,15 +901,13 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.service_namespace()
+      iex> OpenTelemetry.SemanticConventions.Resource.service_namespace()
       :"service.namespace"
   """
   @spec service_namespace :: :"service.namespace"
-  defmacro service_namespace do
+  def service_namespace do
     :"service.namespace"
   end
-
   @doc """
   The string ID of the service instance
 
@@ -1073,108 +915,91 @@ defmodule OpenTelemetry.SemanticConventions.Resource do
 
   MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.service_instance_id()
+      iex> OpenTelemetry.SemanticConventions.Resource.service_instance_id()
       :"service.instance.id"
   """
   @spec service_instance_id :: :"service.instance.id"
-  defmacro service_instance_id do
+  def service_instance_id do
     :"service.instance.id"
   end
-
   @doc """
   The version string of the service API or implementation
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.service_version()
+      iex> OpenTelemetry.SemanticConventions.Resource.service_version()
       :"service.version"
   """
   @spec service_version :: :"service.version"
-  defmacro service_version do
+  def service_version do
     :"service.version"
   end
-
   @doc """
   The name of the telemetry SDK as defined above
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.telemetry_sdk_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.telemetry_sdk_name()
       :"telemetry.sdk.name"
   """
   @spec telemetry_sdk_name :: :"telemetry.sdk.name"
-  defmacro telemetry_sdk_name do
+  def telemetry_sdk_name do
     :"telemetry.sdk.name"
   end
-
   @doc """
   The language of the telemetry SDK
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.telemetry_sdk_language()
+      iex> OpenTelemetry.SemanticConventions.Resource.telemetry_sdk_language()
       :"telemetry.sdk.language"
   """
   @spec telemetry_sdk_language :: :"telemetry.sdk.language"
-  defmacro telemetry_sdk_language do
+  def telemetry_sdk_language do
     :"telemetry.sdk.language"
   end
-
   @doc """
   The version string of the telemetry SDK
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.telemetry_sdk_version()
+      iex> OpenTelemetry.SemanticConventions.Resource.telemetry_sdk_version()
       :"telemetry.sdk.version"
   """
   @spec telemetry_sdk_version :: :"telemetry.sdk.version"
-  defmacro telemetry_sdk_version do
+  def telemetry_sdk_version do
     :"telemetry.sdk.version"
   end
-
   @doc """
   The version string of the auto instrumentation agent, if used
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.telemetry_auto_version()
+      iex> OpenTelemetry.SemanticConventions.Resource.telemetry_auto_version()
       :"telemetry.auto.version"
   """
   @spec telemetry_auto_version :: :"telemetry.auto.version"
-  defmacro telemetry_auto_version do
+  def telemetry_auto_version do
     :"telemetry.auto.version"
   end
-
   @doc """
   The name of the web engine
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.webengine_name()
+      iex> OpenTelemetry.SemanticConventions.Resource.webengine_name()
       :"webengine.name"
   """
   @spec webengine_name :: :"webengine.name"
-  defmacro webengine_name do
+  def webengine_name do
     :"webengine.name"
   end
-
   @doc """
   The version of the web engine
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.webengine_version()
+      iex> OpenTelemetry.SemanticConventions.Resource.webengine_version()
       :"webengine.version"
   """
   @spec webengine_version :: :"webengine.version"
-  defmacro webengine_version do
+  def webengine_version do
     :"webengine.version"
   end
-
   @doc """
   Additional description of the web engine (e.g. detailed version and edition information)
 
-      iex> require OpenTelemetry.SemanticConventions.Resource
-      ...> OpenTelemetry.SemanticConventions.Resource.webengine_description()
+      iex> OpenTelemetry.SemanticConventions.Resource.webengine_description()
       :"webengine.description"
   """
   @spec webengine_description :: :"webengine.description"
-  defmacro webengine_description do
+  def webengine_description do
     :"webengine.description"
   end
 end

--- a/apps/opentelemetry_semantic_conventions/lib/open_telemetry/semantic_conventions/trace.ex
+++ b/apps/opentelemetry_semantic_conventions/lib/open_telemetry/semantic_conventions/trace.ex
@@ -2,15 +2,13 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
   @doc """
   The schema url for telemetry resources.
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.trace_schema_url()
+      iex> OpenTelemetry.SemanticConventions.Trace.trace_schema_url()
       "https://opentelemetry.io/schemas/1.13.0"
   """
   @spec trace_schema_url :: String.t()
-  defmacro trace_schema_url do
+  def trace_schema_url do
     "https://opentelemetry.io/schemas/1.13.0"
   end
-
   @doc """
   The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable)
 
@@ -18,75 +16,63 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   This may be different from `faas.id` if an alias is involved
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_lambda_invoked_arn()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_lambda_invoked_arn()
       :"aws.lambda.invoked_arn"
   """
   @spec aws_lambda_invoked_arn :: :"aws.lambda.invoked_arn"
-  defmacro aws_lambda_invoked_arn do
+  def aws_lambda_invoked_arn do
     :"aws.lambda.invoked_arn"
   end
-
   @doc """
   The [event_id](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id) uniquely identifies the event
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_id()
       :"cloudevents.event_id"
   """
   @spec cloudevents_event_id :: :"cloudevents.event_id"
-  defmacro cloudevents_event_id do
+  def cloudevents_event_id do
     :"cloudevents.event_id"
   end
-
   @doc """
   The [source](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1) identifies the context in which an event happened
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_source()
+      iex> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_source()
       :"cloudevents.event_source"
   """
   @spec cloudevents_event_source :: :"cloudevents.event_source"
-  defmacro cloudevents_event_source do
+  def cloudevents_event_source do
     :"cloudevents.event_source"
   end
-
   @doc """
   The [version of the CloudEvents specification](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#specversion) which the event uses
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_spec_version()
+      iex> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_spec_version()
       :"cloudevents.event_spec_version"
   """
   @spec cloudevents_event_spec_version :: :"cloudevents.event_spec_version"
-  defmacro cloudevents_event_spec_version do
+  def cloudevents_event_spec_version do
     :"cloudevents.event_spec_version"
   end
-
   @doc """
   The [event_type](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type) contains a value describing the type of event related to the originating occurrence
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_type()
+      iex> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_type()
       :"cloudevents.event_type"
   """
   @spec cloudevents_event_type :: :"cloudevents.event_type"
-  defmacro cloudevents_event_type do
+  def cloudevents_event_type do
     :"cloudevents.event_type"
   end
-
   @doc """
   The [subject](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject) of the event in the context of the event producer (identified by source)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_subject()
+      iex> OpenTelemetry.SemanticConventions.Trace.cloudevents_event_subject()
       :"cloudevents.event_subject"
   """
   @spec cloudevents_event_subject :: :"cloudevents.event_subject"
-  defmacro cloudevents_event_subject do
+  def cloudevents_event_subject do
     :"cloudevents.event_subject"
   end
-
   @doc """
   Parent-child Reference type
 
@@ -94,63 +80,53 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   The causal relationship between a child Span and a parent Span
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.opentracing_ref_type()
+      iex> OpenTelemetry.SemanticConventions.Trace.opentracing_ref_type()
       :"opentracing.ref_type"
   """
   @spec opentracing_ref_type :: :"opentracing.ref_type"
-  defmacro opentracing_ref_type do
+  def opentracing_ref_type do
     :"opentracing.ref_type"
   end
-
   @doc """
   An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_system()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_system()
       :"db.system"
   """
   @spec db_system :: :"db.system"
-  defmacro db_system do
+  def db_system do
     :"db.system"
   end
-
   @doc """
   The connection string used to connect to the database. It is recommended to remove embedded credentials
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_connection_string()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_connection_string()
       :"db.connection_string"
   """
   @spec db_connection_string :: :"db.connection_string"
-  defmacro db_connection_string do
+  def db_connection_string do
     :"db.connection_string"
   end
-
   @doc """
   Username for accessing the database
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_user()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_user()
       :"db.user"
   """
   @spec db_user :: :"db.user"
-  defmacro db_user do
+  def db_user do
     :"db.user"
   end
-
   @doc """
   The fully-qualified class name of the [Java Database Connectivity (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to connect
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_jdbc_driver_classname()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_jdbc_driver_classname()
       :"db.jdbc.driver_classname"
   """
   @spec db_jdbc_driver_classname :: :"db.jdbc.driver_classname"
-  defmacro db_jdbc_driver_classname do
+  def db_jdbc_driver_classname do
     :"db.jdbc.driver_classname"
   end
-
   @doc """
   This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails)
 
@@ -158,15 +134,13 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   In some SQL databases, the database name to be used is called "schema name". In case there are multiple layers that could be considered for database name (e.g. Oracle instance name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema name)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_name()
       :"db.name"
   """
   @spec db_name :: :"db.name"
-  defmacro db_name do
+  def db_name do
     :"db.name"
   end
-
   @doc """
   The database statement being executed
 
@@ -174,15 +148,13 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   The value may be sanitized to exclude sensitive information
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_statement()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_statement()
       :"db.statement"
   """
   @spec db_statement :: :"db.statement"
-  defmacro db_statement do
+  def db_statement do
     :"db.statement"
   end
-
   @doc """
   The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword
 
@@ -190,15 +162,13 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_operation()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_operation()
       :"db.operation"
   """
   @spec db_operation :: :"db.operation"
-  defmacro db_operation do
+  def db_operation do
     :"db.operation"
   end
-
   @doc """
   Name of the database host
 
@@ -206,87 +176,73 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   `net.peer.name` SHOULD NOT be set if capturing it would require an extra DNS lookup
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_peer_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_peer_name()
       :"net.peer.name"
   """
   @spec net_peer_name :: :"net.peer.name"
-  defmacro net_peer_name do
+  def net_peer_name do
     :"net.peer.name"
   end
-
   @doc """
   Logical remote port number
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_peer_port()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_peer_port()
       :"net.peer.port"
   """
   @spec net_peer_port :: :"net.peer.port"
-  defmacro net_peer_port do
+  def net_peer_port do
     :"net.peer.port"
   end
-
   @doc """
   Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, [etc](https://man7.org/linux/man-pages/man7/address_families.7.html)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_sock_peer_addr()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_sock_peer_addr()
       :"net.sock.peer.addr"
   """
   @spec net_sock_peer_addr :: :"net.sock.peer.addr"
-  defmacro net_sock_peer_addr do
+  def net_sock_peer_addr do
     :"net.sock.peer.addr"
   end
-
   @doc """
   Remote socket peer port
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_sock_peer_port()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_sock_peer_port()
       :"net.sock.peer.port"
   """
   @spec net_sock_peer_port :: :"net.sock.peer.port"
-  defmacro net_sock_peer_port do
+  def net_sock_peer_port do
     :"net.sock.peer.port"
   end
-
   @doc """
   Protocol [address family](https://man7.org/linux/man-pages/man7/address_families.7.html) which is used for communication
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_sock_family()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_sock_family()
       :"net.sock.family"
   """
   @spec net_sock_family :: :"net.sock.family"
-  defmacro net_sock_family do
+  def net_sock_family do
     :"net.sock.family"
   end
-
   @doc """
   Remote socket peer name
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_sock_peer_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_sock_peer_name()
       :"net.sock.peer.name"
   """
   @spec net_sock_peer_name :: :"net.sock.peer.name"
-  defmacro net_sock_peer_name do
+  def net_sock_peer_name do
     :"net.sock.peer.name"
   end
-
   @doc """
   Transport protocol used. See note below
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_transport()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_transport()
       :"net.transport"
   """
   @spec net_transport :: :"net.transport"
-  defmacro net_transport do
+  def net_transport do
     :"net.transport"
   end
-
   @doc """
   The Microsoft SQL Server [instance name](https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) connecting to. This name is used to determine the port of a named instance
 
@@ -294,39 +250,33 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   If setting a `db.mssql.instance_name`, `net.peer.port` is no longer required (but still recommended if non-standard)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_mssql_instance_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_mssql_instance_name()
       :"db.mssql.instance_name"
   """
   @spec db_mssql_instance_name :: :"db.mssql.instance_name"
-  defmacro db_mssql_instance_name do
+  def db_mssql_instance_name do
     :"db.mssql.instance_name"
   end
-
   @doc """
   The fetch size used for paging, i.e. how many rows will be returned at once
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_cassandra_page_size()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_cassandra_page_size()
       :"db.cassandra.page_size"
   """
   @spec db_cassandra_page_size :: :"db.cassandra.page_size"
-  defmacro db_cassandra_page_size do
+  def db_cassandra_page_size do
     :"db.cassandra.page_size"
   end
-
   @doc """
   The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_cassandra_consistency_level()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_cassandra_consistency_level()
       :"db.cassandra.consistency_level"
   """
   @spec db_cassandra_consistency_level :: :"db.cassandra.consistency_level"
-  defmacro db_cassandra_consistency_level do
+  def db_cassandra_consistency_level do
     :"db.cassandra.consistency_level"
   end
-
   @doc """
   The name of the primary table that the operation is acting upon, including the keyspace name (if applicable)
 
@@ -334,87 +284,73 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_cassandra_table()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_cassandra_table()
       :"db.cassandra.table"
   """
   @spec db_cassandra_table :: :"db.cassandra.table"
-  defmacro db_cassandra_table do
+  def db_cassandra_table do
     :"db.cassandra.table"
   end
-
   @doc """
   Whether or not the query is idempotent
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_cassandra_idempotence()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_cassandra_idempotence()
       :"db.cassandra.idempotence"
   """
   @spec db_cassandra_idempotence :: :"db.cassandra.idempotence"
-  defmacro db_cassandra_idempotence do
+  def db_cassandra_idempotence do
     :"db.cassandra.idempotence"
   end
-
   @doc """
   The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_cassandra_speculative_execution_count()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_cassandra_speculative_execution_count()
       :"db.cassandra.speculative_execution_count"
   """
   @spec db_cassandra_speculative_execution_count :: :"db.cassandra.speculative_execution_count"
-  defmacro db_cassandra_speculative_execution_count do
+  def db_cassandra_speculative_execution_count do
     :"db.cassandra.speculative_execution_count"
   end
-
   @doc """
   The ID of the coordinating node for a query
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_cassandra_coordinator_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_cassandra_coordinator_id()
       :"db.cassandra.coordinator.id"
   """
   @spec db_cassandra_coordinator_id :: :"db.cassandra.coordinator.id"
-  defmacro db_cassandra_coordinator_id do
+  def db_cassandra_coordinator_id do
     :"db.cassandra.coordinator.id"
   end
-
   @doc """
   The data center of the coordinating node for a query
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_cassandra_coordinator_dc()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_cassandra_coordinator_dc()
       :"db.cassandra.coordinator.dc"
   """
   @spec db_cassandra_coordinator_dc :: :"db.cassandra.coordinator.dc"
-  defmacro db_cassandra_coordinator_dc do
+  def db_cassandra_coordinator_dc do
     :"db.cassandra.coordinator.dc"
   end
-
   @doc """
   The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` attribute
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_redis_database_index()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_redis_database_index()
       :"db.redis.database_index"
   """
   @spec db_redis_database_index :: :"db.redis.database_index"
-  defmacro db_redis_database_index do
+  def db_redis_database_index do
     :"db.redis.database_index"
   end
-
   @doc """
   The collection being accessed within the database stated in `db.name`
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_mongodb_collection()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_mongodb_collection()
       :"db.mongodb.collection"
   """
   @spec db_mongodb_collection :: :"db.mongodb.collection"
-  defmacro db_mongodb_collection do
+  def db_mongodb_collection do
     :"db.mongodb.collection"
   end
-
   @doc """
   The name of the primary table that the operation is acting upon, including the database name (if applicable)
 
@@ -422,51 +358,43 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.db_sql_table()
+      iex> OpenTelemetry.SemanticConventions.Trace.db_sql_table()
       :"db.sql.table"
   """
   @spec db_sql_table :: :"db.sql.table"
-  defmacro db_sql_table do
+  def db_sql_table do
     :"db.sql.table"
   end
-
   @doc """
   The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.exception_type()
+      iex> OpenTelemetry.SemanticConventions.Trace.exception_type()
       :"exception.type"
   """
   @spec exception_type :: :"exception.type"
-  defmacro exception_type do
+  def exception_type do
     :"exception.type"
   end
-
   @doc """
   The exception message
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.exception_message()
+      iex> OpenTelemetry.SemanticConventions.Trace.exception_message()
       :"exception.message"
   """
   @spec exception_message :: :"exception.message"
-  defmacro exception_message do
+  def exception_message do
     :"exception.message"
   end
-
   @doc """
   A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.exception_stacktrace()
+      iex> OpenTelemetry.SemanticConventions.Trace.exception_stacktrace()
       :"exception.stacktrace"
   """
   @spec exception_stacktrace :: :"exception.stacktrace"
-  defmacro exception_stacktrace do
+  def exception_stacktrace do
     :"exception.stacktrace"
   end
-
   @doc """
   SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span
 
@@ -477,27 +405,25 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
   This may be actually "in flight" in some languages (e.g. if the exception
   is passed to a Context manager's `__exit__` method in Python) but will
   usually be caught at the point of recording the exception in most languages.
-
+  
   It is usually not possible to determine at the point where an exception is thrown
   whether it will escape the scope of a span.
   However, it is trivial to know that an exception
   will escape, if one checks for an active exception just before ending the span,
   as done in the [example above](#recording-an-exception).
-
+  
   It follows that an exception may still escape the scope of the span
   even if the `exception.escaped` attribute was not set or set to false,
   since the event might have been recorded at a time where it was not
   clear whether the exception will escape
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.exception_escaped()
+      iex> OpenTelemetry.SemanticConventions.Trace.exception_escaped()
       :"exception.escaped"
   """
   @spec exception_escaped :: :"exception.escaped"
-  defmacro exception_escaped do
+  def exception_escaped do
     :"exception.escaped"
   end
-
   @doc """
   Type of the trigger which caused this function execution
 
@@ -505,7 +431,7 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   For the server/consumer span on the incoming side,
   `faas.trigger` MUST be set.
-
+  
   Clients invoking FaaS instances usually cannot set `faas.trigger`,
   since they would typically need to look in the payload to determine
   the event type. If clients set it, it should be the same as the
@@ -513,99 +439,83 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
   nothing to do with the underlying transport used to make the API
   call to invoke the lambda, which is often HTTP)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_trigger()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_trigger()
       :"faas.trigger"
   """
   @spec faas_trigger :: :"faas.trigger"
-  defmacro faas_trigger do
+  def faas_trigger do
     :"faas.trigger"
   end
-
   @doc """
   The execution ID of the current function execution
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_execution()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_execution()
       :"faas.execution"
   """
   @spec faas_execution :: :"faas.execution"
-  defmacro faas_execution do
+  def faas_execution do
     :"faas.execution"
   end
-
   @doc """
   The name of the source on which the triggering operation was performed. For example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_document_collection()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_document_collection()
       :"faas.document.collection"
   """
   @spec faas_document_collection :: :"faas.document.collection"
-  defmacro faas_document_collection do
+  def faas_document_collection do
     :"faas.document.collection"
   end
-
   @doc """
   Describes the type of the operation that was performed on the data
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_document_operation()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_document_operation()
       :"faas.document.operation"
   """
   @spec faas_document_operation :: :"faas.document.operation"
-  defmacro faas_document_operation do
+  def faas_document_operation do
     :"faas.document.operation"
   end
-
   @doc """
   A string containing the time when the data was accessed in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_document_time()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_document_time()
       :"faas.document.time"
   """
   @spec faas_document_time :: :"faas.document.time"
-  defmacro faas_document_time do
+  def faas_document_time do
     :"faas.document.time"
   end
-
   @doc """
   The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_document_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_document_name()
       :"faas.document.name"
   """
   @spec faas_document_name :: :"faas.document.name"
-  defmacro faas_document_name do
+  def faas_document_name do
     :"faas.document.name"
   end
-
   @doc """
   HTTP request method
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_method()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_method()
       :"http.method"
   """
   @spec http_method :: :"http.method"
-  defmacro http_method do
+  def http_method do
     :"http.method"
   end
-
   @doc """
   [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_status_code()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_status_code()
       :"http.status_code"
   """
   @spec http_status_code :: :"http.status_code"
-  defmacro http_status_code do
+  def http_status_code do
     :"http.status_code"
   end
-
   @doc """
   Kind of HTTP protocol used
 
@@ -613,75 +523,63 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_flavor()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_flavor()
       :"http.flavor"
   """
   @spec http_flavor :: :"http.flavor"
-  defmacro http_flavor do
+  def http_flavor do
     :"http.flavor"
   end
-
   @doc """
   Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_user_agent()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_user_agent()
       :"http.user_agent"
   """
   @spec http_user_agent :: :"http.user_agent"
-  defmacro http_user_agent do
+  def http_user_agent do
     :"http.user_agent"
   end
-
   @doc """
   The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_request_content_length()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_request_content_length()
       :"http.request_content_length"
   """
   @spec http_request_content_length :: :"http.request_content_length"
-  defmacro http_request_content_length do
+  def http_request_content_length do
     :"http.request_content_length"
   end
-
   @doc """
   The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_response_content_length()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_response_content_length()
       :"http.response_content_length"
   """
   @spec http_response_content_length :: :"http.response_content_length"
-  defmacro http_response_content_length do
+  def http_response_content_length do
     :"http.response_content_length"
   end
-
   @doc """
   The URI scheme identifying the used protocol
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_scheme()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_scheme()
       :"http.scheme"
   """
   @spec http_scheme :: :"http.scheme"
-  defmacro http_scheme do
+  def http_scheme do
     :"http.scheme"
   end
-
   @doc """
   The full request target as passed in a HTTP request line or equivalent
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_target()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_target()
       :"http.target"
   """
   @spec http_target :: :"http.target"
-  defmacro http_target do
+  def http_target do
     :"http.target"
   end
-
   @doc """
   The matched route (path template in the format used by the respective server framework). See note below
 
@@ -689,15 +587,13 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_route()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_route()
       :"http.route"
   """
   @spec http_route :: :"http.route"
-  defmacro http_route do
+  def http_route do
     :"http.route"
   end
-
   @doc """
   The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For))
 
@@ -705,7 +601,7 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   This is not necessarily the same as `net.sock.peer.addr`, which would
   identify the network-level peer, which may be a proxy.
-
+  
   This attribute should be set when a source of information different
   from the one used for `net.sock.peer.addr`, is available even if that other
   source just confirms the same value as `net.sock.peer.addr`.
@@ -715,96 +611,84 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
   one is at least somewhat confident that the address is not that of
   the closest proxy
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_client_ip()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_client_ip()
       :"http.client_ip"
   """
   @spec http_client_ip :: :"http.client_ip"
-  defmacro http_client_ip do
+  def http_client_ip do
     :"http.client_ip"
   end
-
   @doc """
   Name of the local HTTP server that received the request
 
   ### Notes
 
   Determined by using the first of the following that applies
-
+  
   - The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
     include host identifier.
   - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
     if it's sent in absolute-form.
   - Host identifier of the `Host` header
-
+  
   SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_host_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_host_name()
       :"net.host.name"
   """
   @spec net_host_name :: :"net.host.name"
-  defmacro net_host_name do
+  def net_host_name do
     :"net.host.name"
   end
-
   @doc """
   Port of the local HTTP server that received the request
 
   ### Notes
 
   Determined by using the first of the following that applies
-
+  
   - Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
   - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
     if it's sent in absolute-form.
   - Port identifier of the `Host` header
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_host_port()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_host_port()
       :"net.host.port"
   """
   @spec net_host_port :: :"net.host.port"
-  defmacro net_host_port do
+  def net_host_port do
     :"net.host.port"
   end
-
   @doc """
   Local socket address. Useful in case of a multi-IP host
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_sock_host_addr()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_sock_host_addr()
       :"net.sock.host.addr"
   """
   @spec net_sock_host_addr :: :"net.sock.host.addr"
-  defmacro net_sock_host_addr do
+  def net_sock_host_addr do
     :"net.sock.host.addr"
   end
-
   @doc """
   Local socket port number
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_sock_host_port()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_sock_host_port()
       :"net.sock.host.port"
   """
   @spec net_sock_host_port :: :"net.sock.host.port"
-  defmacro net_sock_host_port do
+  def net_sock_host_port do
     :"net.sock.host.port"
   end
-
   @doc """
   Application layer protocol used. The value SHOULD be normalized to lowercase
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_app_protocol_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_app_protocol_name()
       :"net.app.protocol.name"
   """
   @spec net_app_protocol_name :: :"net.app.protocol.name"
-  defmacro net_app_protocol_name do
+  def net_app_protocol_name do
     :"net.app.protocol.name"
   end
-
   @doc """
   Version of the application layer protocol used. See note below
 
@@ -812,256 +696,213 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   `net.app.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_app_protocol_version()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_app_protocol_version()
       :"net.app.protocol.version"
   """
   @spec net_app_protocol_version :: :"net.app.protocol.version"
-  defmacro net_app_protocol_version do
+  def net_app_protocol_version do
     :"net.app.protocol.version"
   end
-
   @doc """
   The internet connection type currently being used by the host
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_host_connection_type()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_host_connection_type()
       :"net.host.connection.type"
   """
   @spec net_host_connection_type :: :"net.host.connection.type"
-  defmacro net_host_connection_type do
+  def net_host_connection_type do
     :"net.host.connection.type"
   end
-
   @doc """
   This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_host_connection_subtype()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_host_connection_subtype()
       :"net.host.connection.subtype"
   """
   @spec net_host_connection_subtype :: :"net.host.connection.subtype"
-  defmacro net_host_connection_subtype do
+  def net_host_connection_subtype do
     :"net.host.connection.subtype"
   end
-
   @doc """
   The name of the mobile carrier
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_host_carrier_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_host_carrier_name()
       :"net.host.carrier.name"
   """
   @spec net_host_carrier_name :: :"net.host.carrier.name"
-  defmacro net_host_carrier_name do
+  def net_host_carrier_name do
     :"net.host.carrier.name"
   end
-
   @doc """
   The mobile carrier country code
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_host_carrier_mcc()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_host_carrier_mcc()
       :"net.host.carrier.mcc"
   """
   @spec net_host_carrier_mcc :: :"net.host.carrier.mcc"
-  defmacro net_host_carrier_mcc do
+  def net_host_carrier_mcc do
     :"net.host.carrier.mcc"
   end
-
   @doc """
   The mobile carrier network code
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_host_carrier_mnc()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_host_carrier_mnc()
       :"net.host.carrier.mnc"
   """
   @spec net_host_carrier_mnc :: :"net.host.carrier.mnc"
-  defmacro net_host_carrier_mnc do
+  def net_host_carrier_mnc do
     :"net.host.carrier.mnc"
   end
-
   @doc """
   The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.net_host_carrier_icc()
+      iex> OpenTelemetry.SemanticConventions.Trace.net_host_carrier_icc()
       :"net.host.carrier.icc"
   """
   @spec net_host_carrier_icc :: :"net.host.carrier.icc"
-  defmacro net_host_carrier_icc do
+  def net_host_carrier_icc do
     :"net.host.carrier.icc"
   end
-
   @doc """
   A string identifying the messaging system
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_system()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_system()
       :"messaging.system"
   """
   @spec messaging_system :: :"messaging.system"
-  defmacro messaging_system do
+  def messaging_system do
     :"messaging.system"
   end
-
   @doc """
   The message destination name. This might be equal to the span name but is required nevertheless
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_destination()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_destination()
       :"messaging.destination"
   """
   @spec messaging_destination :: :"messaging.destination"
-  defmacro messaging_destination do
+  def messaging_destination do
     :"messaging.destination"
   end
-
   @doc """
   The kind of message destination
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_destination_kind()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_destination_kind()
       :"messaging.destination_kind"
   """
   @spec messaging_destination_kind :: :"messaging.destination_kind"
-  defmacro messaging_destination_kind do
+  def messaging_destination_kind do
     :"messaging.destination_kind"
   end
-
   @doc """
   A boolean that is true if the message destination is temporary
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_temp_destination()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_temp_destination()
       :"messaging.temp_destination"
   """
   @spec messaging_temp_destination :: :"messaging.temp_destination"
-  defmacro messaging_temp_destination do
+  def messaging_temp_destination do
     :"messaging.temp_destination"
   end
-
   @doc """
   The name of the transport protocol
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_protocol()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_protocol()
       :"messaging.protocol"
   """
   @spec messaging_protocol :: :"messaging.protocol"
-  defmacro messaging_protocol do
+  def messaging_protocol do
     :"messaging.protocol"
   end
-
   @doc """
   The version of the transport protocol
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_protocol_version()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_protocol_version()
       :"messaging.protocol_version"
   """
   @spec messaging_protocol_version :: :"messaging.protocol_version"
-  defmacro messaging_protocol_version do
+  def messaging_protocol_version do
     :"messaging.protocol_version"
   end
-
   @doc """
   Connection string
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_url()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_url()
       :"messaging.url"
   """
   @spec messaging_url :: :"messaging.url"
-  defmacro messaging_url do
+  def messaging_url do
     :"messaging.url"
   end
-
   @doc """
   A value used by the messaging system as an identifier for the message, represented as a string
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_message_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_message_id()
       :"messaging.message_id"
   """
   @spec messaging_message_id :: :"messaging.message_id"
-  defmacro messaging_message_id do
+  def messaging_message_id do
     :"messaging.message_id"
   end
-
   @doc """
   The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID"
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_conversation_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_conversation_id()
       :"messaging.conversation_id"
   """
   @spec messaging_conversation_id :: :"messaging.conversation_id"
-  defmacro messaging_conversation_id do
+  def messaging_conversation_id do
     :"messaging.conversation_id"
   end
-
   @doc """
   The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_message_payload_size_bytes()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_message_payload_size_bytes()
       :"messaging.message_payload_size_bytes"
   """
   @spec messaging_message_payload_size_bytes :: :"messaging.message_payload_size_bytes"
-  defmacro messaging_message_payload_size_bytes do
+  def messaging_message_payload_size_bytes do
     :"messaging.message_payload_size_bytes"
   end
-
   @doc """
   The compressed size of the message payload in bytes
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_message_payload_compressed_size_bytes()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_message_payload_compressed_size_bytes()
       :"messaging.message_payload_compressed_size_bytes"
   """
-  @spec messaging_message_payload_compressed_size_bytes ::
-          :"messaging.message_payload_compressed_size_bytes"
-  defmacro messaging_message_payload_compressed_size_bytes do
+  @spec messaging_message_payload_compressed_size_bytes :: :"messaging.message_payload_compressed_size_bytes"
+  def messaging_message_payload_compressed_size_bytes do
     :"messaging.message_payload_compressed_size_bytes"
   end
-
   @doc """
   A string containing the function invocation time in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_time()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_time()
       :"faas.time"
   """
   @spec faas_time :: :"faas.time"
-  defmacro faas_time do
+  def faas_time do
     :"faas.time"
   end
-
   @doc """
   A string containing the schedule period as [Cron Expression](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_cron()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_cron()
       :"faas.cron"
   """
   @spec faas_cron :: :"faas.cron"
-  defmacro faas_cron do
+  def faas_cron do
     :"faas.cron"
   end
-
   @doc """
   A boolean that is true if the serverless function is executed for the first time (aka cold-start)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_coldstart()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_coldstart()
       :"faas.coldstart"
   """
   @spec faas_coldstart :: :"faas.coldstart"
-  defmacro faas_coldstart do
+  def faas_coldstart do
     :"faas.coldstart"
   end
-
   @doc """
   The name of the invoked function
 
@@ -1069,15 +910,13 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   SHOULD be equal to the `faas.name` resource attribute of the invoked function
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_invoked_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_invoked_name()
       :"faas.invoked_name"
   """
   @spec faas_invoked_name :: :"faas.invoked_name"
-  defmacro faas_invoked_name do
+  def faas_invoked_name do
     :"faas.invoked_name"
   end
-
   @doc """
   The cloud provider of the invoked function
 
@@ -1085,15 +924,13 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   SHOULD be equal to the `cloud.provider` resource attribute of the invoked function
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_invoked_provider()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_invoked_provider()
       :"faas.invoked_provider"
   """
   @spec faas_invoked_provider :: :"faas.invoked_provider"
-  defmacro faas_invoked_provider do
+  def faas_invoked_provider do
     :"faas.invoked_provider"
   end
-
   @doc """
   The cloud region of the invoked function
 
@@ -1101,135 +938,113 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   SHOULD be equal to the `cloud.region` resource attribute of the invoked function
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.faas_invoked_region()
+      iex> OpenTelemetry.SemanticConventions.Trace.faas_invoked_region()
       :"faas.invoked_region"
   """
   @spec faas_invoked_region :: :"faas.invoked_region"
-  defmacro faas_invoked_region do
+  def faas_invoked_region do
     :"faas.invoked_region"
   end
-
   @doc """
   The [`service.name`](../../resource/semantic_conventions/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.peer_service()
+      iex> OpenTelemetry.SemanticConventions.Trace.peer_service()
       :"peer.service"
   """
   @spec peer_service :: :"peer.service"
-  defmacro peer_service do
+  def peer_service do
     :"peer.service"
   end
-
   @doc """
   Username or client_id extracted from the access token or [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the inbound request from outside the system
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.enduser_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.enduser_id()
       :"enduser.id"
   """
   @spec enduser_id :: :"enduser.id"
-  defmacro enduser_id do
+  def enduser_id do
     :"enduser.id"
   end
-
   @doc """
   Actual/assumed role the client is making the request under extracted from token or application security context
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.enduser_role()
+      iex> OpenTelemetry.SemanticConventions.Trace.enduser_role()
       :"enduser.role"
   """
   @spec enduser_role :: :"enduser.role"
-  defmacro enduser_role do
+  def enduser_role do
     :"enduser.role"
   end
-
   @doc """
   Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an [OAuth 2.0 Access Token](https://tools.ietf.org/html/rfc6749#section-3.3) or an attribute value in a [SAML 2.0 Assertion](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.enduser_scope()
+      iex> OpenTelemetry.SemanticConventions.Trace.enduser_scope()
       :"enduser.scope"
   """
   @spec enduser_scope :: :"enduser.scope"
-  defmacro enduser_scope do
+  def enduser_scope do
     :"enduser.scope"
   end
-
   @doc """
   Current "managed" thread ID (as opposed to OS thread ID)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.thread_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.thread_id()
       :"thread.id"
   """
   @spec thread_id :: :"thread.id"
-  defmacro thread_id do
+  def thread_id do
     :"thread.id"
   end
-
   @doc """
   Current thread name
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.thread_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.thread_name()
       :"thread.name"
   """
   @spec thread_name :: :"thread.name"
-  defmacro thread_name do
+  def thread_name do
     :"thread.name"
   end
-
   @doc """
   The method or function name, or equivalent (usually rightmost part of the code unit's name)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.code_function()
+      iex> OpenTelemetry.SemanticConventions.Trace.code_function()
       :"code.function"
   """
   @spec code_function :: :"code.function"
-  defmacro code_function do
+  def code_function do
     :"code.function"
   end
-
   @doc """
   The "namespace" within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.code_namespace()
+      iex> OpenTelemetry.SemanticConventions.Trace.code_namespace()
       :"code.namespace"
   """
   @spec code_namespace :: :"code.namespace"
-  defmacro code_namespace do
+  def code_namespace do
     :"code.namespace"
   end
-
   @doc """
   The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.code_filepath()
+      iex> OpenTelemetry.SemanticConventions.Trace.code_filepath()
       :"code.filepath"
   """
   @spec code_filepath :: :"code.filepath"
-  defmacro code_filepath do
+  def code_filepath do
     :"code.filepath"
   end
-
   @doc """
   The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.code_lineno()
+      iex> OpenTelemetry.SemanticConventions.Trace.code_lineno()
       :"code.lineno"
   """
   @spec code_lineno :: :"code.lineno"
-  defmacro code_lineno do
+  def code_lineno do
     :"code.lineno"
   end
-
   @doc """
   Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless
 
@@ -1237,39 +1052,33 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value should be `https://www.example.com/`
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_url()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_url()
       :"http.url"
   """
   @spec http_url :: :"http.url"
-  defmacro http_url do
+  def http_url do
     :"http.url"
   end
-
   @doc """
   The ordinal number of request re-sending attempt
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.http_retry_count()
+      iex> OpenTelemetry.SemanticConventions.Trace.http_retry_count()
       :"http.retry_count"
   """
   @spec http_retry_count :: :"http.retry_count"
-  defmacro http_retry_count do
+  def http_retry_count do
     :"http.retry_count"
   end
-
   @doc """
   The value `aws-api`
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.rpc_system()
+      iex> OpenTelemetry.SemanticConventions.Trace.rpc_system()
       :"rpc.system"
   """
   @spec rpc_system :: :"rpc.system"
-  defmacro rpc_system do
+  def rpc_system do
     :"rpc.system"
   end
-
   @doc """
   The name of the service to which a request is made, as returned by the AWS SDK
 
@@ -1277,15 +1086,13 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.rpc_service()
+      iex> OpenTelemetry.SemanticConventions.Trace.rpc_service()
       :"rpc.service"
   """
   @spec rpc_service :: :"rpc.service"
-  defmacro rpc_service do
+  def rpc_service do
     :"rpc.service"
   end
-
   @doc """
   The name of the operation corresponding to the request, as returned by the AWS SDK
 
@@ -1293,304 +1100,253 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side)
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.rpc_method()
+      iex> OpenTelemetry.SemanticConventions.Trace.rpc_method()
       :"rpc.method"
   """
   @spec rpc_method :: :"rpc.method"
-  defmacro rpc_method do
+  def rpc_method do
     :"rpc.method"
   end
-
   @doc """
   The keys in the `RequestItems` object field
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_table_names()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_table_names()
       :"aws.dynamodb.table_names"
   """
   @spec aws_dynamodb_table_names :: :"aws.dynamodb.table_names"
-  defmacro aws_dynamodb_table_names do
+  def aws_dynamodb_table_names do
     :"aws.dynamodb.table_names"
   end
-
   @doc """
   The JSON-serialized value of each item in the `ConsumedCapacity` response field
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_consumed_capacity()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_consumed_capacity()
       :"aws.dynamodb.consumed_capacity"
   """
   @spec aws_dynamodb_consumed_capacity :: :"aws.dynamodb.consumed_capacity"
-  defmacro aws_dynamodb_consumed_capacity do
+  def aws_dynamodb_consumed_capacity do
     :"aws.dynamodb.consumed_capacity"
   end
-
   @doc """
   The JSON-serialized value of the `ItemCollectionMetrics` response field
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_item_collection_metrics()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_item_collection_metrics()
       :"aws.dynamodb.item_collection_metrics"
   """
   @spec aws_dynamodb_item_collection_metrics :: :"aws.dynamodb.item_collection_metrics"
-  defmacro aws_dynamodb_item_collection_metrics do
+  def aws_dynamodb_item_collection_metrics do
     :"aws.dynamodb.item_collection_metrics"
   end
-
   @doc """
   The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_provisioned_read_capacity()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_provisioned_read_capacity()
       :"aws.dynamodb.provisioned_read_capacity"
   """
   @spec aws_dynamodb_provisioned_read_capacity :: :"aws.dynamodb.provisioned_read_capacity"
-  defmacro aws_dynamodb_provisioned_read_capacity do
+  def aws_dynamodb_provisioned_read_capacity do
     :"aws.dynamodb.provisioned_read_capacity"
   end
-
   @doc """
   The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_provisioned_write_capacity()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_provisioned_write_capacity()
       :"aws.dynamodb.provisioned_write_capacity"
   """
   @spec aws_dynamodb_provisioned_write_capacity :: :"aws.dynamodb.provisioned_write_capacity"
-  defmacro aws_dynamodb_provisioned_write_capacity do
+  def aws_dynamodb_provisioned_write_capacity do
     :"aws.dynamodb.provisioned_write_capacity"
   end
-
   @doc """
   The value of the `ConsistentRead` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_consistent_read()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_consistent_read()
       :"aws.dynamodb.consistent_read"
   """
   @spec aws_dynamodb_consistent_read :: :"aws.dynamodb.consistent_read"
-  defmacro aws_dynamodb_consistent_read do
+  def aws_dynamodb_consistent_read do
     :"aws.dynamodb.consistent_read"
   end
-
   @doc """
   The value of the `ProjectionExpression` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_projection()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_projection()
       :"aws.dynamodb.projection"
   """
   @spec aws_dynamodb_projection :: :"aws.dynamodb.projection"
-  defmacro aws_dynamodb_projection do
+  def aws_dynamodb_projection do
     :"aws.dynamodb.projection"
   end
-
   @doc """
   The value of the `Limit` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_limit()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_limit()
       :"aws.dynamodb.limit"
   """
   @spec aws_dynamodb_limit :: :"aws.dynamodb.limit"
-  defmacro aws_dynamodb_limit do
+  def aws_dynamodb_limit do
     :"aws.dynamodb.limit"
   end
-
   @doc """
   The value of the `AttributesToGet` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_attributes_to_get()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_attributes_to_get()
       :"aws.dynamodb.attributes_to_get"
   """
   @spec aws_dynamodb_attributes_to_get :: :"aws.dynamodb.attributes_to_get"
-  defmacro aws_dynamodb_attributes_to_get do
+  def aws_dynamodb_attributes_to_get do
     :"aws.dynamodb.attributes_to_get"
   end
-
   @doc """
   The value of the `IndexName` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_index_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_index_name()
       :"aws.dynamodb.index_name"
   """
   @spec aws_dynamodb_index_name :: :"aws.dynamodb.index_name"
-  defmacro aws_dynamodb_index_name do
+  def aws_dynamodb_index_name do
     :"aws.dynamodb.index_name"
   end
-
   @doc """
   The value of the `Select` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_select()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_select()
       :"aws.dynamodb.select"
   """
   @spec aws_dynamodb_select :: :"aws.dynamodb.select"
-  defmacro aws_dynamodb_select do
+  def aws_dynamodb_select do
     :"aws.dynamodb.select"
   end
-
   @doc """
   The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_global_secondary_indexes()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_global_secondary_indexes()
       :"aws.dynamodb.global_secondary_indexes"
   """
   @spec aws_dynamodb_global_secondary_indexes :: :"aws.dynamodb.global_secondary_indexes"
-  defmacro aws_dynamodb_global_secondary_indexes do
+  def aws_dynamodb_global_secondary_indexes do
     :"aws.dynamodb.global_secondary_indexes"
   end
-
   @doc """
   The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_local_secondary_indexes()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_local_secondary_indexes()
       :"aws.dynamodb.local_secondary_indexes"
   """
   @spec aws_dynamodb_local_secondary_indexes :: :"aws.dynamodb.local_secondary_indexes"
-  defmacro aws_dynamodb_local_secondary_indexes do
+  def aws_dynamodb_local_secondary_indexes do
     :"aws.dynamodb.local_secondary_indexes"
   end
-
   @doc """
   The value of the `ExclusiveStartTableName` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_exclusive_start_table()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_exclusive_start_table()
       :"aws.dynamodb.exclusive_start_table"
   """
   @spec aws_dynamodb_exclusive_start_table :: :"aws.dynamodb.exclusive_start_table"
-  defmacro aws_dynamodb_exclusive_start_table do
+  def aws_dynamodb_exclusive_start_table do
     :"aws.dynamodb.exclusive_start_table"
   end
-
   @doc """
   The the number of items in the `TableNames` response parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_table_count()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_table_count()
       :"aws.dynamodb.table_count"
   """
   @spec aws_dynamodb_table_count :: :"aws.dynamodb.table_count"
-  defmacro aws_dynamodb_table_count do
+  def aws_dynamodb_table_count do
     :"aws.dynamodb.table_count"
   end
-
   @doc """
   The value of the `ScanIndexForward` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_scan_forward()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_scan_forward()
       :"aws.dynamodb.scan_forward"
   """
   @spec aws_dynamodb_scan_forward :: :"aws.dynamodb.scan_forward"
-  defmacro aws_dynamodb_scan_forward do
+  def aws_dynamodb_scan_forward do
     :"aws.dynamodb.scan_forward"
   end
-
   @doc """
   The value of the `Segment` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_segment()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_segment()
       :"aws.dynamodb.segment"
   """
   @spec aws_dynamodb_segment :: :"aws.dynamodb.segment"
-  defmacro aws_dynamodb_segment do
+  def aws_dynamodb_segment do
     :"aws.dynamodb.segment"
   end
-
   @doc """
   The value of the `TotalSegments` request parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_total_segments()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_total_segments()
       :"aws.dynamodb.total_segments"
   """
   @spec aws_dynamodb_total_segments :: :"aws.dynamodb.total_segments"
-  defmacro aws_dynamodb_total_segments do
+  def aws_dynamodb_total_segments do
     :"aws.dynamodb.total_segments"
   end
-
   @doc """
   The value of the `Count` response parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_count()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_count()
       :"aws.dynamodb.count"
   """
   @spec aws_dynamodb_count :: :"aws.dynamodb.count"
-  defmacro aws_dynamodb_count do
+  def aws_dynamodb_count do
     :"aws.dynamodb.count"
   end
-
   @doc """
   The value of the `ScannedCount` response parameter
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_scanned_count()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_scanned_count()
       :"aws.dynamodb.scanned_count"
   """
   @spec aws_dynamodb_scanned_count :: :"aws.dynamodb.scanned_count"
-  defmacro aws_dynamodb_scanned_count do
+  def aws_dynamodb_scanned_count do
     :"aws.dynamodb.scanned_count"
   end
-
   @doc """
   The JSON-serialized value of each item in the `AttributeDefinitions` request field
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_attribute_definitions()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_attribute_definitions()
       :"aws.dynamodb.attribute_definitions"
   """
   @spec aws_dynamodb_attribute_definitions :: :"aws.dynamodb.attribute_definitions"
-  defmacro aws_dynamodb_attribute_definitions do
+  def aws_dynamodb_attribute_definitions do
     :"aws.dynamodb.attribute_definitions"
   end
-
   @doc """
   The JSON-serialized value of each item in the the `GlobalSecondaryIndexUpdates` request field
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_global_secondary_index_updates()
+      iex> OpenTelemetry.SemanticConventions.Trace.aws_dynamodb_global_secondary_index_updates()
       :"aws.dynamodb.global_secondary_index_updates"
   """
-  @spec aws_dynamodb_global_secondary_index_updates ::
-          :"aws.dynamodb.global_secondary_index_updates"
-  defmacro aws_dynamodb_global_secondary_index_updates do
+  @spec aws_dynamodb_global_secondary_index_updates :: :"aws.dynamodb.global_secondary_index_updates"
+  def aws_dynamodb_global_secondary_index_updates do
     :"aws.dynamodb.global_secondary_index_updates"
   end
-
   @doc """
   The name of the operation being executed
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.graphql_operation_name()
+      iex> OpenTelemetry.SemanticConventions.Trace.graphql_operation_name()
       :"graphql.operation.name"
   """
   @spec graphql_operation_name :: :"graphql.operation.name"
-  defmacro graphql_operation_name do
+  def graphql_operation_name do
     :"graphql.operation.name"
   end
-
   @doc """
   The type of the operation being executed
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.graphql_operation_type()
+      iex> OpenTelemetry.SemanticConventions.Trace.graphql_operation_type()
       :"graphql.operation.type"
   """
   @spec graphql_operation_type :: :"graphql.operation.type"
-  defmacro graphql_operation_type do
+  def graphql_operation_type do
     :"graphql.operation.type"
   end
-
   @doc """
   The GraphQL document being executed
 
@@ -1598,51 +1354,43 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   The value may be sanitized to exclude sensitive information
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.graphql_document()
+      iex> OpenTelemetry.SemanticConventions.Trace.graphql_document()
       :"graphql.document"
   """
   @spec graphql_document :: :"graphql.document"
-  defmacro graphql_document do
+  def graphql_document do
     :"graphql.document"
   end
-
   @doc """
   A string identifying the kind of message consumption as defined in the [Operation names](#operation-names) section above. If the operation is "send", this attribute MUST NOT be set, since the operation can be inferred from the span kind in that case
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_operation()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_operation()
       :"messaging.operation"
   """
   @spec messaging_operation :: :"messaging.operation"
-  defmacro messaging_operation do
+  def messaging_operation do
     :"messaging.operation"
   end
-
   @doc """
   The identifier for the consumer receiving a message. For Kafka, set it to `{messaging.kafka.consumer_group} - {messaging.kafka.client_id}`, if both are present, or only `messaging.kafka.consumer_group`. For brokers, such as RabbitMQ and Artemis, set it to the `client_id` of the client consuming the message
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_consumer_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_consumer_id()
       :"messaging.consumer_id"
   """
   @spec messaging_consumer_id :: :"messaging.consumer_id"
-  defmacro messaging_consumer_id do
+  def messaging_consumer_id do
     :"messaging.consumer_id"
   end
-
   @doc """
   RabbitMQ message routing key
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_rabbitmq_routing_key()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_rabbitmq_routing_key()
       :"messaging.rabbitmq.routing_key"
   """
   @spec messaging_rabbitmq_routing_key :: :"messaging.rabbitmq.routing_key"
-  defmacro messaging_rabbitmq_routing_key do
+  def messaging_rabbitmq_routing_key do
     :"messaging.rabbitmq.routing_key"
   end
-
   @doc """
   Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message_id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set
 
@@ -1650,219 +1398,183 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_message_key()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_message_key()
       :"messaging.kafka.message_key"
   """
   @spec messaging_kafka_message_key :: :"messaging.kafka.message_key"
-  defmacro messaging_kafka_message_key do
+  def messaging_kafka_message_key do
     :"messaging.kafka.message_key"
   end
-
   @doc """
   Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_consumer_group()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_consumer_group()
       :"messaging.kafka.consumer_group"
   """
   @spec messaging_kafka_consumer_group :: :"messaging.kafka.consumer_group"
-  defmacro messaging_kafka_consumer_group do
+  def messaging_kafka_consumer_group do
     :"messaging.kafka.consumer_group"
   end
-
   @doc """
   Client Id for the Consumer or Producer that is handling the message
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_client_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_client_id()
       :"messaging.kafka.client_id"
   """
   @spec messaging_kafka_client_id :: :"messaging.kafka.client_id"
-  defmacro messaging_kafka_client_id do
+  def messaging_kafka_client_id do
     :"messaging.kafka.client_id"
   end
-
   @doc """
   Partition the message is sent to
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_partition()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_partition()
       :"messaging.kafka.partition"
   """
   @spec messaging_kafka_partition :: :"messaging.kafka.partition"
-  defmacro messaging_kafka_partition do
+  def messaging_kafka_partition do
     :"messaging.kafka.partition"
   end
-
   @doc """
   A boolean that is true if the message is a tombstone
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_tombstone()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_kafka_tombstone()
       :"messaging.kafka.tombstone"
   """
   @spec messaging_kafka_tombstone :: :"messaging.kafka.tombstone"
-  defmacro messaging_kafka_tombstone do
+  def messaging_kafka_tombstone do
     :"messaging.kafka.tombstone"
   end
-
   @doc """
   Namespace of RocketMQ resources, resources in different namespaces are individual
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_namespace()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_namespace()
       :"messaging.rocketmq.namespace"
   """
   @spec messaging_rocketmq_namespace :: :"messaging.rocketmq.namespace"
-  defmacro messaging_rocketmq_namespace do
+  def messaging_rocketmq_namespace do
     :"messaging.rocketmq.namespace"
   end
-
   @doc """
   Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_client_group()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_client_group()
       :"messaging.rocketmq.client_group"
   """
   @spec messaging_rocketmq_client_group :: :"messaging.rocketmq.client_group"
-  defmacro messaging_rocketmq_client_group do
+  def messaging_rocketmq_client_group do
     :"messaging.rocketmq.client_group"
   end
-
   @doc """
   The unique identifier for each client
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_client_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_client_id()
       :"messaging.rocketmq.client_id"
   """
   @spec messaging_rocketmq_client_id :: :"messaging.rocketmq.client_id"
-  defmacro messaging_rocketmq_client_id do
+  def messaging_rocketmq_client_id do
     :"messaging.rocketmq.client_id"
   end
-
   @doc """
   Type of message
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_message_type()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_message_type()
       :"messaging.rocketmq.message_type"
   """
   @spec messaging_rocketmq_message_type :: :"messaging.rocketmq.message_type"
-  defmacro messaging_rocketmq_message_type do
+  def messaging_rocketmq_message_type do
     :"messaging.rocketmq.message_type"
   end
-
   @doc """
   The secondary classifier of message besides topic
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_message_tag()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_message_tag()
       :"messaging.rocketmq.message_tag"
   """
   @spec messaging_rocketmq_message_tag :: :"messaging.rocketmq.message_tag"
-  defmacro messaging_rocketmq_message_tag do
+  def messaging_rocketmq_message_tag do
     :"messaging.rocketmq.message_tag"
   end
-
   @doc """
   Key(s) of message, another way to mark message besides message id
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_message_keys()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_message_keys()
       :"messaging.rocketmq.message_keys"
   """
   @spec messaging_rocketmq_message_keys :: :"messaging.rocketmq.message_keys"
-  defmacro messaging_rocketmq_message_keys do
+  def messaging_rocketmq_message_keys do
     :"messaging.rocketmq.message_keys"
   end
-
   @doc """
   Model of message consumption. This only applies to consumer spans
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_consumption_model()
+      iex> OpenTelemetry.SemanticConventions.Trace.messaging_rocketmq_consumption_model()
       :"messaging.rocketmq.consumption_model"
   """
   @spec messaging_rocketmq_consumption_model :: :"messaging.rocketmq.consumption_model"
-  defmacro messaging_rocketmq_consumption_model do
+  def messaging_rocketmq_consumption_model do
     :"messaging.rocketmq.consumption_model"
   end
-
   @doc """
   The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.rpc_grpc_status_code()
+      iex> OpenTelemetry.SemanticConventions.Trace.rpc_grpc_status_code()
       :"rpc.grpc.status_code"
   """
   @spec rpc_grpc_status_code :: :"rpc.grpc.status_code"
-  defmacro rpc_grpc_status_code do
+  def rpc_grpc_status_code do
     :"rpc.grpc.status_code"
   end
-
   @doc """
   Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 does not specify this, the value can be omitted
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.rpc_jsonrpc_version()
+      iex> OpenTelemetry.SemanticConventions.Trace.rpc_jsonrpc_version()
       :"rpc.jsonrpc.version"
   """
   @spec rpc_jsonrpc_version :: :"rpc.jsonrpc.version"
-  defmacro rpc_jsonrpc_version do
+  def rpc_jsonrpc_version do
     :"rpc.jsonrpc.version"
   end
-
   @doc """
   `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.rpc_jsonrpc_request_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.rpc_jsonrpc_request_id()
       :"rpc.jsonrpc.request_id"
   """
   @spec rpc_jsonrpc_request_id :: :"rpc.jsonrpc.request_id"
-  defmacro rpc_jsonrpc_request_id do
+  def rpc_jsonrpc_request_id do
     :"rpc.jsonrpc.request_id"
   end
-
   @doc """
   `error.code` property of response if it is an error response
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.rpc_jsonrpc_error_code()
+      iex> OpenTelemetry.SemanticConventions.Trace.rpc_jsonrpc_error_code()
       :"rpc.jsonrpc.error_code"
   """
   @spec rpc_jsonrpc_error_code :: :"rpc.jsonrpc.error_code"
-  defmacro rpc_jsonrpc_error_code do
+  def rpc_jsonrpc_error_code do
     :"rpc.jsonrpc.error_code"
   end
-
   @doc """
   `error.message` property of response if it is an error response
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.rpc_jsonrpc_error_message()
+      iex> OpenTelemetry.SemanticConventions.Trace.rpc_jsonrpc_error_message()
       :"rpc.jsonrpc.error_message"
   """
   @spec rpc_jsonrpc_error_message :: :"rpc.jsonrpc.error_message"
-  defmacro rpc_jsonrpc_error_message do
+  def rpc_jsonrpc_error_message do
     :"rpc.jsonrpc.error_message"
   end
-
   @doc """
   Whether this is a received or sent message
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.message_type()
+      iex> OpenTelemetry.SemanticConventions.Trace.message_type()
       :"message.type"
   """
   @spec message_type :: :"message.type"
-  defmacro message_type do
+  def message_type do
     :"message.type"
   end
-
   @doc """
   MUST be calculated as two different counters starting from `1` one for sent messages and one for received message
 
@@ -1870,36 +1582,31 @@ defmodule OpenTelemetry.SemanticConventions.Trace do
 
   This way we guarantee that the values will be consistent between different implementations
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.message_id()
+      iex> OpenTelemetry.SemanticConventions.Trace.message_id()
       :"message.id"
   """
   @spec message_id :: :"message.id"
-  defmacro message_id do
+  def message_id do
     :"message.id"
   end
-
   @doc """
   Compressed size of the message in bytes
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.message_compressed_size()
+      iex> OpenTelemetry.SemanticConventions.Trace.message_compressed_size()
       :"message.compressed_size"
   """
   @spec message_compressed_size :: :"message.compressed_size"
-  defmacro message_compressed_size do
+  def message_compressed_size do
     :"message.compressed_size"
   end
-
   @doc """
   Uncompressed size of the message in bytes
 
-      iex> require OpenTelemetry.SemanticConventions.Trace
-      ...> OpenTelemetry.SemanticConventions.Trace.message_uncompressed_size()
+      iex> OpenTelemetry.SemanticConventions.Trace.message_uncompressed_size()
       :"message.uncompressed_size"
   """
   @spec message_uncompressed_size :: :"message.uncompressed_size"
-  defmacro message_uncompressed_size do
+  def message_uncompressed_size do
     :"message.uncompressed_size"
   end
 end

--- a/apps/opentelemetry_semantic_conventions/templates/semantic_conventions.ex.j2
+++ b/apps/opentelemetry_semantic_conventions/templates/semantic_conventions.ex.j2
@@ -8,12 +8,11 @@ defmodule OpenTelemetry.SemanticConventions.{{ upFirst(module) }} do
   @doc """
   The schema url for telemetry resources.
 
-      iex> require OpenTelemetry.SemanticConventions.{{ upFirst(module) }}
-      ...> OpenTelemetry.SemanticConventions.{{ upFirst(module) }}.{{ module }}_schema_url()
+      iex> OpenTelemetry.SemanticConventions.{{ upFirst(module) }}.{{ module }}_schema_url()
       "{{ schema_uri }}"
   """
   @spec {{ module }}_schema_url :: String.t()
-  defmacro {{ module }}_schema_url do
+  def {{ module }}_schema_url do
     "{{ schema_uri }}"
   end
 
@@ -27,8 +26,7 @@ defmodule OpenTelemetry.SemanticConventions.{{ upFirst(module) }} do
   {{attribute.note | to_doc_brief | regex_replace(pattern="\n", replace="\n  ") }}
   {%- endif %}
 
-      iex> require OpenTelemetry.SemanticConventions.{{ upFirst(module) }}
-      ...> OpenTelemetry.SemanticConventions.{{ upFirst(module) }}.{{ funcName(attribute.fqn) }}()
+      iex> OpenTelemetry.SemanticConventions.{{ upFirst(module) }}.{{ funcName(attribute.fqn) }}()
       :"{{ attribute.fqn }}"
   """
   {%- if attribute.deprecated %}
@@ -37,7 +35,7 @@ defmodule OpenTelemetry.SemanticConventions.{{ upFirst(module) }} do
   """
   {%- endif %}
   @spec {{ funcName(attribute.fqn) }} :: :"{{ attribute.fqn }}"
-  defmacro {{ funcName(attribute.fqn) }} do
+  def {{ funcName(attribute.fqn) }} do
     :"{{ attribute.fqn }}"
   end
 


### PR DESCRIPTION
Macros are harder to use, since we must require the module. Requiring the module also pollutes the current context, which makes them less suitable for being used in other macros. The Elixir guide and hexdocs also both recommend against using macros unless absolutely necessary, see [Library Guidelines - Avoid Macros](https://hexdocs.pm/elixir/library-guidelines.html#avoid-macros). In this case, functions will work great!

If there are any performance concerns, we can inline the functions, and I believe the JIT compiler would inline these anyway because they're returning constants.

The only consequence of this change to users of this library will be compiler warnings saying that the `require` statement is unused, otherwise it will work exactly the same.