### PR TITLE
Fix flaky Elixir test

### DIFF
--- a/test/otel_tests.exs
+++ b/test/otel_tests.exs
@@ -15,6 +15,12 @@ defmodule OtelTests do
   @fields Record.extract(:span_ctx, from_lib: "opentelemetry_api/include/opentelemetry.hrl")
   Record.defrecordp(:span_ctx, @fields)
 
+  setup_all do
+    :ok = Application.ensure_loaded(:opentelemetry)
+    :ok = Application.stop(:opentelemetry)
+    :ok = Application.unload(:opentelemetry)
+  end
+
   setup do
     Application.load(:opentelemetry)
 


### PR DESCRIPTION
Fix #616 

Added a step to load and unload opentelemetry application before starting the test suite.

The flakiness comes from the fact that calling `Application.put_env/3` before the application is loaded at least once has no effect at all, starting the application with an empty config.

With an empty processors list, it falls back to `otel_batch_processor`, which won't send messages until it hits some thresholds and ends up in the empty mailbox error that happens every now and then.
Some seeds, e.g. 423484, start testing with `"Span.record_exception/4 should return false if passed an invalid exception"`, which passes without a problem. This specific test doesn't require checking the mailbox, so it doesn't fail while using batch processor and runs the "first application load" necessary for the next `Application.put_env/3` calls to have an effect, allowing the next tests to pass without issues.