### PR TITLE
metrics: support delta/cumulative conversions in sum aggregator

### DIFF
--- a/apps/opentelemetry_api_experimental/include/otel_metrics.hrl
+++ b/apps/opentelemetry_api_experimental/include/otel_metrics.hrl
@@ -4,8 +4,13 @@
                      description   :: otel_instrument:description(),
                      kind          :: otel_instrument:kind(),
                      unit          :: otel_instrument:unit() | undefined,
+                     temporality   :: otel_instrument:temporality(),
                      callback      :: otel_instrument:callback() | undefined,
                      callback_args :: term() | undefined}).
+
+-define(TEMPORALITY_DELTA, temporality_delta).
+-define(TEMPORALITY_CUMULATIVE, temporality_cumulative).
+-define(TEMPORALITY_UNSPECIFIED, temporality_unspecified).
 
 -define(KIND_COUNTER, counter).
 -define(KIND_OBSERVABLE_COUNTER, observable_counter).

--- a/apps/opentelemetry_api_experimental/src/otel_instrument.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_instrument.erl
@@ -34,6 +34,10 @@
 -type callback() :: fun((callback_args()) -> observation() |
                                              [named_observation()]).
 
+-type temporality() :: ?TEMPORALITY_UNSPECIFIED |
+                       ?TEMPORALITY_DELTA |
+                       ?TEMPORALITY_CUMULATIVE.
+
 -type t() :: #instrument{}.
 
 -export_type([t/0,
@@ -41,6 +45,7 @@
               description/0,
               kind/0,
               unit/0,
+              temporality/0,
               callback/0,
               callback_args/0]).
 
@@ -50,6 +55,7 @@ new(Module, Meter, Kind, Name, Description, Unit) ->
                 meter       = Meter,
                 name        = Name,
                 description = Description,
+                temporality = ?TEMPORALITY_DELTA,
                 kind        = Kind,
                 unit        = Unit}.
 
@@ -61,6 +67,7 @@ new(Module, Meter, Kind, Name, Description, Unit, Callback, CallbackArgs) ->
                 description   = Description,
                 kind          = Kind,
                 unit          = Unit,
+                temporality   = ?TEMPORALITY_CUMULATIVE,
                 callback      = Callback,
                 callback_args = CallbackArgs}.
 

--- a/apps/opentelemetry_experimental/include/otel_metrics.hrl
+++ b/apps/opentelemetry_experimental/include/otel_metrics.hrl
@@ -1,9 +1,5 @@
 -define(DEFAULT_METER_PROVIDER, otel_meter_provider_default).
 
--define(AGGREGATION_TEMPORALITY_DELTA, aggregation_temporality_delta).
--define(AGGREGATION_TEMPORALITY_CUMULATIVE, aggregation_temporality_cumulative).
--define(AGGREGATION_TEMPORALITY_UNSPECIFIED, aggregation_temporality_unspecified).
-
 -record(meter,
         {
          module                  :: module() | '_',
@@ -30,6 +26,7 @@
          start_time_unix_nano :: integer() | '_' | '$1' | {const, integer()},
          last_start_time_unix_nano :: integer() | undefined | '$5',
          checkpoint :: number() | undefined | '_' | '$2' | '$3',
+         previous_checkpoint :: number() | undefined | '_' | '$5',
          int_value :: number() | undefined | '$3' | {'+', '$3', {const, number()}},
          float_value :: number() | undefined | '$4' | {'+', '$4', {const, number()}}
         }).
