### PR TITLE
metrics: fix observable callbacks to return a list of results

### DIFF
--- a/apps/opentelemetry_api_experimental/src/otel_instrument.erl
+++ b/apps/opentelemetry_api_experimental/src/otel_instrument.erl
@@ -29,10 +29,11 @@
                 ?KIND_OBSERVABLE_GAUGE | ?KIND_UPDOWN_COUNTER | ?KIND_OBSERVABLE_UPDOWNCOUNTER.
 -type unit() :: atom(). %% latin1, maximum length of 63 characters
 -type observation() :: {number(), opentelemetry:attributes_map()}.
--type named_observation() :: {name(), number(), opentelemetry:attributes_map()}.
+-type named_observations() :: {name(), [observation()]}.
 -type callback_args() :: term().
--type callback() :: fun((callback_args()) -> observation() |
-                                             [named_observation()]).
+-type callback_result() :: [observation()] |
+                           [named_observations()].
+-type callback() :: fun((callback_args()) -> callback_result()).
 
 -type temporality() :: ?TEMPORALITY_UNSPECIFIED |
                        ?TEMPORALITY_DELTA |
@@ -47,7 +48,8 @@
               unit/0,
               temporality/0,
               callback/0,
-              callback_args/0]).
+              callback_args/0,
+              callback_result/0]).
 
 -spec new(module(), otel_meter:t(), kind(), name(), description(), unit()) -> t().
 new(Module, Meter, Kind, Name, Description, Unit) ->

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -311,7 +311,7 @@ add_instrument_(InstrumentsTab, CallbacksTab, ViewAggregationsTab, Instrument=#i
                                       {undefined, _} ->
                                           ok;
                                       {Callback, CallbackArgs} ->
-                                          ets:insert(CallbacksTab, {ReaderId, {Callback, CallbackArgs, [Instrument]}})
+                                          ets:insert(CallbacksTab, {ReaderId, {Callback, CallbackArgs, Instrument}})
                                   end
                           end, Readers);
         false ->
@@ -337,7 +337,7 @@ update_view_aggregations_(Instrument=#instrument{meter=Meter,
                               {undefined, _} ->
                                   ok;
                               {Callback, CallbackArgs} ->
-                                  ets:insert(CallbacksTab, {ReaderId, {Callback, CallbackArgs, [Instrument]}})
+                                  ets:insert(CallbacksTab, {ReaderId, {Callback, CallbackArgs, Instrument}})
                           end
                   end, Readers).
 

--- a/apps/opentelemetry_experimental/src/otel_observables.erl
+++ b/apps/opentelemetry_experimental/src/otel_observables.erl
@@ -1,0 +1,105 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2023, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% @end
+%%%-------------------------------------------------------------------------
+-module(otel_observables).
+
+-export([run_callbacks/4]).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("opentelemetry_api_experimental/include/otel_metrics.hrl").
+-include("otel_metrics.hrl").
+-include("otel_view.hrl").
+
+-type callbacks() :: [{otel_instrument:callback(), otel_instrument:callback_args(), otel_instrument:t()}].
+
+%% call each callback and associate the result with the Instruments it observes
+-spec run_callbacks(callbacks(), reference(), ets:table(), ets:table()) -> ok.
+run_callbacks(Callbacks, ReaderId, ViewAggregationTab, MetricsTab) ->
+    lists:foreach(fun({Callback, CallbackArgs, Instruments})
+                        when is_list(Instruments) ->
+                          Results = Callback(CallbackArgs),
+                          handle_instruments_observations(Results,
+                                                          Instruments,
+                                                          ViewAggregationTab,
+                                                          MetricsTab,
+                                                          ReaderId);
+                     ({Callback, CallbackArgs, Instrument}) ->
+                          Results = Callback(CallbackArgs),
+                          handle_instrument_observations(Results,
+                                                         Instrument,
+                                                         ViewAggregationTab,
+                                                         MetricsTab,
+                                                         ReaderId)
+                  end, Callbacks).
+
+%% lookup ViewAggregations for Instrument and aggregate each observation
+-spec handle_instrument_observations([otel_instrument:observation()], otel_instrument:t(),
+                                     ets:table(), ets:table(), reference()) -> ok.
+handle_instrument_observations(Results, #instrument{meter=Meter,
+                                                    name=Name},
+                               ViewAggregationTab, MetricsTab, ReaderId) ->
+    try ets:lookup_element(ViewAggregationTab, {Meter, Name}, 2) of
+        ViewAggregations ->
+            [handle_observations(MetricsTab, ViewAggregation, Results)
+             || #view_aggregation{reader=Id}=ViewAggregation <- ViewAggregations,
+                Id =:= ReaderId],
+            ok
+    catch
+        error:badarg ->
+            %% no Views for this Instrument, so nothing to do
+            []
+    end.
+
+%% handle results for a multi-instrument callback
+-spec handle_instruments_observations([otel_instrument:named_observations()], [otel_instrument:t()],
+                                      ets:table(), ets:table(), reference()) -> ok.
+handle_instruments_observations([], _Instruments, _ViewAggregationTab, _MetricsTab, _ReaderId) ->
+    ok;
+handle_instruments_observations([{InstrumentName, Results} | Rest], Instruments,
+                                ViewAggregationTab, MetricsTab, ReaderId) ->
+    case lists:keyfind(InstrumentName, #instrument.name, Instruments) of
+        false ->
+            ?LOG_DEBUG("Unknown Instrument ~p used in metric callback", [InstrumentName]);
+        Instrument ->
+            handle_instrument_observations(Results, Instrument, ViewAggregationTab, MetricsTab, ReaderId)
+    end,
+    handle_instruments_observations(Rest, Instruments, ViewAggregationTab, MetricsTab, ReaderId);
+handle_instruments_observations([Result | Rest], Instruments, ViewAggregationTab, MetricsTab, ReaderId) ->
+    ?LOG_DEBUG("Each multi-instrument callback result must be a tuple of "
+               "type {atom(), [{number(), map()}]} but got ~p", [Result]),
+    handle_instruments_observations(Rest, Instruments, ViewAggregationTab, MetricsTab, ReaderId);
+handle_instruments_observations(Results, _Instruments, _ViewAggregationTab, _MetricsTab, _ReaderId) ->
+    ?LOG_DEBUG("Multi-instrument callback result must be a list of type "
+               "[{atom(), [{number(), map()}]}] but got ~p", [Results]),
+    ok.
+
+
+%% update aggregation for each observation
+handle_observations(_MetricsTab, _ViewAggregation, []) ->
+    ok;
+handle_observations(MetricsTab, ViewAggregation, [{Number, Attributes} | Rest])
+  when is_number(Number),
+       is_map(Attributes) ->
+    _ = otel_aggregation:maybe_init_aggregate(MetricsTab, ViewAggregation, Number, Attributes),
+    handle_observations(MetricsTab, ViewAggregation, Rest);
+handle_observations(MetricsTab, ViewAggregation, [Result | Rest]) ->
+    ?LOG_DEBUG("Each metric callback result must be of type {number(), map()} but got ~p", [Result]),
+    handle_observations(MetricsTab, ViewAggregation, Rest);
+handle_observations(_MetricsTab, _ViewAggregation, Result) ->
+    ?LOG_DEBUG("Metric callback return must be a list of type [{number(), map()}] or "
+               "[{atom(), [{number(), map()}]}] but got", [Result]),
+    ok.


### PR DESCRIPTION
the instrument could have a result for multiple sets of attributes, so a list of observations must be returned in every case.