### PR TITLE
Resource as an argument to starting the tracer provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## SDK
+
+### Changes
+
+- [Resource is now an argument to TracerProvider start, but still set
+  automatically by SDK startup of the global
+  Provider](https://github.com/open-telemetry/opentelemetry-erlang/pull/568)
+- [Global Tracer no longer set to no-op on SDK
+  shutdown](https://github.com/open-telemetry/opentelemetry-erlang/pull/568)
+
 ## SDK 1.3.0 - 2023-03-21
 
 ### Fixes
 
 - [Fix swapping exporter
-  tables](https://github.com/open-telemetry/opentelemetry-erlang/pull/550)
+  tables](https://github.com/open-telemetry/opentelemetry-erlang/pull/559)
 
 ## Exporter 1.4.0 - 2023-02-21
 

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -36,7 +36,8 @@ start(_StartType, _StartArgs) ->
 
     SupResult = opentelemetry_sup:start_link(Config),
 
-    _ = opentelemetry:start_tracer_provider(?GLOBAL_TRACER_PROVIDER_NAME, Config),
+    Resource = otel_resource_detector:get_resource(),
+    _ = opentelemetry:start_tracer_provider(?GLOBAL_TRACER_PROVIDER_NAME, Resource, Config),
 
     %% must be done after the supervisor starts so that otel_tracer_server is running
     %% TODO: make this work with release upgrades. Currently if an application's version

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -37,7 +37,7 @@ start(_StartType, _StartArgs) ->
     SupResult = opentelemetry_sup:start_link(Config),
 
     Resource = otel_resource_detector:get_resource(),
-    _ = opentelemetry:start_tracer_provider(?GLOBAL_TRACER_PROVIDER_NAME, Resource, Config),
+    _ = otel_tracer_provider_sup:start(?GLOBAL_TRACER_PROVIDER_NAME, Resource, Config),
 
     %% must be done after the supervisor starts so that otel_tracer_server is running
     %% TODO: make this work with release upgrades. Currently if an application's version

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -47,7 +47,6 @@ start(_StartType, _StartArgs) ->
     SupResult.
 
 stop(_State) ->
-    opentelemetry:set_default_tracer({otel_tracer_noop, []}),
     ok.
 
 %% internal functions

--- a/apps/opentelemetry/src/otel_tracer_provider_sup.erl
+++ b/apps/opentelemetry/src/otel_tracer_provider_sup.erl
@@ -19,7 +19,9 @@
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/0,
+         start/2,
+         start/3]).
 
 -export([init/1]).
 
@@ -27,6 +29,13 @@
 
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%% here to support deprecated function `opentelemetry:start_tracer_provider/2'
+start(Name, Config) ->
+    supervisor:start_child(?MODULE, [Name, otel_resource:create([]), Config]).
+
+start(Name, Resource, Config) ->
+    supervisor:start_child(?MODULE, [Name, Resource, Config]).
 
 init([]) ->
     SupFlags = #{strategy => simple_one_for_one,

--- a/apps/opentelemetry/src/otel_tracer_provider_sup.erl
+++ b/apps/opentelemetry/src/otel_tracer_provider_sup.erl
@@ -32,7 +32,7 @@ start_link() ->
 
 %% here to support deprecated function `opentelemetry:start_tracer_provider/2'
 start(Name, Config) ->
-    supervisor:start_child(?MODULE, [Name, otel_resource:create([]), Config]).
+    start(Name, otel_resource:create([]), Config).
 
 start(Name, Resource, Config) ->
     supervisor:start_child(?MODULE, [Name, Resource, Config]).

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -23,7 +23,7 @@
 
 -behaviour(gen_server).
 
--export([start_link/4]).
+-export([start_link/5]).
 
 -export([init/1,
          handle_call/3,
@@ -54,16 +54,14 @@
          deny_list :: [atom() | {atom(), string()}]
         }).
 
--spec start_link(atom(), atom(), atom(), otel_configuration:t()) -> {ok, pid()} | ignore | {error, term()}.
-start_link(Name, RegName, SpanProcessorSupRegName, Config) ->
-    gen_server:start_link({local, RegName}, ?MODULE, [Name, SpanProcessorSupRegName, Config], []).
+-spec start_link(atom(), atom(), atom(), otel_resource:t(), otel_configuration:t()) -> {ok, pid()} | ignore | {error, term()}.
+start_link(Name, RegName, SpanProcessorSupRegName, Resource, Config) ->
+    gen_server:start_link({local, RegName}, ?MODULE, [Name, SpanProcessorSupRegName, Resource, Config], []).
 
-init([Name, SpanProcessorSup, #{id_generator := IdGeneratorModule,
-                                sampler := SamplerSpec,
-                                processors := Processors,
-                                deny_list := DenyList}]) ->
-    Resource = otel_resource_detector:get_resource(),
-
+init([Name, SpanProcessorSup, Resource, #{id_generator := IdGeneratorModule,
+                                          sampler := SamplerSpec,
+                                          processors := Processors,
+                                          deny_list := DenyList}]) ->
     Sampler = otel_sampler:new(SamplerSpec),
 
     Processors1 = init_processors(SpanProcessorSup, Processors),