@@ -83,7 +80,7 @@
 -record(sum,
         {
          datapoints :: [#datapoint{}],
-         aggregation_temporality :: otel_aggregation:temporality(),
+         aggregation_temporality :: otel_instrument:temporality(),
          is_monotonic :: boolean()
         }).
 
@@ -110,7 +107,7 @@
 -record(histogram,
        {
         datapoints :: [#histogram_datapoint{}],
-        aggregation_temporality :: otel_aggregation:temporality()
+        aggregation_temporality :: otel_instrument:temporality()
        }).
 
 -record(metric,

--- a/apps/opentelemetry_experimental/src/otel_aggregation.erl
+++ b/apps/opentelemetry_experimental/src/otel_aggregation.erl
@@ -9,10 +9,6 @@
 -include("otel_metrics.hrl").
 -include("otel_view.hrl").
 
--type temporality() :: ?AGGREGATION_TEMPORALITY_UNSPECIFIED |
-                       ?AGGREGATION_TEMPORALITY_DELTA |
-                       ?AGGREGATION_TEMPORALITY_CUMULATIVE.
-
 %% -type t() :: drop | sum | last_value | histogram.
 -type t() :: otel_aggregation_drop:t() | otel_aggregation_sum:t() |
              otel_aggregation_last_value:t() | otel_aggregation_histogram_explicit:t().
@@ -23,8 +19,7 @@
 
 -export_type([t/0,
               key/0,
-              options/0,
-              temporality/0]).
+              options/0]).
 
 %% Returns the aggregation's record as it is seen and updated by
 %% the aggregation module in the metrics table.
@@ -79,22 +74,22 @@ default_mapping() ->
       ?KIND_OBSERVABLE_UPDOWNCOUNTER => otel_aggregation_sum}.
 
 temporality_mapping() ->
