### PR TITLE
only split on first leading '=' in parsing key/value list config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Global Tracer no longer set to no-op on SDK
   shutdown](https://github.com/open-telemetry/opentelemetry-erlang/pull/568)
 
+### Fixes
+
+- [Fixed parsing of key/value list configuration where value has = in
+  it](https://github.com/open-telemetry/opentelemetry-erlang/pull/596)
+
 ## Exporter 1.5.0 - 2023-05-19
 
 ### Fixes

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -433,7 +433,7 @@ transform(key_value_list, Value) when is_list(Value) ->
         true ->
             Pairs = string:split(Value, ",", all),
             lists:filtermap(fun(Pair) ->
-                                    case string:split(Pair, "=", all) of
+                                    case string:split(Pair, "=", leading) of
                                         [K, V] ->
                                             V1 = re:replace(string:trim(V), "^\"|\"$", "", [global, {return, list}]),
                                             {true, {string:trim(K), V1}};


### PR DESCRIPTION
From comment https://github.com/open-telemetry/opentelemetry-erlang/issues/595#issuecomment-1565694418