### PR TITLE
Add record_exceptions options to with_span

### DIFF
--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -28,6 +28,7 @@
          is_valid/1,
          is_valid_name/1,
          validate_start_opts/1,
+         validate_with_opts/1,
          set_attribute/3,
          set_attributes/2,
          add_event/3,
@@ -51,7 +52,15 @@
                         start_time := opentelemetry:timestamp(),
                         kind := opentelemetry:span_kind()}.
 
--export_type([start_opts/0]).
+-type with_opts() :: #{attributes => opentelemetry:attributes_map(),
+                       links => [opentelemetry:link()],
+                       is_recording => boolean(),
+                       start_time => opentelemetry:timestamp(),
+                       kind => opentelemetry:span_kind(),
+                       record_exception => boolean(),
+                       set_status_on_exception => boolean()}.
+
+-export_type([start_opts/0, with_opts/0]).
 
 -spec validate_start_opts(start_opts()) -> start_opts().
 validate_start_opts(Opts) when is_map(Opts) ->
@@ -67,6 +76,17 @@ validate_start_opts(Opts) when is_map(Opts) ->
       start_time => StartTime,
       is_recording => IsRecording
      }.
+
+-spec validate_with_opts(with_opts()) -> with_opts().
+validate_with_opts(Opts) when is_map(Opts) ->
+    StartOpts = validate_start_opts(Opts),
+    RecordException = maps:get(record_exception, Opts, false),
+    SetStatusOnException = maps:get(set_status_on_exception, Opts, false),
+    maps:merge(StartOpts, #{
+      record_exception => RecordException,
+      set_status_on_exception => SetStatusOnException
+     }).
+
 
 -spec is_recording(SpanCtx) -> boolean() when
       SpanCtx :: opentelemetry:span_ctx().
@@ -201,11 +221,12 @@ add_events(_, _) ->
 record_exception(SpanCtx, Class, Term, Stacktrace, Attributes) when is_list(Attributes) ->
     record_exception(SpanCtx, Class, Term, Stacktrace, maps:from_list(Attributes));
 record_exception(SpanCtx, Class, Term, Stacktrace, Attributes) when is_map(Attributes) ->
-    {ok, ExceptionType} = otel_utils:format_binary_string("~0tP:~0tP", [Class, 10, Term, 10], [{chars_limit, 50}]),
+    ExceptionType = exception_type(Class, Term),
     {ok, StacktraceString} = otel_utils:format_binary_string("~0tP", [Stacktrace, 10], [{chars_limit, 50}]),
     ExceptionAttributes = #{?EXCEPTION_TYPE => ExceptionType,
                             ?EXCEPTION_STACKTRACE => StacktraceString},
-    add_event(SpanCtx, 'exception', maps:merge(ExceptionAttributes, Attributes));
+    ExceptionAttributes1 = add_elixir_message(ExceptionAttributes, Term),
+    add_event(SpanCtx, 'exception', maps:merge(ExceptionAttributes1, Attributes));
 record_exception(_, _, _, _, _) ->
     false.
 
@@ -219,7 +240,7 @@ record_exception(_, _, _, _, _) ->
 record_exception(SpanCtx, Class, Term, Message, Stacktrace, Attributes) when is_list(Attributes) ->
     record_exception(SpanCtx, Class, Term, Message, Stacktrace, maps:from_list(Attributes));
 record_exception(SpanCtx, Class, Term, Message, Stacktrace, Attributes) when is_map(Attributes) ->
-    {ok, ExceptionType} = otel_utils:format_binary_string("~0tP:~0tP", [Class, 10, Term, 10], [{chars_limit, 50}]),
+    ExceptionType = exception_type(Class, Term),
     {ok, StacktraceString} = otel_utils:format_binary_string("~0tP", [Stacktrace, 10], [{chars_limit, 50}]),
     ExceptionAttributes = #{?EXCEPTION_TYPE => ExceptionType,
                             ?EXCEPTION_STACKTRACE => StacktraceString,
@@ -227,6 +248,28 @@ record_exception(SpanCtx, Class, Term, Message, Stacktrace, Attributes) when is_
     add_event(SpanCtx, 'exception', maps:merge(ExceptionAttributes, Attributes));
 record_exception(_, _, _, _, _, _) ->
     false.
