### PR TITLE
documents valid span statuses

### DIFF
--- a/apps/opentelemetry_api/lib/open_telemetry.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry.ex
@@ -98,10 +98,11 @@ defmodule OpenTelemetry do
 
   @typedoc """
   An optional final status for this span. Semantically when Status
-  wasn't set it means span ended without errors and assume `unset`.
+  wasn't set it means span ended without errors and assume `:unset`.
 
-  Application developers may set the status as `ok` when the operation
-  has been validated to have completed successfully.
+  Application developers may set the status as `:ok` when the operation
+  has been validated to have completed successfully, or `:error` when
+  the operation contains an error.
   """
   @type status() :: :opentelemetry.status()
 

--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -154,7 +154,7 @@ defmodule OpenTelemetry.Span do
   Sets the Status of the currently active Span.
 
   If used, this will override the default Span Status, which is `:unset`.
-  Valid statuses are `:unset`, `:ok`, or `:error`.
+  Valid statuses are `:ok`, or `:error`.
   """
   @spec set_status(OpenTelemetry.span_ctx(), OpenTelemetry.status()) :: boolean()
   defdelegate set_status(span_ctx, status), to: :otel_span

--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -154,7 +154,8 @@ defmodule OpenTelemetry.Span do
   Sets the Status of the currently active Span.
 
   If used, this will override the default Span Status, which is `:unset`.
-  Valid statuses are `:ok`, or `:error`.
+  Valid statuses are `:ok`, or `:error`. Calling this will also set the
+  `status_code` attribute to `1`(`:ok`), or `2`(`:error`).
   """
   @spec set_status(OpenTelemetry.span_ctx(), OpenTelemetry.status()) :: boolean()
   defdelegate set_status(span_ctx, status), to: :otel_span

--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -154,6 +154,7 @@ defmodule OpenTelemetry.Span do
   Sets the Status of the currently active Span.
 
   If used, this will override the default Span Status, which is `:unset`.
+  Valid statuses are `:unset`, `:ok`, or `:error`.
   """
   @spec set_status(OpenTelemetry.span_ctx(), OpenTelemetry.status()) :: boolean()
   defdelegate set_status(span_ctx, status), to: :otel_span


### PR DESCRIPTION
In hindsight the `:unset` was a clue, but it wasn't clear to me what the valid options are for status -- might be nice to spell it out explicitly. I could also see it [here](https://github.com/open-telemetry/opentelemetry-erlang/blob/v1.2.1/apps/opentelemetry_api/lib/open_telemetry.ex#LL106-L106) instead 🤷🏻‍♂️