--- a/apps/opentelemetry/src/otel_tracer_server_sup.erl
+++ b/apps/opentelemetry/src/otel_tracer_server_sup.erl
@@ -19,16 +19,16 @@
 
 -behaviour(supervisor).
 
--export([start_link/2]).
+-export([start_link/3]).
 
 -export([init/1]).
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 
-start_link(Name, Opts) ->
-    supervisor:start_link(?MODULE, [Name, Opts]).
+start_link(Name, Resource, Opts) ->
+    supervisor:start_link(?MODULE, [Name, Resource, Opts]).
 
-init([Name, Opts]) ->
+init([Name, Resource, Opts]) ->
     SupFlags = #{strategy => one_for_one,
                  intensity => 1,
                  period => 5},
@@ -50,6 +50,7 @@ init([Name, Opts]) ->
                      start => {otel_tracer_server, start_link, [Name,
                                                                 TracerServeRegName,
                                                                 SpanProcessorSupRegName,
+                                                                Resource,
                                                                 Opts]},
                      restart => permanent,
                      shutdown => 5000,

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -632,14 +632,14 @@ multiple_processors(_Config) ->
 
 multiple_tracer_providers(_Config) ->
     Resource = otel_resource:create([{<<"a">>, <<"b">>}]),
-    ?assertMatch({ok, _}, opentelemetry:start_tracer_provider(test_provider,
-                                                              Resource,
-                                                              #{id_generator => otel_id_generator,
-                                                                sampler => {otel_sampler_always_on, []},
-                                                                processors => [{otel_batch_processor, #{name => test_batch,
-                                                                                                        scheduled_delay_ms => 1,
-                                                                                                        exporter => {otel_exporter_pid, self()}}}],
-                                                                deny_list => []})),
+    ?assertMatch({ok, _}, otel_tracer_provider_sup:start(test_provider,
+                                                         Resource,
+                                                         #{id_generator => otel_id_generator,
+                                                           sampler => {otel_sampler_always_on, []},
+                                                           processors => [{otel_batch_processor, #{name => test_batch,
+                                                                                                   scheduled_delay_ms => 1,
+                                                                                                   exporter => {otel_exporter_pid, self()}}}],
+                                                           deny_list => []})),
 
 
     ?assertEqual(Resource, otel_tracer_provider:resource(test_provider)),

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -640,9 +640,18 @@ multiple_tracer_providers(_Config) ->
                                                                                                    scheduled_delay_ms => 1,
                                                                                                    exporter => {otel_exporter_pid, self()}}}],
                                                            deny_list => []})),
-
-
     ?assertEqual(Resource, otel_tracer_provider:resource(test_provider)),
+
+    %% keep around a test of the deprecated API function for starting a tracer provider
+    ?assertMatch({ok, _}, opentelemetry:start_tracer_provider(deprecated_test_provider_start,
+                                                              #{id_generator => otel_id_generator,
+                                                                sampler => {otel_sampler_always_on, []},
+                                                                processors => [{otel_batch_processor, #{name => test_batch_2,
+                                                                                                        scheduled_delay_ms => 1000,
+                                                                                                        exporter => {otel_exporter_pid, self()}}}],
+                                                                deny_list => []})),
+
+    ?assertEqual(otel_resource:create([]), otel_tracer_provider:resource(deprecated_test_provider_start)),
 
     GlobalResource = otel_tracer_provider:resource(),
     GlobalResourceAttributes = otel_attributes:map(otel_resource:attributes(GlobalResource)),

