### PR TITLE
update api, sdk and otlp exporter apps to pass eqwalizer checks

### DIFF
--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -24,16 +24,11 @@
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 
--dialyzer({nowarn_function, start/2}).
--dialyzer({nowarn_function, setup_text_map_propagators/1}).
--dialyzer({nowarn_function, create_loaded_application_tracers/1}).
-
 start(_StartType, _StartArgs) ->
     Config = otel_configuration:merge_with_os(
              application:get_all_env(opentelemetry)),
 
     %% set global span limits record based on configuration
-    %% eqwalizer:ignore not sure why this typing isn't working
     otel_span_limits:set(Config),
 
     %% set the global propagators for HTTP based on the application env

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -24,6 +24,10 @@
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 
+-dialyzer({nowarn_function, start/2}).
+-dialyzer({nowarn_function, setup_text_map_propagators/1}).
+-dialyzer({nowarn_function, create_loaded_application_tracers/1}).
+
 start(_StartType, _StartArgs) ->
     Config = otel_configuration:merge_with_os(
              application:get_all_env(opentelemetry)),

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -29,6 +29,7 @@ start(_StartType, _StartArgs) ->
              application:get_all_env(opentelemetry)),
 
     %% set global span limits record based on configuration
+    %% eqwalizer:ignore not sure why this typing isn't working
     otel_span_limits:set(Config),
 
     %% set the global propagators for HTTP based on the application env

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -52,7 +52,7 @@
                readers := [#{id := atom(), module => module(), config => map()}],
                processors := list(),
                sampler := {atom(), term()},
-               sweeper := #{sinterval => integer() | infinity,
+               sweeper := #{interval => integer() | infinity,
                             strategy => atom() | fun(),
                             span_ttl => integer() | infinity,
                             storage_size => integer() | infinity},

--- a/apps/opentelemetry/src/otel_span_ets.erl
+++ b/apps/opentelemetry/src/otel_span_ets.erl
@@ -36,6 +36,11 @@
          set_status/2,
          update_name/2]).
 
+%% since `span_ctx' and `span' are in the API the `span_sdk' has to be term()
+-eqwalizer({nowarn_function, end_span/1}).
+-eqwalizer({nowarn_function, end_span/2}).
+-eqwalizer({nowarn_function, get_ctx/1}).
+
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include("otel_span.hrl").
 -include("otel_span_ets.hrl").
@@ -50,7 +55,7 @@ start_link(Opts) ->
 
 %% @doc Start a span and insert into the active span ets table.
 -spec start_span(otel_ctx:t(), opentelemetry:span_name(), otel_sampler:t(), otel_id_generator:t(),
-                 otel_span:start_opts(), fun(), otel_tracer_server:instrumentation_scope())
+                 otel_span:start_opts(), fun(), otel_tracer_server:instrumentation_scope() | undefined)
                 -> opentelemetry:span_ctx().
 start_span(Ctx, Name, Sampler, IdGeneratorModule, Opts, Processors, InstrumentationScope) ->
     case otel_span_utils:start_span(Ctx, Name, Sampler, IdGeneratorModule, Opts) of

--- a/apps/opentelemetry/src/otel_span_limits.erl
+++ b/apps/opentelemetry/src/otel_span_limits.erl
@@ -35,12 +35,7 @@
 get() ->
     persistent_term:get(?SPAN_LIMITS_KEY).
 
