### PR TITLE
don't export unit fields in metrics when the unit is undefined

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_otlp_metrics.erl
+++ b/apps/opentelemetry_experimental/src/otel_otlp_metrics.erl
@@ -60,10 +60,14 @@ to_proto(#metric{name=Name,
                  description=Description,
                  unit=Unit,
                  data=Data}) ->
-    #{name => otel_otlp_common:to_binary(Name),
-      description => Description,
-      unit => otel_otlp_common:to_binary(Unit),
-      data => to_data(Data)}.
+    Metric =
+        #{name => otel_otlp_common:to_binary(Name),
+          description => Description,
+          data => to_data(Data)},
+    case Unit of
+        undefined -> Metric;
+        _ -> Metric#{unit => otel_otlp_common:to_binary(Unit)}
+    end.
 
 to_data(#sum{aggregation_temporality=Temporality,
              is_monotonic=IsMonotonic,


### PR DESCRIPTION
The term `undefined` is used for metrics where not unit is declared. When exporting such a metric, we should not set the OTLP unit field to the string "undefined" as that it not a valid unit.