### PR TITLE
fix(otel_processor): wait for runner process termination

### DIFF
--- a/apps/opentelemetry/src/otel_simple_processor.erl
+++ b/apps/opentelemetry/src/otel_simple_processor.erl
@@ -195,10 +195,15 @@ complete_exporting(Data=#data{current_from=From,
      [{reply, From, ok}]}.
 
 kill_runner(Data=#data{runner_pid=RunnerPid}) when RunnerPid =/= undefined ->
+    Mon = erlang:monitor(process, RunnerPid),
     erlang:unlink(RunnerPid),
     erlang:exit(RunnerPid, kill),
-    Data#data{runner_pid=undefined,
-              handed_off_table=undefined}.
+    %% Wait for the runner process termination to be sure that
+    %% the export table is destroyed and can be safely recreated
+    receive
+        {'DOWN', Mon, process, RunnerPid, _} ->
+            Data#data{runner_pid=undefined, handed_off_table=undefined}
+    end.
 
 new_export_table(Name) ->
      ets:new(Name, [public,


### PR DESCRIPTION
As `new_export_table(ExportingTable)` is called right after killing the runner, it's necessary to wait for its termination. 
Otherwise, `new_export_table/1`can raise `badarg` error because the table is still not destroyed. 