--- a/apps/opentelemetry_api/dialyzer.ignore-warnings
+++ b/apps/opentelemetry_api/dialyzer.ignore-warnings
@@ -1,0 +1,1 @@
+src/otel_tracer_provider.erl:37:5: Unknown function otel_tracer_provider_sup:start/2

--- a/apps/opentelemetry_api/mix.exs
+++ b/apps/opentelemetry_api/mix.exs
@@ -18,7 +18,8 @@ defmodule OpenTelemetry.MixProject do
       name: "OpenTelemetry API",
       test_coverage: [tool: :covertool],
       package: package(),
-      aliases: [docs: & &1]
+      aliases: [docs: & &1],
+      dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"]
     ]
   end
 

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -28,7 +28,7 @@
 %%%-------------------------------------------------------------------------
 -module(opentelemetry).
 
--export([start_tracer_provider/3,
+-export([start_tracer_provider/2,
          set_default_tracer/1,
          set_default_tracer/2,
          create_application_tracers/1,
@@ -152,11 +152,13 @@
 -define(TEXT_MAP_EXTRACTOR_KEY, {?MODULE, text_map_extractor}).
 -define(TEXT_MAP_INJECTOR_KEY, {?MODULE, text_map_injector}).
 
+-deprecated({start_tracer_provider, 2, "start the TracerProvider through the SDK"}).
+
 -include("gradualizer.hrl").
 
--spec start_tracer_provider(atom(), otel_resource:t(), map()) -> {ok, pid() | undefined} | {error, term()}.
-start_tracer_provider(Name, Resource, Config) ->
-    otel_tracer_provider:start(Name, Resource, Config).
+-spec start_tracer_provider(atom(), map()) -> {ok, pid() | undefined} | {error, term()}.
+start_tracer_provider(Name, Config) ->
+    otel_tracer_provider:start(Name, Config).
 
 -spec set_default_tracer(tracer()) -> boolean().
 set_default_tracer(Tracer) ->

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -28,7 +28,7 @@
 %%%-------------------------------------------------------------------------
 -module(opentelemetry).
 
--export([start_tracer_provider/2,
+-export([start_tracer_provider/3,
          set_default_tracer/1,
          set_default_tracer/2,
          create_application_tracers/1,
@@ -154,9 +154,9 @@
 
 -include("gradualizer.hrl").
 
--spec start_tracer_provider(atom(), map()) -> {ok, pid() | undefined} | {error, term()}.
-start_tracer_provider(Name, Config) ->
-    otel_tracer_provider:start(Name, Config).
+-spec start_tracer_provider(atom(), otel_resource:t(), map()) -> {ok, pid() | undefined} | {error, term()}.
+start_tracer_provider(Name, Resource, Config) ->
+    otel_tracer_provider:start(Name, Resource, Config).
 
 -spec set_default_tracer(tracer()) -> boolean().
 set_default_tracer(Tracer) ->

--- a/apps/opentelemetry_api/src/otel_tracer_provider.erl
+++ b/apps/opentelemetry_api/src/otel_tracer_provider.erl
@@ -34,7 +34,7 @@
 -deprecated({start, 2, "start the TracerProvider through the SDK"}).
 
 start(Name, Config) ->
-    supervisor:start_child(otel_tracer_provider_sup, [Name, Config]).
+    otel_tracer_provider_sup:start(Name, Config).
 
 -spec get_tracer(Name, Vsn, SchemaUrl) -> Tracer when
       Name :: atom(),

--- a/apps/opentelemetry_api/src/otel_tracer_provider.erl
+++ b/apps/opentelemetry_api/src/otel_tracer_provider.erl
@@ -21,7 +21,7 @@
 %%%-------------------------------------------------------------------------
 -module(otel_tracer_provider).
 
--export([start/3,
+-export([start/2,
          get_tracer/3,
          get_tracer/4,
          resource/0,
@@ -31,10 +31,10 @@
 
 -include("opentelemetry.hrl").
 
-start(Name, Resource, Config) ->
-    %% SDK must register a simple one for one supervisor of tracer providers
-    %% under the name `otel_tracer_provider_sup'
-    supervisor:start_child(otel_tracer_provider_sup, [Name, Resource, Config]).
+-deprecated({start, 2, "start the TracerProvider through the SDK"}).
+
+start(Name, Config) ->
+    supervisor:start_child(otel_tracer_provider_sup, [Name, Config]).
 
 -spec get_tracer(Name, Vsn, SchemaUrl) -> Tracer when
       Name :: atom(),

--- a/apps/opentelemetry_api/src/otel_tracer_provider.erl
+++ b/apps/opentelemetry_api/src/otel_tracer_provider.erl
@@ -21,7 +21,7 @@
 %%%-------------------------------------------------------------------------
 -module(otel_tracer_provider).
 
--export([start/2,
+-export([start/3,
          get_tracer/3,
          get_tracer/4,
          resource/0,
@@ -31,10 +31,10 @@
 
 -include("opentelemetry.hrl").
 
-start(Name, Config) ->
+start(Name, Resource, Config) ->
     %% SDK must register a simple one for one supervisor of tracer providers
     %% under the name `otel_tracer_provider_sup'
-    supervisor:start_child(otel_tracer_provider_sup, [Name, Config]).
+    supervisor:start_child(otel_tracer_provider_sup, [Name, Resource, Config]).
 
 -spec get_tracer(Name, Vsn, SchemaUrl) -> Tracer when
       Name :: atom(),

--- a/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
+++ b/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
@@ -20,6 +20,9 @@ all() ->
 
 init_per_suite(Config) ->
     application:load(opentelemetry_api),
+    %% this used to be done in the SDK `stop'
+    %% need it here in case SDK tests were run before these
+    opentelemetry:set_default_tracer({otel_tracer_noop, []}),
     Config.
 
 end_per_suite(_Config) ->

--- a/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
@@ -26,6 +26,10 @@ groups() ->
 
 init_per_suite(Config) ->
     application:load(opentelemetry_api),
+
+    %% this used to be done in the SDK `stop'
+    %% need it here in case SDK tests were run before these
+    opentelemetry:set_default_tracer({otel_tracer_noop, []}),
     CompositePropagator = otel_propagator_text_map_composite:create([custom_propagator,
                                                                      otel_propagator_trace_context]),
     opentelemetry:set_text_map_propagator(CompositePropagator),

--- a/apps/opentelemetry_api_experimental/src/opentelemetry_experimental.erl
+++ b/apps/opentelemetry_api_experimental/src/opentelemetry_experimental.erl
@@ -17,8 +17,7 @@
 %%%-------------------------------------------------------------------------
 -module(opentelemetry_experimental).
 
--export([start_meter_provider/2,
-         set_meter/2,
+-export([set_meter/2,
          set_meter/4,
          set_meter/5,
          set_default_meter/1,
@@ -36,10 +35,6 @@
 -define(METER_KEY(Name), {?MODULE, meter, Name}).
 -define(METER_KEY(MeterProvider, Name), {?MODULE, MeterProvider, meter, Name}).
 -define(DEFAULT_METER_KEY(MeterProvider), ?METER_KEY(MeterProvider, '$__default_meter')).
-
--spec start_meter_provider(atom(), map()) -> {ok, pid() | undefined} | {error, term()}.
-start_meter_provider(Name, Config) ->
-    otel_meter_provider:start(Name, Config).
 
 -spec set_default_meter(meter()) -> boolean().
 set_default_meter(Meter) ->

--- a/apps/opentelemetry_experimental/src/opentelemetry_experimental_app.erl
+++ b/apps/opentelemetry_experimental/src/opentelemetry_experimental_app.erl
@@ -8,7 +8,6 @@
 -behaviour(application).
 
 -export([start/2,
-         prep_stop/1,
          stop/1]).
 
 -include_lib("opentelemetry_api_experimental/include/otel_meter.hrl").
@@ -19,17 +18,10 @@ start(_StartType, _StartArgs) ->
 
     {ok, Pid} = opentelemetry_experimental_sup:start_link(Config),
 
-    {ok, _} = opentelemetry_experimental:start_meter_provider(?GLOBAL_METER_PROVIDER_NAME, Config),
+    Resource = otel_resource_detector:get_resource(),
+    {ok, _} = otel_meter_provider_sup:start(?GLOBAL_METER_PROVIDER_NAME, Resource, Config),
 
     {ok, Pid}.
-
-%% called before the supervision tree is shutdown.
-prep_stop(_State) ->
-    %% on application stop set meter to the noop implementation.
-    %% This is to ensure no crashes if the sdk isn't the last
-    %% thing to shutdown or if the opentelemetry application crashed.
-    opentelemetry_experimental:set_default_meter({otel_meter_noop, []}),
-    ok.
 
 stop(_State) ->
     ok.

--- a/apps/opentelemetry_experimental/src/otel_meter_provider_sup.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_provider_sup.erl
@@ -20,7 +20,7 @@
 -behaviour(supervisor).
 
 -export([start_link/0,
-         start_child/2]).
+         start/3]).
 
 -export([init/1]).
 
@@ -29,8 +29,8 @@
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-start_child(Name, Opts) ->
-    supervisor:start_child(?SERVER, [Name, Opts]).
+start(Name, Resource, Opts) ->
+    supervisor:start_child(?SERVER, [Name, Resource, Opts]).
 
 init([]) ->
     SupFlags = #{strategy => simple_one_for_one,

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -34,7 +34,7 @@
 
 -behaviour(gen_server).
 
--export([start_link/3,
+-export([start_link/4,
          add_metric_reader/4,
          add_metric_reader/5,
          add_instrument/1,
@@ -105,9 +105,9 @@
          resource :: otel_resource:t()
         }).
 
--spec start_link(atom(), atom(), otel_configuration:t()) -> {ok, pid()} | ignore | {error, term()}.
-start_link(Name, RegName, Config) ->
-    gen_server:start_link({local, RegName}, ?MODULE, [Name, RegName, Config], []).
+-spec start_link(atom(), atom(), otel_resource:t(), otel_configuration:t()) -> {ok, pid()} | ignore | {error, term()}.
+start_link(Name, RegName, Resource, Config) ->
+    gen_server:start_link({local, RegName}, ?MODULE, [Name, RegName, Resource, Config], []).
 
 -spec add_instrument(otel_instrument:t()) -> boolean().
 add_instrument(Instrument) ->
@@ -162,13 +162,11 @@ force_flush() ->
 force_flush(Provider) ->
     gen_server:call(Provider, force_flush).
 
-init([Name, RegName, Config]) ->
+init([Name, RegName, Resource, Config]) ->
     InstrumentsTab = instruments_tab(RegName),
     CallbacksTab = callbacks_tab(RegName),
     ViewAggregationsTab = view_aggregations_tab(RegName),
     MetricsTab = metrics_tab(RegName),
-
-    Resource = otel_resource_detector:get_resource(),
 
     Meter = #meter{module=otel_meter_default,
                    instruments_tab=InstrumentsTab,

--- a/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
@@ -83,7 +83,7 @@ all() ->
      kill_reader, kill_server, observable_counter, observable_updown_counter, observable_gauge,
      multi_instrument_callback, using_macros, float_counter, float_updown_counter, float_histogram,
      sync_filtered_attributes, async_filtered_attributes, delta_observable_counter,
-     bad_observable_return
+     bad_observable_return, default_resource
     ].
 
 init_per_suite(Config) ->
@@ -183,6 +183,14 @@ init_per_testcase(_, Config) ->
 end_per_testcase(_, _Config) ->
     ok = application:stop(opentelemetry_experimental),
     application:unload(opentelemetry_experimental),
+    ok.
+
+default_resource(_Config) ->
+    Resource = otel_meter_provider:resource(),
+
+    ?assertMatch(#{'process.executable.name' := <<"erl">>},
+                 otel_attributes:map(otel_resource:attributes(Resource))),
+
     ok.
 
 using_macros(_Config) ->

--- a/rebar.config
+++ b/rebar.config
@@ -52,6 +52,9 @@
 {xref_ignores, [opentelemetry_exporter, %% TODO: remove once metrics is moved to
                 otel_otlp_metrics,      %% an experimental exporter app
 
+                {opentelemetry, start_tracer_provider, 2},
+                {otel_tracer_provider, start, 2},
+
                 opentelemetry_exporter_trace_service_pb,
                 opentelemetry_exporter_metrics_service_pb,
                 opentelemetry_exporter_logs_service_pb,


### PR DESCRIPTION
Also a commit to remove the setting of the global tracer to `noop` when the SDK stops. I think this makes it safer to not potentially drastically harm performance for users on shutdown. The hope would be it is the last thing done but since this can't be guaranteed and technically could be stopped at anytime, so not having a global GC happen seems best.