--spec set(#{attribute_count_limit := integer(),
-            attribute_value_length_limit := integer() | infinity,
-            event_count_limit := integer(),
-            link_count_limit := integer(),
-            attribute_per_event_limit := integer(),
-            attribute_per_link_limit := integer()}) -> ok.
+-spec set(otel_configuration:t()) -> ok.
 set(#{attribute_count_limit := AttributeCountLimit,
       attribute_value_length_limit := AttributeValueLengthLimit,
       event_count_limit := EventCountLimit,

--- a/apps/opentelemetry/src/otel_span_limits.erl
+++ b/apps/opentelemetry/src/otel_span_limits.erl
@@ -35,29 +35,24 @@
 get() ->
     persistent_term:get(?SPAN_LIMITS_KEY).
 
-%% -spec set(#{attribute_count_limit => integer(),
-%%             attribute_value_length_limit => integer() | infinity,
-%%             event_count_limit => integer(),
-%%             link_count_limit => integer(),
-%%             attribute_per_event_limit => integer(),
-%%             attribute_per_link_limit => integer()}) -> ok.
--spec set(otel_configuration:t()) -> ok.
-set(Opts) ->
-    SpanLimits = maps:fold(fun(attribute_count_limit, AttributeCountLimit, Acc) ->
-                                   Acc#span_limits{attribute_count_limit=AttributeCountLimit};
-                              (attribute_value_length_limit, AttributeValueLengthLimit, Acc) ->
-                                   Acc#span_limits{attribute_value_length_limit=AttributeValueLengthLimit};
-                              (event_count_limit, EventCountLimit, Acc) ->
-                                   Acc#span_limits{event_count_limit=EventCountLimit};
-                              (link_count_limit, LinkCountLimit, Acc) ->
-                                   Acc#span_limits{link_count_limit=LinkCountLimit};
-                              (attribute_per_event_limit, AttributePerEventLimit, Acc) ->
-                                   Acc#span_limits{attribute_per_event_limit=AttributePerEventLimit};
-                              (attribute_per_link_limit, AttributePerLinkLimit, Acc) ->
-                                   Acc#span_limits{attribute_per_link_limit=AttributePerLinkLimit};
-                              (_, _, Acc) ->
-                                   Acc
-                           end, #span_limits{}, Opts),
+-spec set(#{attribute_count_limit := integer(),
+            attribute_value_length_limit := integer() | infinity,
+            event_count_limit := integer(),
+            link_count_limit := integer(),
+            attribute_per_event_limit := integer(),
+            attribute_per_link_limit := integer()}) -> ok.
+set(#{attribute_count_limit := AttributeCountLimit,
+      attribute_value_length_limit := AttributeValueLengthLimit,
+      event_count_limit := EventCountLimit,
+      link_count_limit := LinkCountLimit,
+      attribute_per_event_limit := AttributePerEventLimit,
+      attribute_per_link_limit := AttributePerLinkLimit}) ->
+    SpanLimits = #span_limits{attribute_count_limit=AttributeCountLimit,
+                              attribute_value_length_limit=AttributeValueLengthLimit,
+                              event_count_limit=EventCountLimit,
+                              link_count_limit=LinkCountLimit,
+                              attribute_per_event_limit=AttributePerEventLimit,
+                              attribute_per_link_limit=AttributePerLinkLimit},
     persistent_term:put(?SPAN_LIMITS_KEY, SpanLimits).
 
 attribute_count_limit() ->

