### PR TITLE
Fix swapping exporter tables

### DIFF
--- a/apps/opentelemetry/src/otel_batch_processor.erl
+++ b/apps/opentelemetry/src/otel_batch_processor.erl
@@ -392,7 +392,7 @@ export_spans(#data{exporter=Exporter,
                                   Table1 ->
                                       Table2;
                                   Table2 ->
-                                      Table2
+                                      Table1
                               end,
 
             %% an atom is a single word so this does not trigger a global GC


### PR DESCRIPTION
As discussed here: https://github.com/open-telemetry/opentelemetry-erlang/commit/dd91b8e8375bc3a211020f421985a8178fc40fed#r104883313

@tsloughter I haven't reproduced this case in the `openetelemetry` tests; I saw missing traces in our end-to-end tests where we check for traces after specific actions are executed. If you can suggest a good place to add a test in this repo (if possible), I'd appreciate it!

Thanks!

Edit: Will need to check on the CLA