### PR TITLE
Changed a couple of include_lib directives to include

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_otlp_metrics.erl
+++ b/apps/opentelemetry_experimental/src/otel_otlp_metrics.erl
@@ -22,7 +22,7 @@
 -include_lib("kernel/include/logger.hrl").
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include_lib("opentelemetry/include/otel_span.hrl").
--include_lib("opentelemetry_experimental/include/otel_metrics.hrl").
+-include("otel_metrics.hrl").
 
 to_proto(Metrics, Resource) ->
     InstrumentationScopeMetrics = to_proto_by_scope(Metrics),

--- a/apps/opentelemetry_experimental/src/otel_view.erl
+++ b/apps/opentelemetry_experimental/src/otel_view.erl
@@ -23,7 +23,7 @@
 
 -include_lib("opentelemetry_api_experimental/include/otel_metrics.hrl").
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
--include_lib("opentelemetry_experimental/include/otel_metrics.hrl").
+-include("otel_metrics.hrl").
 -include("otel_view.hrl").
 
 -type name() :: atom().


### PR DESCRIPTION
We're running a bezel-based build system, and it doesn't like these couple of include_lib directives - I believe they technically should just be includes anyway, so this shouldn't cause issues for other build systems (e.g., rebar3)