--- a/apps/opentelemetry/src/otel_span_utils.erl
+++ b/apps/opentelemetry/src/otel_span_utils.erl
@@ -107,7 +107,7 @@ end_span(Span=#span{end_time=undefined,
 end_span(Span) ->
     Span.
 
--spec end_span(opentelemetry:span(), integer() | undefined) -> opentelemetry:span().
+-spec end_span(#span{}, integer() | undefined) -> opentelemetry:span().
 end_span(Span, Timestamp) when is_integer(Timestamp) ->
     Span#span{end_time=Timestamp};
 end_span(Span, _) ->

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -88,7 +88,8 @@ handle_call(resource, _From, State=#state{resource=Resource}) ->
 handle_call({get_tracer, _Name, _Vsn, _SchemaUrl}, _From, State=#state{shared_tracer=undefined}) ->
     {reply, {otel_tracer_noop, []}, State};
 handle_call({get_tracer, Name, Vsn, SchemaUrl}, _From, State=#state{shared_tracer=Tracer,
-                                                                    deny_list=DenyList}) ->
+                                                                    deny_list=DenyList})
+  when Tracer =/= undefined ->
     %% TODO: support semver constraints in denylist
     case proplists:is_defined(Name, DenyList) of
         true ->
@@ -100,7 +101,8 @@ handle_call({get_tracer, Name, Vsn, SchemaUrl}, _From, State=#state{shared_trace
             {reply, TracerTuple, State}
     end;
 handle_call({get_tracer, InstrumentationScope}, _From, State=#state{shared_tracer=Tracer,
-                                                                    deny_list=_DenyList}) ->
+                                                                    deny_list=_DenyList})
+  when Tracer =/= undefined ->
     {reply, {Tracer#tracer.module,
              Tracer#tracer{instrumentation_scope=InstrumentationScope}}, State};
 handle_call(force_flush, _From, State=#state{processors=Processors}) ->

--- a/apps/opentelemetry_api/mix.exs
+++ b/apps/opentelemetry_api/mix.exs
@@ -19,7 +19,7 @@ defmodule OpenTelemetry.MixProject do
       test_coverage: [tool: :covertool],
       package: package(),
       aliases: [docs: & &1],
-      dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"]
+      dialyzer: [ignore_warnings: "dialyzer.ignore-warnings", remove_defaults: [:unknown]]
     ]
   end
 

--- a/apps/opentelemetry_api/src/otel_baggage.erl
+++ b/apps/opentelemetry_api/src/otel_baggage.erl
@@ -65,6 +65,7 @@ set(Key, Value) when (is_list(Key) orelse is_binary(Key)) andalso is_binary(Valu
 set(Key, Value) when (is_list(Key) orelse is_binary(Key)) andalso not is_binary(Value) ->
     ok;
 set(Ctx, KeyValues) when is_list(KeyValues) ->
+    %% eqwalizer:ignore I know what I'm doing
     ?assert_type(set(Ctx, maps:from_list(KeyValues)), ok | undefined | #{any() => any()});
 set(Ctx, KeyValues) when is_map(KeyValues) andalso (is_map(Ctx) orelse Ctx =:= undefined)->
     Baggage = otel_ctx:get_value(Ctx, ?BAGGAGE_KEY, #{}),

--- a/apps/opentelemetry_api/src/otel_ctx.erl
+++ b/apps/opentelemetry_api/src/otel_ctx.erl
@@ -70,15 +70,15 @@ set_value(Ctx, Key, Value) when is_map(Ctx) ->
 set_value(_, Key, Value) ->
     #{Key => Value}.
 
--spec get_value(term()) -> term().
+-spec get_value(term()) -> eqwalizer:dynamic().
 get_value(Key) ->
     get_value(erlang:get(?CURRENT_CTX), Key, undefined).
 
--spec get_value(term(), term()) -> term().
+-spec get_value(term(), term()) -> eqwalizer:dynamic().
 get_value(Key, Default) ->
     get_value(erlang:get(?CURRENT_CTX), Key, Default).
 
--spec get_value(t(), term(), term()) -> term().
+-spec get_value(t(), term(), term()) -> eqwalizer:dynamic().
 get_value(undefined, _Key, Default) ->
     Default;
 get_value(Ctx, Key, Default) when is_map(Ctx) ->

--- a/apps/opentelemetry_api/src/otel_propagator.erl
+++ b/apps/opentelemetry_api/src/otel_propagator.erl
@@ -38,7 +38,7 @@
 -callback inject(t(), carrier()) -> carrier().
 -callback inject_from(otel_ctx:t(), t(), carrier()) -> carrier().
 %% extracts values from a carrier and sets them in the context
--callback extract(t(), carrier()) -> otel_ctx:t().
+-callback extract(t(), carrier()) -> otel_ctx:t() | otel_ctx:token().
 -callback extract_to(otel_ctx:t(), t(), carrier()) -> otel_ctx:t().
 
 -type t() :: builtin() | module() | {module(), term()}.

--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -119,7 +119,7 @@ is_valid_atom_value(nil) ->
 is_valid_atom_value(Value) ->
     is_atom(Value) andalso (is_boolean(Value) == false).
 
--spec process_attributes(any()) -> opentelemetry:attributes_map().
+-spec process_attributes(eqwalizer:dynamic()) -> opentelemetry:attributes_map().
 process_attributes(Attributes) when is_map(Attributes) ->
     maps:fold(fun process_attribute/3, #{}, Attributes);
 process_attributes([]) -> #{};

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -155,7 +155,7 @@
                 headers :: headers(),
                 compression :: compression() | undefined,
                 grpc_metadata :: map() | undefined,
-                endpoints :: [endpoint()]}).
+                endpoints :: [endpoint_map()]}).
 
 -include_lib("opentelemetry_api/include/gradualizer.hrl").
 
@@ -602,4 +602,3 @@ config_mapping() ->
 
      {"OTEL_EXPORTER_SSL_OPTIONS", ssl_options, key_value_list}
     ].
-

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -127,7 +127,8 @@
 -type headers() :: [{unicode:chardata(), unicode:chardata()}].
 -type scheme() :: http | https | string() | binary().
 -type host() :: unicode:chardata().
--type endpoint() :: uri_string:uri_string() | uri_string:uri_map() | endpoint_map().
+-type input_endpoint() :: uri_string:uri_string() | uri_string:uri_map() | endpoint_map().
+-type endpoint() :: uri_string:uri_string() | uri_string:uri_map().
 -type endpoint_map() :: #{scheme := scheme(),
                           host := host(),
                           path => unicode:chardata(),
@@ -137,9 +138,10 @@
 -type protocol() :: grpc | http_protobuf | http_json.
 -type compression() :: gzip.
 
--type opts() :: #{endpoints => [endpoint()],
+-type opts() :: #{endpoints => [input_endpoint()],
                   headers => headers(),
-                  protocol => protocol()}.
+                  protocol => protocol(),
+                  ssl_options => list()}.
 
 -export_type([opts/0,
               headers/0,
@@ -153,7 +155,7 @@
                 headers :: headers(),
                 compression :: compression() | undefined,
                 grpc_metadata :: map() | undefined,
-                endpoints :: [endpoint_map()]}).
+                endpoints :: [endpoint()]}).
 
 -include_lib("opentelemetry_api/include/gradualizer.hrl").
 
