### PR TITLE
Remove the opaque type `config`

### DIFF
--- a/apps/opentelemetry/src/otel_sampler_trace_id_ratio_based.erl
+++ b/apps/opentelemetry/src/otel_sampler_trace_id_ratio_based.erl
@@ -24,18 +24,12 @@
 
 -export([description/1, setup/1, should_sample/7]).
 
--export_type([config/0, probability/0]).
-
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include("otel_sampler.hrl").
-
--type probability() :: float().
--opaque config() :: #{probability := probability(), id_upper_bound := integer()}.
 
 %% 2^63 - 1
 -define(MAX_VALUE, 9223372036854775807).
 
--spec setup(probability()) -> config().
 setup(Probability) ->
     IdUpperBound =
         case Probability of


### PR DESCRIPTION
This is confusing dialyzer, leading to the following error:

```
The call :otel_sampler_trace_id_ratio_based.should_sample(_ctx@1::any(),_trace_id@1::any(),_links@1::any(),_span_name@1::
any(),_span_kind@1::any(),_attributes@1::any(),otel_sampler_trace_id_ratio_based:config()) contains an opaque term in 7th
 argument when terms of different types are expected in these positions}.                                                
```

I think it is because we are speccing the `setup/1` function to return `config()`, which is opaque, while the sampler callback specifies `term()` for the last argument to `should_sample/7`.

I won't pretend to completely understand why this is not allowed. In my mind, `term()` should match anything we send it, but Dialyzer apparently disagrees.

Removing the typespecs, which reverts to the behaviour's specs, resolves the issue.

For the record here is the code I'm using locally that generates this dialyzer error:

```elixir
defmodule OpenTelemetry.HoneycombSampler do
  @behaviour :otel_sampler

  @impl :otel_sampler
  def setup(_sampler_opts) do
    []
  end

  @impl :otel_sampler
  def description(_sampler_config) do
    "HoneycombSampler"
  end

  @impl :otel_sampler
  def should_sample(
        ctx,
        trace_id,
        links,
        span_name,
        span_kind,
        attributes,
        sampler_config
      ) do
    sample_rate =
      sample_rate(
        ctx,
        trace_id,
        links,
        span_name,
        span_kind,
        attributes,
        sampler_config
      )

    {result, _attrs, tracestate} =
      :otel_sampler_trace_id_ratio_based.should_sample(
        ctx,
        trace_id,
        links,
        span_name,
        span_kind,
        attributes,
        :otel_sampler_trace_id_ratio_based.setup(1.0 / sample_rate)
      )

    # Honeycomb wants to know the SampleRate so that it can account for the non-sampled spans
    {result, [SampleRate: sample_rate], tracestate}
  end

  # sample rate here is "1/x events get sent", so if you put 10, then one in ten events get sampled, and nine out of ten get discarded.
  defp sample_rate(
         _ctx,
         _trace_id,
         _links,
         _span_name,
         _span_kind,
         _span_attributes,
         _sampler_config
       ) do
    # 1 = always sample, 10 = sample 1 in 10, etc
    1
  end
end
```