### PR TITLE
metric views: support filtering attributes

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_view.erl
+++ b/apps/opentelemetry_experimental/src/otel_view.erl
@@ -61,7 +61,7 @@ new(Criteria, Config) ->
     #view{name=CriteriaInstrumentName,
           instrument_matchspec=Matchspec,
           description=maps:get(description, Config, undefined),
-          attribute_keys=maps:get(attribute_keys, Config, []),
+          attribute_keys=maps:get(attribute_keys, Config, undefined),
           aggregation_module=maps:get(aggregation_module, Config, undefined),
           aggregation_options=maps:get(aggregation_options, Config, #{})}.
 
@@ -84,6 +84,7 @@ match_instrument_to_views(Instrument=#instrument{name=InstrumentName,
     Scope = otel_meter:scope(Meter),
     case lists:filtermap(fun(View=#view{name=ViewName,
                                         description=ViewDescription,
+                                        attribute_keys=AttributeKeys,
                                         aggregation_options=AggregationOptions,
                                         instrument_matchspec=Matchspec}) ->
                                  case ets:match_spec_run([Instrument], Matchspec) of
@@ -96,6 +97,7 @@ match_instrument_to_views(Instrument=#instrument{name=InstrumentName,
                                                                          instrument=Instrument,
                                                                          temporality=Temporality,
                                                                          is_monotonic=IsMonotonic,
+                                                                         attribute_keys=AttributeKeys,
                                                                          aggregation_options=AggregationOptions,
                                                                          description=value_or(ViewDescription,
                                                                                               Description)
@@ -108,6 +110,7 @@ match_instrument_to_views(Instrument=#instrument{name=InstrumentName,
                                            instrument=Instrument,
                                            temporality=Temporality,
                                            is_monotonic=IsMonotonic,
+                                           attribute_keys=undefined,
                                            aggregation_options=#{},
                                            description=Description}}];
         Aggs ->

--- a/apps/opentelemetry_experimental/src/otel_view.hrl
+++ b/apps/opentelemetry_experimental/src/otel_view.hrl
@@ -2,7 +2,7 @@
         {name                    :: otel_instrument:name(),
          instrument_matchspec    :: ets:compiled_match_spec(),
          description             :: unicode:unicode_binary() | undefined,
-         attribute_keys          :: [opentelemetry:attribute_key()],
+         attribute_keys          :: [opentelemetry:attribute_key()] | undefined,
          aggregation_module      :: module(),
          aggregation_options=#{} :: map()}).
 
@@ -12,6 +12,8 @@
          scope :: opentelemetry:instrumentation_scope(),
          instrument :: otel_instrument:t(),
          reader :: reference() | undefined,
+
+         attribute_keys :: [opentelemetry:attribute_key()] | undefined,
 
          aggregation_module :: module(),
          aggregation_options :: map(),


### PR DESCRIPTION
This required feature allows users to set the keys of attributes that a view will keep when creating metrics.