-    #{?KIND_COUNTER =>?AGGREGATION_TEMPORALITY_DELTA,
-      ?KIND_OBSERVABLE_COUNTER => ?AGGREGATION_TEMPORALITY_CUMULATIVE,
-      ?KIND_UPDOWN_COUNTER => ?AGGREGATION_TEMPORALITY_DELTA,
-      ?KIND_OBSERVABLE_UPDOWNCOUNTER => ?AGGREGATION_TEMPORALITY_CUMULATIVE,
-      ?KIND_HISTOGRAM => ?AGGREGATION_TEMPORALITY_UNSPECIFIED,
-      ?KIND_OBSERVABLE_GAUGE => ?AGGREGATION_TEMPORALITY_UNSPECIFIED}.
+    #{?KIND_COUNTER =>?TEMPORALITY_DELTA,
+      ?KIND_OBSERVABLE_COUNTER => ?TEMPORALITY_CUMULATIVE,
+      ?KIND_UPDOWN_COUNTER => ?TEMPORALITY_DELTA,
+      ?KIND_OBSERVABLE_UPDOWNCOUNTER => ?TEMPORALITY_CUMULATIVE,
+      ?KIND_HISTOGRAM => ?TEMPORALITY_UNSPECIFIED,
+      ?KIND_OBSERVABLE_GAUGE => ?TEMPORALITY_UNSPECIFIED}.
 
 instrument_temporality(#instrument{kind=?KIND_COUNTER}) ->
-    ?AGGREGATION_TEMPORALITY_DELTA;
+    ?TEMPORALITY_DELTA;
 instrument_temporality(#instrument{kind=?KIND_OBSERVABLE_COUNTER}) ->
-    ?AGGREGATION_TEMPORALITY_CUMULATIVE;
+    ?TEMPORALITY_CUMULATIVE;
 instrument_temporality(#instrument{kind=?KIND_UPDOWN_COUNTER}) ->
-    ?AGGREGATION_TEMPORALITY_DELTA;
+    ?TEMPORALITY_DELTA;
 instrument_temporality(#instrument{kind=?KIND_OBSERVABLE_UPDOWNCOUNTER}) ->
-    ?AGGREGATION_TEMPORALITY_CUMULATIVE;
+    ?TEMPORALITY_CUMULATIVE;
 instrument_temporality(#instrument{kind=?KIND_HISTOGRAM}) ->
-    ?AGGREGATION_TEMPORALITY_UNSPECIFIED;
+    ?TEMPORALITY_UNSPECIFIED;
 instrument_temporality(#instrument{kind=?KIND_OBSERVABLE_GAUGE}) ->
-    ?AGGREGATION_TEMPORALITY_UNSPECIFIED.
+    ?TEMPORALITY_UNSPECIFIED.

--- a/apps/opentelemetry_experimental/src/otel_aggregation_histogram_explicit.erl
+++ b/apps/opentelemetry_experimental/src/otel_aggregation_histogram_explicit.erl
@@ -133,7 +133,7 @@ aggregate(Table, #view_aggregation{name=Name,
 -dialyzer({nowarn_function, checkpoint/3}).
 checkpoint(Tab, #view_aggregation{name=Name,
                                   reader=ReaderId,
-                                  temporality=?AGGREGATION_TEMPORALITY_DELTA}, CollectionStartNano) ->
+                                  temporality=?TEMPORALITY_DELTA}, CollectionStartNano) ->
     MS = [{#explicit_histogram_aggregation{key='$1',
                                            start_time_unix_nano='$9',
                                            boundaries='$2',

--- a/apps/opentelemetry_experimental/src/otel_aggregation_last_value.erl
+++ b/apps/opentelemetry_experimental/src/otel_aggregation_last_value.erl
@@ -24,6 +24,7 @@
          checkpoint/3,
          collect/3]).
 
+-include_lib("opentelemetry_api_experimental/include/otel_metrics.hrl").
 -include("otel_metrics.hrl").
 
 -type t() :: #last_value_aggregation{}.
@@ -55,7 +56,7 @@ aggregate(Tab, ViewAggregation=#view_aggregation{name=Name,
 -dialyzer({nowarn_function, checkpoint/3}).
 checkpoint(Tab, #view_aggregation{name=Name,
                                   reader=ReaderId,
-                                  temporality=?AGGREGATION_TEMPORALITY_DELTA}, CollectionStartNano) ->
+                                  temporality=?TEMPORALITY_DELTA}, CollectionStartNano) ->
     MS = [{#last_value_aggregation{key='$1',
                                    start_time_unix_nano='$3',
                                    last_start_time_unix_nano='_',

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -220,10 +220,8 @@ handle_call({add_instrument, Instrument}, _From, State=#state{readers=Readers,
     _ = add_instrument_(InstrumentsTab, CallbacksTab, ViewAggregationsTab, Instrument, Views, Readers),
     {reply, ok, State};
 handle_call({register_callback, Instruments, Callback, CallbackArgs}, _From, State=#state{readers=Readers,
-                                                                                          views=Views,
-                                                                                          callbacks_tab=CallbacksTab,
-                                                                                          view_aggregations_tab=ViewAggregationsTab}) ->
-    _ = register_callback_(CallbacksTab, ViewAggregationsTab, Instruments, Callback, CallbackArgs, Views, Readers),
+                                                                                          callbacks_tab=CallbacksTab}) ->
+    _ = register_callback_(CallbacksTab, Instruments, Callback, CallbackArgs, Readers),
     {reply, ok, State};
 handle_call({get_meter, Name, Vsn, SchemaUrl}, _From, State=#state{shared_meter=Meter}) ->
     Scope = opentelemetry:instrumentation_scope(Name, Vsn, SchemaUrl),
@@ -344,15 +342,10 @@ update_view_aggregations_(Instrument=#instrument{meter=Meter,
                   end, Readers).
 
 %% Match the Instrument to views and then store a per-Reader aggregation for the View
-register_callback_(CallbacksTab, ViewAggregationsTab, Instruments, Callback, CallbackArgs, Views, Readers) ->
-    lists:foreach(fun(Instrument) ->
-                          ViewMatches = otel_view:match_instrument_to_views(Instrument, Views),
-                          lists:map(fun(Reader=#reader{id=ReaderId}) ->
-                                            Matches = per_reader_aggregations(Reader, Instrument, ViewMatches),
-                                            [true = ets:insert(ViewAggregationsTab, {Instrument, M}) || M <- Matches],
-                                            ets:insert(CallbacksTab, {ReaderId, {Callback, CallbackArgs, Instruments}})
-                                    end, Readers)
-                  end, Instruments).
+register_callback_(CallbacksTab, Instruments, Callback, CallbackArgs, Readers) ->
+    lists:map(fun(#reader{id=ReaderId}) ->
+                      ets:insert(CallbacksTab, {ReaderId, {Callback, CallbackArgs, Instruments}})
+              end, Readers).
 
 metric_reader(ReaderId, ReaderPid, DefaultAggregationMapping, Temporality) ->
     %% TODO: Uncomment when we can drop OTP-23 support
@@ -407,7 +400,7 @@ view_aggregation_for_reader(Instrument=#instrument{kind=Kind}, ViewAggregation, 
                             Reader=#reader{id=Id,
                                            default_temporality_mapping=ReaderTemporalityMapping}) ->
     AggregationModule = aggregation_module(Instrument, View, Reader),
-    Temporality = maps:get(Kind, ReaderTemporalityMapping, ?AGGREGATION_TEMPORALITY_UNSPECIFIED),
+    Temporality = maps:get(Kind, ReaderTemporalityMapping, ?TEMPORALITY_UNSPECIFIED),
 
     ViewAggregation#view_aggregation{
       reader=Id,
@@ -419,7 +412,7 @@ view_aggregation_for_reader(Instrument=#instrument{kind=Kind}, ViewAggregation, 
                             Reader=#reader{id=Id,
                                            default_temporality_mapping=ReaderTemporalityMapping}) ->
     AggregationModule = aggregation_module(Instrument, View, Reader),
-    Temporality = maps:get(Kind, ReaderTemporalityMapping, ?AGGREGATION_TEMPORALITY_UNSPECIFIED),
+    Temporality = maps:get(Kind, ReaderTemporalityMapping, ?TEMPORALITY_UNSPECIFIED),
 
     ViewAggregation#view_aggregation{
       reader=Id,

--- a/apps/opentelemetry_experimental/src/otel_view.hrl
+++ b/apps/opentelemetry_experimental/src/otel_view.hrl
@@ -8,7 +8,7 @@
 
 -record(view_aggregation,
         {%% name of the view or instrument if the view has no name
-         name ::  atom(),
+         name :: atom(),
          scope :: opentelemetry:instrumentation_scope(),
          instrument :: otel_instrument:t(),
          reader :: reference() | undefined,
@@ -18,7 +18,7 @@
          aggregation_module :: module(),
          aggregation_options :: map(),
 
-         temporality :: otel_aggregation:temporality(),
+         temporality :: otel_instrument:temporality(),
          is_monotonic :: boolean(),
 
          %% description from the view or the instrument if the view has no name

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -76,7 +76,7 @@ verify_metrics_export(Config) ->
                        name = <<"sum name">>,
                        description = <<"some sum description">>,
                        unit = kb,
-                       data = #sum{aggregation_temporality = 'AGGREGATION_TEMPORALITY_CUMULATIVE',
+                       data = #sum{aggregation_temporality = 'TEMPORALITY_CUMULATIVE',
                                    is_monotonic=true,
                                    datapoints=[#datapoint{
                                                   attributes=otel_attributes:new(#{<<"key-1">> => <<"value-1">>},
@@ -126,7 +126,7 @@ verify_metrics_export(Config) ->
                        name = <<"histogram name">>,
                        description = <<"some histogram description">>,
                        unit = kb,
-                       data = #histogram{aggregation_temporality = 'AGGREGATION_TEMPORALITY_CUMULATIVE',
+                       data = #histogram{aggregation_temporality = 'TEMPORALITY_CUMULATIVE',
                                          datapoints=[#histogram_datapoint{
                                                         attributes=otel_attributes:new(#{<<"key-1">> => <<"value-1">>},
                                                                                        128, 128),


### PR DESCRIPTION
Cumulative aggregate is now also reset on each collection. A previous checkpoint field is tracked in order to add the current value to the previous in the case of needing the cumulative and subtracting in the case you have a cumulative but need a delta (example being an Observable which reports the cumulative value in each callback and needed it reported as a delta).