### PR TITLE
move attribute processing to otel-attribute module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add `otel_tracestate` module for creating and updating
   tracestate](https://github.com/open-telemetry/opentelemetry-erlang/pull/607)
 - [Attributes module `otel_attributes` moved to
-  SDK](https://github.com/open-telemetry/opentelemetry-erlang/pull/618)
+  API](https://github.com/open-telemetry/opentelemetry-erlang/pull/618)
 
 ## SDK
 
 ### Changes
 
 - [Attributes module `otel_attributes` moved to
-  SDK](https://github.com/open-telemetry/opentelemetry-erlang/pull/618)
+  API](https://github.com/open-telemetry/opentelemetry-erlang/pull/618)
 
 ## Experimental API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tracestate](https://github.com/open-telemetry/opentelemetry-erlang/pull/607)
 - [Attributes module `otel_attributes` moved to
   API](https://github.com/open-telemetry/opentelemetry-erlang/pull/618)
+- [Moved attribute processing functions to `otel_attributes` from
+  `otel_span`](https://github.com/open-telemetry/opentelemetry-erlang/pull/620)
 
 ## SDK
 

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -340,12 +340,12 @@ convert_timestamp(Timestamp, Unit) ->
 links(List) when is_list(List) ->
     lists:filtermap(fun({TraceId, SpanId, Attributes, TraceState}) when is_integer(TraceId) ,
                                                                         is_integer(SpanId) ->
-                            link_or_false(TraceId, SpanId, otel_span:process_attributes(Attributes), TraceState);
+                            link_or_false(TraceId, SpanId, otel_attributes:process_attributes(Attributes), TraceState);
                        ({#span_ctx{trace_id=TraceId,
                                    span_id=SpanId,
                                    tracestate=TraceState}, Attributes}) when is_integer(TraceId) ,
                                                                              is_integer(SpanId) ->
-                            link_or_false(TraceId, SpanId, otel_span:process_attributes(Attributes), TraceState);
+                            link_or_false(TraceId, SpanId, otel_attributes:process_attributes(Attributes), TraceState);
                        (#span_ctx{trace_id=TraceId,
                                   span_id=SpanId,
                                   tracestate=TraceState}) when is_integer(TraceId) ,
@@ -365,7 +365,7 @@ link(SpanCtx) ->
 link(#span_ctx{trace_id=TraceId,
                span_id=SpanId,
                tracestate=TraceState}, Attributes) ->
-    ?MODULE:link(TraceId, SpanId, otel_span:process_attributes(Attributes), TraceState);
+    ?MODULE:link(TraceId, SpanId, otel_attributes:process_attributes(Attributes), TraceState);
 link(_, _) ->
     undefined.
 
@@ -379,7 +379,7 @@ link(TraceId, SpanId, Attributes, TraceState) when is_integer(TraceId),
                                                    (is_list(Attributes) orelse is_map(Attributes)) ->
     #{trace_id => TraceId,
       span_id => SpanId,
-      attributes => otel_span:process_attributes(Attributes),
+      attributes => otel_attributes:process_attributes(Attributes),
       tracestate => TraceState};
 link(_, _, _, _) ->
     undefined.
@@ -401,7 +401,7 @@ event(Timestamp, Name, Attributes) when is_integer(Timestamp),
         true ->
             #{system_time_native => Timestamp,
               name => Name,
-              attributes => otel_span:process_attributes(Attributes)};
+              attributes => otel_attributes:process_attributes(Attributes)};
         false ->
             undefined
     end;

--- a/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
+++ b/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
@@ -76,7 +76,7 @@ can_create_link_from_span(_Config) ->
 
 validations(_Config) ->
     InvalidAttributesArg = undefined,
-    ?assertMatch(#{}, otel_span:process_attributes(InvalidAttributesArg)),
+    ?assertMatch(#{}, otel_attributes:process_attributes(InvalidAttributesArg)),
 
     Attributes = [
                   {<<"key-1">>, <<"value-1">>},
@@ -102,7 +102,7 @@ validations(_Config) ->
               {untimed_event, Attributes},
               {<<"">>, Attributes},
               {123, Attributes}],
-    ProcessedAttributes = otel_span:process_attributes(Attributes),
+    ProcessedAttributes = otel_attributes:process_attributes(Attributes),
 
     ?assertMatch(#{key2 := 1,
                    key3 := true,


### PR DESCRIPTION
This just cleans up some stuff that got put in otel_span because otel_attributes was in the SDK.

I checked that no lib in -contrib is calling the otel_span functions