### PR TITLE
Return ctx on attach

### DIFF
--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -745,7 +745,8 @@ attach_ctx(Config) ->
     Ctx = otel_ctx:get_current(),
 
     erlang:spawn(fun() ->
-                         otel_ctx:attach(Ctx),
+                         ReturnVal = otel_ctx:attach(Ctx),
+                         ?assertEqual(Ctx, ReturnVal),
                          ?set_current_span(SpanCtx2),
                          otel_span:end_span(SpanCtx2)
                  end),

--- a/apps/opentelemetry_api/src/otel_ctx.erl
+++ b/apps/opentelemetry_api/src/otel_ctx.erl
@@ -123,7 +123,8 @@ get_current() ->
 -spec attach(t()) -> token().
 attach(Ctx) ->
     update_logger_process_metadata(Ctx),
-    erlang:put(?CURRENT_CTX, Ctx).
+    erlang:put(?CURRENT_CTX, Ctx),
+    Ctx.
 
 -spec detach(token()) -> ok.
 detach(Token) ->


### PR DESCRIPTION
Given `attach/1` is doing a pdict put which returns `undefined` on success for the first call and the value on subsequent calls, always returning the ctx value which was passed rather than undefined is consistent. Selfishly, it will clean up a couple things I am doing where pipelining into attach from an `extract_to/2` call.