@@ -354,7 +356,7 @@ headers(List) when is_list(List) ->
 headers(_) ->
     [].
 
--spec endpoints([endpoint()], list()) -> [endpoint_map()].
+-spec endpoints([endpoint()], list() | undefined) -> [endpoint()].
 endpoints(List, DefaultSSLOpts) when is_list(List) ->
     Endpoints = case io_lib:printable_list(List) of
                     true ->

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.erl
@@ -127,10 +127,16 @@
 -type headers() :: [{unicode:chardata(), unicode:chardata()}].
 -type scheme() :: http | https | string() | binary().
 -type host() :: unicode:chardata().
--type input_endpoint() :: uri_string:uri_string() | uri_string:uri_map() | endpoint_map().
--type endpoint() :: uri_string:uri_string() | uri_string:uri_map().
--type endpoint_map() :: #{scheme := scheme(),
+-type input_endpoint_map() :: #{scheme := scheme(),
                           host := host(),
+                          path => unicode:chardata(),
+                          port => integer(),
+                          ssl_options => []}.
+
+-type input_endpoint() :: uri_string:uri_string() | uri_string:uri_map() | input_endpoint_map().
+-type endpoint() :: uri_string:uri_string() | uri_string:uri_map().
+-type endpoint_map() :: #{scheme := unicode:chardata(),
+                          host := unicode:chardata(), %%host(),
                           path => unicode:chardata(),
                           port => integer(),
                           ssl_options => []}.
@@ -356,7 +362,7 @@ headers(List) when is_list(List) ->
 headers(_) ->
     [].
 
--spec endpoints([endpoint()], list() | undefined) -> [endpoint()].
+-spec endpoints([endpoint()], list() | undefined) -> [endpoint_map()].
 endpoints(List, DefaultSSLOpts) when is_list(List) ->
     Endpoints = case io_lib:printable_list(List) of
                     true ->

--- a/apps/opentelemetry_exporter/src/opentelemetry_logs_service.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_logs_service.erl
@@ -32,8 +32,10 @@ export(Input) ->
 -spec export(ctx:t() | opentelemetry_exporter_logs_service_pb:export_logs_service_request(), opentelemetry_exporter_logs_service_pb:export_logs_service_request() | grpcbox_client:options()) ->
     {ok, opentelemetry_exporter_logs_service_pb:export_logs_service_response(), grpcbox:metadata()} | grpcbox_stream:grpc_error_response() | {error, any()}.
 export(Ctx, Input) when ?is_ctx(Ctx) ->
