### PR TITLE
Fix flaky test

### DIFF
--- a/test/otel_metric_tests.exs
+++ b/test/otel_metric_tests.exs
@@ -1,5 +1,5 @@
 defmodule OtelMetricTests do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   require OpenTelemetryAPIExperimental.Counter, as: Counter
   require OpenTelemetryAPIExperimental.UpDownCounter, as: UpDownCounter

--- a/test/otel_tests.exs
+++ b/test/otel_tests.exs
@@ -1,5 +1,5 @@
 defmodule OtelTests do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   require OpenTelemetry.Tracer, as: Tracer
   require OpenTelemetry.Span, as: Span


### PR DESCRIPTION
Fix #616 

The problem is that the 2 test modules were running concurrently and they are both modifying the `:opentelemetry` application environment. Sometimes the metric test sets the exporter to none and next span test fails.