+
+exception_type(error, #{'__exception__' := true, '__struct__' := ElixirErrorStruct} = Term) ->
+    case atom_to_binary(ElixirErrorStruct) of
+        <<"Elixir.", ExceptionType/binary>> -> ExceptionType;
+        _ -> exception_type_erl(error, Term)
+    end;
+exception_type(Class, Term) ->
+    exception_type_erl(Class, Term).
+exception_type_erl(Class, Term) ->
+    {ok, ExceptionType} = otel_utils:format_binary_string("~0tP:~0tP", [Class, 10, Term, 10], [{chars_limit, 50}]),
+    ExceptionType.
+
+add_elixir_message(Attributes, #{'__exception__' := true} = Exception) ->
+    try
+        Message = 'Elixir.Exception':message(Exception),
+        maps:put(?EXCEPTION_MESSAGE, Message, Attributes)
+    catch
+        _Class:_Exception ->
+            Attributes
+    end;
+add_elixir_message(Attributes, _) ->
+    Attributes.
 
 -spec set_status(SpanCtx, StatusOrCode) -> boolean() when
       StatusOrCode :: opentelemetry:status() | undefined | opentelemetry:status_code(),

--- a/apps/opentelemetry_api/src/otel_tracer.erl
+++ b/apps/opentelemetry_api/src/otel_tracer.erl
@@ -66,20 +66,20 @@ start_span(Ctx, Tracer={Module, _}, SpanName, Opts) ->
             otel_tracer_noop:noop_span_ctx()
     end.
 
--spec with_span(opentelemetry:tracer(), opentelemetry:span_name(), otel_span:start_opts(), traced_fun(T)) -> T.
+-spec with_span(opentelemetry:tracer(), opentelemetry:span_name(), otel_span:with_opts(), traced_fun(T)) -> T.
 with_span(Tracer={Module, _}, SpanName, Opts, Fun) when is_atom(Module) ->
     case otel_span:is_valid_name(SpanName) of
         true ->
-            Module:with_span(otel_ctx:get_current(), Tracer, SpanName, otel_span:validate_start_opts(Opts), Fun);
+            Module:with_span(otel_ctx:get_current(), Tracer, SpanName, otel_span:validate_with_opts(Opts), Fun);
         false ->
             Fun(otel_tracer_noop:noop_span_ctx())
     end.
 
--spec with_span(otel_ctx:t(), opentelemetry:tracer(), opentelemetry:span_name(), otel_span:start_opts(), traced_fun(T)) -> T.
+-spec with_span(otel_ctx:t(), opentelemetry:tracer(), opentelemetry:span_name(), otel_span:with_opts(), traced_fun(T)) -> T.
 with_span(Ctx, Tracer={Module, _}, SpanName, Opts, Fun) when is_atom(Module) ->
     case otel_span:is_valid_name(SpanName) of
         true ->
-            Module:with_span(Ctx, Tracer, SpanName, otel_span:validate_start_opts(Opts), Fun);
+            Module:with_span(Ctx, Tracer, SpanName, otel_span:validate_with_opts(Opts), Fun);
         false ->
             Fun(otel_tracer_noop:noop_span_ctx())
     end.

--- a/rebar.config
+++ b/rebar.config
@@ -60,7 +60,7 @@
                 opentelemetry_exporter_logs_service_pb,
                 opentelemetry_zipkin_pb,
                 
-                {'Elixir.Exception', message, 1}]}.
+                'Elixir.Exception']}.
 
 {dialyzer, [{warnings, [no_unknown]}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -58,8 +58,9 @@
                 opentelemetry_exporter_trace_service_pb,
                 opentelemetry_exporter_metrics_service_pb,
                 opentelemetry_exporter_logs_service_pb,
-                opentelemetry_zipkin_pb]}.
-
+                opentelemetry_zipkin_pb,
+                
+                {'Elixir.Exception', message, 1}]}.
 
 {dialyzer, [{warnings, [no_unknown]}]}.
 

--- a/test/otel_tests.exs
+++ b/test/otel_tests.exs
@@ -247,7 +247,7 @@ defmodule OtelTests do
         attributes =
           :otel_attributes.new(
             [
-              {:"exception.type", "Elixir.RuntimeError"},
+              {:"exception.type", "RuntimeError"},
               {:"exception.message", "my error message"},
               {:"exception.stacktrace", stacktrace}
             ],
@@ -265,7 +265,7 @@ defmodule OtelTests do
                             :infinity,
                             0,
                             [
-                              {:event, _, "exception", ^attributes}
+                              {:event, _, :exception, ^attributes}
                             ]
                           }
                         )}
@@ -358,7 +358,7 @@ defmodule OtelTests do
                event
 
       assert %{
-               "exception.type": "error:badarg",
+               "exception.type": "ArgumentError",
                "exception.stacktrace": _
              } = received_attirbutes
     end


### PR DESCRIPTION
Fixes #236

The [Python API](https://opentelemetry-python.readthedocs.io/en/latest/api/trace.html#opentelemetry.trace.Tracer.start_span) has been taken as a reference.

There is still something that does not fully convince me.

Elixir exceptions are recorded with `exception.type` equal to the name of the exception struct (see [test](https://github.com/open-telemetry/opentelemetry-erlang/compare/main...albertored:record_exception?expand=1#diff-a7be571ceeaa7a92cf5b75ac1c269834d65dc2d7ad59ae761e550fc95f5324c6R319)).

Standard erlang errors are mapped by Elixir to exception structs so when in Elixir, inside a trace, an exception is raised with `:erlang.error(type)` the exception is recorded with the erlang type (e.g. `error:badarg`) but the user get an `ArgumentError` (see [test](https://github.com/open-telemetry/opentelemetry-erlang/compare/main...albertored:record_exception?expand=1#diff-a7be571ceeaa7a92cf5b75ac1c269834d65dc2d7ad59ae761e550fc95f5324c6R343)).