+    %% eqwalizer:fixme fix needed in grpcbox generated client code
     export(Ctx, Input, #{});
 export(Input, Options) ->
+    %% eqwalizer:fixme fix needed in grpcbox generated client code
     export(ctx:new(), Input, Options).
 
 -spec export(ctx:t(), opentelemetry_exporter_logs_service_pb:export_logs_service_request(), grpcbox_client:options()) ->

--- a/apps/opentelemetry_exporter/src/opentelemetry_metrics_service.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_metrics_service.erl
@@ -32,8 +32,10 @@ export(Input) ->
 -spec export(ctx:t() | opentelemetry_exporter_metrics_service_pb:export_metrics_service_request(), opentelemetry_exporter_metrics_service_pb:export_metrics_service_request() | grpcbox_client:options()) ->
     {ok, opentelemetry_exporter_metrics_service_pb:export_metrics_service_response(), grpcbox:metadata()} | grpcbox_stream:grpc_error_response() | {error, any()}.
 export(Ctx, Input) when ?is_ctx(Ctx) ->
+    %% eqwalizer:fixme fix needed in grpcbox generated client code
     export(Ctx, Input, #{});
 export(Input, Options) ->
+    %% eqwalizer:fixme fix needed in grpcbox generated client code
     export(ctx:new(), Input, Options).
 
 -spec export(ctx:t(), opentelemetry_exporter_metrics_service_pb:export_metrics_service_request(), grpcbox_client:options()) ->

--- a/apps/opentelemetry_exporter/src/opentelemetry_trace_service.erl
+++ b/apps/opentelemetry_exporter/src/opentelemetry_trace_service.erl
@@ -32,8 +32,10 @@ export(Input) ->
 -spec export(ctx:t() | opentelemetry_exporter_trace_service_pb:export_trace_service_request(), opentelemetry_exporter_trace_service_pb:export_trace_service_request() | grpcbox_client:options()) ->
     {ok, opentelemetry_exporter_trace_service_pb:export_trace_service_response(), grpcbox:metadata()} | grpcbox_stream:grpc_error_response() | {error, any()}.
 export(Ctx, Input) when ?is_ctx(Ctx) ->
+    %% eqwalizer:fixme fix needed in grpcbox generated client code
     export(Ctx, Input, #{});
 export(Input, Options) ->
+    %% eqwalizer:fixme fix needed in grpcbox generated client code
     export(ctx:new(), Input, Options).
 
 -spec export(ctx:t(), opentelemetry_exporter_trace_service_pb:export_trace_service_request(), grpcbox_client:options()) ->

--- a/rebar.config
+++ b/rebar.config
@@ -19,8 +19,8 @@
                     {git_subdir,
                      "https://github.com/whatsapp/eqwalizer.git",
                      {branch, "main"},
-                     "eqwalizer_rebar3"}},
-                   erlfmt]}.
+                     "eqwalizer_rebar3"}}
+                   ]}.
 
 {gradualizer_opts, [{exclude_modules, [opentelemetry_trace_service,
                                        opentelemetry_metrics_service,

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"ctx">>,{pkg,<<"ctx">>,<<"0.6.0">>},1},
  {<<"eqwalizer_support">>,
   {git_subdir,"https://github.com/whatsapp/eqwalizer.git",
-              {ref,"293e5436db7a338610969829041519e9c1966b78"},
+              {ref,"c5d9cc84a9f646c157e0b2f32feaeda012918624"},
               "eqwalizer_support"},
   0},
  {<<"gproc">>,{pkg,<<"gproc">>,<<"0.8.0">>},1},


### PR DESCRIPTION
The main things that have to be "ignores" are:

- Types from the API that the SDK uses. For example, there is a `span_sdk` field in the `span_ctx` record that has to be `term()` in the API so any SDK could put what it needs in there. This causes issues in typing the SDK. I don't know that there is anything to do but ignore those. 
- Fields in records that are used in matchspecs have types like `'_'` and `'$1'`. I don't think there is anything we can do here either except tell eqwalizer to ignore.