### PR TITLE
update variable/record key ViewAggregation to Stream to match specification

### DIFF
--- a/apps/opentelemetry/src/otel_sampler_trace_id_ratio_based.erl
+++ b/apps/opentelemetry/src/otel_sampler_trace_id_ratio_based.erl
@@ -39,7 +39,7 @@
 setup(Probability) ->
     IdUpperBound =
         case Probability of
-            P when P =:= 0.0 ->
+            P when P == 0.0 ->
                 0;
             P when P =:= 1.0 ->
                 ?MAX_VALUE;

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -239,7 +239,7 @@ sampler_parent_based_one(_Config) ->
     ok.
 
 sampler_parent_based_zero(_Config) ->
-    ?assertMatch({parent_based, #{root := {trace_id_ratio_based, 0.0}}},
+    ?assertMatch({parent_based, #{root := {trace_id_ratio_based, +0.0}}},
                  maps:get(sampler, otel_configuration:merge_with_os([]))),
 
     ok.

--- a/apps/opentelemetry_experimental/include/otel_metrics.hrl
+++ b/apps/opentelemetry_experimental/include/otel_metrics.hrl
@@ -8,7 +8,7 @@
          instrumentation_scope   :: opentelemetry:instrumentation_scope() | undefined,
          provider                :: atom() | '_',
          instruments_tab         :: ets:table() | '_',
-         view_aggregations_tab   :: ets:table() | '_',
+         streams_tab             :: ets:table() | '_',
          metrics_tab             :: ets:table() | '_'
         }).
 

--- a/apps/opentelemetry_experimental/src/otel_aggregation_histogram_explicit.erl
+++ b/apps/opentelemetry_experimental/src/otel_aggregation_histogram_explicit.erl
@@ -41,94 +41,94 @@
 %% can't use `ets:fun2ms' as it will shadow `Key' in the `fun' head
 -if(?OTP_RELEASE >= 26).
 -define(AGGREATE_MATCH_SPEC(Key, Value, BucketCounts),
-    [
-        {
-            {explicit_histogram_aggregation,Key,'_','_','_','_','_','$1','$2','$3'},
-            [],
-            [{{
-                explicit_histogram_aggregation,
-                {element,2,'$_'},
-                {element,3,'$_'},
-                {element,4,'$_'},
-                {element,5,'$_'},
-                {element,6,'$_'},
-                {const,BucketCounts},
-                {min,'$1',{const,Value}},
-                {max,'$2',{const,Value}},
-                {'+','$3',{const,Value}}
+        [
+         {
+          {explicit_histogram_aggregation,Key,'_','_','_','_','_','$1','$2','$3'},
+          [],
+          [{{
+             explicit_histogram_aggregation,
+             {element,2,'$_'},
+             {element,3,'$_'},
+             {element,4,'$_'},
+             {element,5,'$_'},
+             {element,6,'$_'},
+             {const,BucketCounts},
+             {min,'$1',{const,Value}},
+             {max,'$2',{const,Value}},
+             {'+','$3',{const,Value}}
             }}]
-        }
-    ]
-).
+         }
+        ]
+       ).
 -else.
 -define(AGGREATE_MATCH_SPEC(Key, Value, BucketCounts),
-    [
-        {
-            {explicit_histogram_aggregation,Key,'_','_','_','_','_','$1','$2','$3'},
-            [{'<','$2',{const,Value}},{'>','$1',{const,Value}}],
-            [{{
-                explicit_histogram_aggregation,
-                {element,2,'$_'},
-                {element,3,'$_'},
-                {element,4,'$_'},
-                {element,5,'$_'},
-                {element,6,'$_'},
-                {const,BucketCounts},
-                {const,Value},
-                {const,Value},
-                {'+','$3',{const,Value}}
+        [
+         {
+          {explicit_histogram_aggregation,Key,'_','_','_','_','_','$1','$2','$3'},
+          [{'<','$2',{const,Value}},{'>','$1',{const,Value}}],
+          [{{
+             explicit_histogram_aggregation,
+             {element,2,'$_'},
+             {element,3,'$_'},
+             {element,4,'$_'},
+             {element,5,'$_'},
+             {element,6,'$_'},
+             {const,BucketCounts},
+             {const,Value},
+             {const,Value},
+             {'+','$3',{const,Value}}
             }}]
-        },
-        {
-            {explicit_histogram_aggregation,Key,'_','_','_','_','_','_','$1','$2'},
-            [{'<','$1',{const,Value}}],
-            [{{
-                explicit_histogram_aggregation,
-                {element,2,'$_'},
-                {element,3,'$_'},
-                {element,4,'$_'},
-                {element,5,'$_'},
-                {element,6,'$_'},
-                {const,BucketCounts},
-                {element,8,'$_'},
-                {const,Value},
-                {'+','$2',{const,Value}}
+         },
+         {
+          {explicit_histogram_aggregation,Key,'_','_','_','_','_','_','$1','$2'},
+          [{'<','$1',{const,Value}}],
+          [{{
+             explicit_histogram_aggregation,
+             {element,2,'$_'},
+             {element,3,'$_'},
+             {element,4,'$_'},
+             {element,5,'$_'},
+             {element,6,'$_'},
+             {const,BucketCounts},
+             {element,8,'$_'},
+             {const,Value},
+             {'+','$2',{const,Value}}
             }}]
-        },
-        {
-            {explicit_histogram_aggregation,Key,'_','_','_','_','_','$1','_','$2'},
-            [{'>','$1',{const,Value}}],
-            [{{
-                explicit_histogram_aggregation,
-                {element,2,'$_'},
-                {element,3,'$_'},
-                {element,4,'$_'},
-                {element,5,'$_'},
-                {element,6,'$_'},
-                {const,BucketCounts},
-                {const,Value},
-                {element,9,'$_'},
-                {'+','$2',{const,Value}}
+         },
+         {
+          {explicit_histogram_aggregation,Key,'_','_','_','_','_','$1','_','$2'},
+          [{'>','$1',{const,Value}}],
+          [{{
+             explicit_histogram_aggregation,
+             {element,2,'$_'},
+             {element,3,'$_'},
+             {element,4,'$_'},
+             {element,5,'$_'},
+             {element,6,'$_'},
+             {const,BucketCounts},
+             {const,Value},
+             {element,9,'$_'},
+             {'+','$2',{const,Value}}
             }}]
-        },
-        {
-            {explicit_histogram_aggregation,Key,'_','_','_','_','_','_','_','$1'},
-            [],
-            [{{
-                explicit_histogram_aggregation,
-                {element,2,'$_'},
-                {element,3,'$_'},
-                {element,4,'$_'},
-                {element,5,'$_'},
-                {element,6,'$_'},
-                {const,BucketCounts},
-                {element,8,'$_'},
-                {element,9,'$_'},
-                {'+','$1',{const,Value}}
+         },
+         {
+          {explicit_histogram_aggregation,Key,'_','_','_','_','_','_','_','$1'},
+          [],
+          [{{
+             explicit_histogram_aggregation,
+             {element,2,'$_'},
+             {element,3,'$_'},
+             {element,4,'$_'},
+             {element,5,'$_'},
+             {element,6,'$_'},
+             {const,BucketCounts},
+             {element,8,'$_'},
+             {element,9,'$_'},
+             {'+','$1',{const,Value}}
             }}]
-        }
-    ]
-).
+         }
+        ]
+       ).
 -endif.
 
 %% ignore eqwalizer errors in functions using a lot of matchspecs
@@ -142,10 +142,10 @@
 -dialyzer({nowarn_function, get_buckets/2}).
 -dialyzer({nowarn_function, counters_get/2}).
 
-init(#view_aggregation{name=Name,
-                       reader=ReaderId,
-                       aggregation_options=Options,
-                       forget=Forget}, Attributes) ->
+init(#stream{name=Name,
+             reader=ReaderId,
+             aggregation_options=Options,
+             forget=Forget}, Attributes) ->
     Generation = case Forget of
                      true ->
                          otel_metric_reader:checkpoint_generation(ReaderId);
@@ -166,10 +166,10 @@ init(#view_aggregation{name=Name,
                                     sum=0
                                    }.
 
-aggregate(Table, #view_aggregation{name=Name,
-                                   reader=ReaderId,
-                                   aggregation_options=Options,
-                                   forget=Forget}, Value, Attributes) ->
+aggregate(Table, #stream{name=Name,
+                         reader=ReaderId,
+                         aggregation_options=Options,
+                         forget=Forget}, Value, Attributes) ->
     Generation = case Forget of
                      true ->
                          otel_metric_reader:checkpoint_generation(ReaderId);
@@ -198,9 +198,9 @@ aggregate(Table, #view_aggregation{name=Name,
             1 =:= ets:select_replace(Table, MS)
     end.
 
-checkpoint(Tab, #view_aggregation{name=Name,
-                                  reader=ReaderId,
-                                  temporality=?TEMPORALITY_DELTA}, Generation) ->
+checkpoint(Tab, #stream{name=Name,
+                        reader=ReaderId,
+                        temporality=?TEMPORALITY_DELTA}, Generation) ->
     MS = [{#explicit_histogram_aggregation{key={Name, '$1', ReaderId, Generation},
                                            start_time='$9',
                                            explicit_bucket_boundaries='$2',
@@ -232,13 +232,13 @@ checkpoint(_Tab, _, _) ->
     %% no good way to checkpoint the `counters' without being out of sync with
     %% min/max/sum, so may as well just collect them in `collect', which will
     %% also be out of sync, but best we can do right now
-    
+
     ok.
 
-collect(Tab, ViewAggregation=#view_aggregation{name=Name,
-                                               reader=ReaderId,
-                                               temporality=Temporality,
-                                               forget=Forget}, Generation0) ->
+collect(Tab, Stream=#stream{name=Name,
+                            reader=ReaderId,
+                            temporality=Temporality,
+                            forget=Forget}, Generation0) ->
     CollectionStartTime = opentelemetry:timestamp(),
     Generation = case Forget of
                      true ->
@@ -247,7 +247,7 @@ collect(Tab, ViewAggregation=#view_aggregation{name=Name,
                          0
                  end,
 
-    checkpoint(Tab, ViewAggregation, Generation),
+    checkpoint(Tab, Stream, Generation),
 
     Select = [{#explicit_histogram_aggregation{key={Name, '$1', ReaderId, Generation},
                                                start_time='$2',
@@ -262,7 +262,7 @@ collect(Tab, ViewAggregation=#view_aggregation{name=Name,
     Result = #histogram{datapoints=[datapoint(CollectionStartTime, SumAgg) || SumAgg <- AttributesAggregation],
                         aggregation_temporality=Temporality},
 
-   %% would be nice to do this in the reader so its not duplicated in each aggregator
+    %% would be nice to do this in the reader so its not duplicated in each aggregator
     maybe_delete_old_generation(Tab, Name, ReaderId, Generation),
 
     Result.

--- a/apps/opentelemetry_experimental/src/otel_meter_default.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_default.erl
@@ -119,10 +119,10 @@ record(Instrument=#instrument{}, Number) ->
 record(Meter={_,#meter{}}, Name, Number) ->
     record(Meter, Name, Number, #{});
 
-record(Instrument=#instrument{meter={_, #meter{view_aggregations_tab=ViewAggregationTab,
+record(Instrument=#instrument{meter={_, #meter{streams_tab=StreamTab,
                                                metrics_tab=MetricsTab}}}, Number, Attributes) ->
-    otel_meter_server:record(ViewAggregationTab, MetricsTab, Instrument, Number, Attributes).
+    otel_meter_server:record(StreamTab, MetricsTab, Instrument, Number, Attributes).
 
-record(Meter={_, #meter{view_aggregations_tab=ViewAggregationTab,
+record(Meter={_, #meter{streams_tab=StreamTab,
                         metrics_tab=MetricsTab}}, Name, Number, Attributes) ->
-    otel_meter_server:record(Meter, ViewAggregationTab, MetricsTab, Name, Number, Attributes).
+    otel_meter_server:record(Meter, StreamTab, MetricsTab, Name, Number, Attributes).

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -91,7 +91,7 @@
 
          instruments_tab :: ets:table(),
          callbacks_tab :: ets:table(),
-         view_aggregations_tab :: ets:table(),
+         streams_tab :: ets:table(),
          metrics_tab :: ets:table(),
 
          views :: [otel_view:t()],
@@ -145,14 +145,14 @@ add_view(Provider, Name, Criteria, Config) ->
     gen_server:call(Provider, {add_view, Name, Criteria, Config}).
 
 -spec record(ets:table(), ets:table(), otel_instrument:t(), number(), opentelemetry:attributes_map()) -> ok.
-record(ViewAggregationsTab, MetricsTab, Instrument, Number, Attributes) ->
+record(StreamsTab, MetricsTab, Instrument, Number, Attributes) ->
     handle_measurement(#measurement{instrument=Instrument,
                                     value=Number,
-                                    attributes=Attributes}, ViewAggregationsTab, MetricsTab).
+                                    attributes=Attributes}, StreamsTab, MetricsTab).
 
 -spec record(otel_meter:t(), ets:table(), ets:table(), otel_instrument:t() | otel_instrument:name(), number(), opentelemetry:attributes_map()) -> ok.
-record(Meter, ViewAggregationTab, MetricsTab, Name, Number, Attributes) ->
-    handle_measurement(Meter, Name, Number, Attributes, ViewAggregationTab, MetricsTab).
+record(Meter, StreamTab, MetricsTab, Name, Number, Attributes) ->
+    handle_measurement(Meter, Name, Number, Attributes, StreamTab, MetricsTab).
 
 -spec force_flush() -> ok.
 force_flush() ->
@@ -165,13 +165,13 @@ force_flush(Provider) ->
 init([Name, RegName, Resource, Config]) ->
     InstrumentsTab = instruments_tab(RegName),
     CallbacksTab = callbacks_tab(RegName),
-    ViewAggregationsTab = view_aggregations_tab(RegName),
+    StreamsTab = streams_tab(RegName),
     MetricsTab = metrics_tab(RegName),
 
     Meter = #meter{module=otel_meter_default,
                    instruments_tab=InstrumentsTab,
                    provider=RegName,
-                   view_aggregations_tab=ViewAggregationsTab,
+                   streams_tab=StreamsTab,
                    metrics_tab=MetricsTab},
 
     %% TODO: don't do this if its already set?
@@ -182,7 +182,7 @@ init([Name, RegName, Resource, Config]) ->
     {ok, #state{shared_meter=Meter,
                 instruments_tab=InstrumentsTab,
                 callbacks_tab=CallbacksTab,
-                view_aggregations_tab=ViewAggregationsTab,
+                streams_tab=StreamsTab,
                 metrics_tab=MetricsTab,
                 views=Views,
                 readers=[],
@@ -193,7 +193,7 @@ handle_call({add_metric_reader, ReaderId, ReaderPid, DefaultAggregationMapping, 
                                 views=Views,
                                 instruments_tab=InstrumentsTab,
                                 callbacks_tab=CallbacksTab,
-                                view_aggregations_tab=ViewAggregationsTab,
+                                streams_tab=StreamsTab,
                                 metrics_tab=MetricsTab,
                                 resource=Resource}) ->
     Reader = metric_reader(ReaderId,
@@ -202,19 +202,19 @@ handle_call({add_metric_reader, ReaderId, ReaderPid, DefaultAggregationMapping, 
                            Temporality),
     Readers1 = [Reader | Readers],
 
-    %% create ViewAggregations entries for existing View/Instrument
+    %% create Streams entries for existing View/Instrument
     %% matches for the new Reader
-    _ = update_view_aggregations(InstrumentsTab, CallbacksTab, ViewAggregationsTab, Views, Readers1),
+    _ = update_streams(InstrumentsTab, CallbacksTab, StreamsTab, Views, Readers1),
 
-    {reply, {CallbacksTab, ViewAggregationsTab, MetricsTab, Resource}, State#state{readers=Readers1}};
+    {reply, {CallbacksTab, StreamsTab, MetricsTab, Resource}, State#state{readers=Readers1}};
 handle_call(resource, _From, State=#state{resource=Resource}) ->
     {reply, Resource, State};
 handle_call({add_instrument, Instrument}, _From, State=#state{readers=Readers,
                                                               views=Views,
                                                               instruments_tab=InstrumentsTab,
                                                               callbacks_tab=CallbacksTab,
-                                                              view_aggregations_tab=ViewAggregationsTab}) ->
-    _ = add_instrument_(InstrumentsTab, CallbacksTab, ViewAggregationsTab, Instrument, Views, Readers),
+                                                              streams_tab=StreamsTab}) ->
+    _ = add_instrument_(InstrumentsTab, CallbacksTab, StreamsTab, Instrument, Views, Readers),
     {reply, ok, State};
 handle_call({register_callback, Instruments, Callback, CallbackArgs}, _From, State=#state{readers=Readers,
                                                                                           callbacks_tab=CallbacksTab}) ->
@@ -231,9 +231,9 @@ handle_call({get_meter, Scope}, _From, State=#state{shared_meter=Meter}) ->
 handle_call({add_view, Name, Criteria, Config}, _From, State=#state{views=Views,
                                                                     instruments_tab=InstrumentsTab,
                                                                     callbacks_tab=CallbacksTab,
-                                                                    view_aggregations_tab=ViewAggregationsTab,
+                                                                    streams_tab=StreamsTab,
                                                                     readers=Readers}) ->
-    add_view_(Name, Criteria, Config, InstrumentsTab, CallbacksTab, ViewAggregationsTab, Readers, Views, State);
+    add_view_(Name, Criteria, Config, InstrumentsTab, CallbacksTab, StreamsTab, Readers, Views, State);
 handle_call(force_flush, _From, State=#state{readers=Readers}) ->
     [otel_metric_reader:collect(Pid) || #reader{pid=Pid} <- Readers],
     {reply, ok, State}.
@@ -253,10 +253,10 @@ code_change(State) ->
 
 %%
 
-add_view_(Name, Criteria, Config, InstrumentsTab, CallbacksTab, ViewAggregationsTab, Readers, Views, State) ->
+add_view_(Name, Criteria, Config, InstrumentsTab, CallbacksTab, StreamsTab, Readers, Views, State) ->
     case otel_view:new(Name, Criteria, Config) of
         {ok, NewView} -> 
-            _ = update_view_aggregations(InstrumentsTab, CallbacksTab, ViewAggregationsTab, [NewView], Readers),
+            _ = update_streams(InstrumentsTab, CallbacksTab, StreamsTab, [NewView], Readers),
             {reply, true, State#state{views=[NewView | Views]}};
         {error, named_wildcard_view} ->
             {reply, false, State}
@@ -274,8 +274,8 @@ callbacks_tab(Name) ->
                                                                  {keypos, 1},
                                                                  protected]).
 
-view_aggregations_tab(Name) ->
-    ets:new(list_to_atom(lists:concat([view_aggregations, "_", Name])), [bag,
+streams_tab(Name) ->
+    ets:new(list_to_atom(lists:concat([streams, "_", Name])), [bag,
                                                                          named_table,
                                                                          {keypos, 1},
                                                                          public]).
@@ -303,30 +303,30 @@ new_view(ViewConfig) ->
     end.
 
 %% Match the Instrument to views and then store a per-Reader aggregation for the View
-add_instrument_(InstrumentsTab, CallbacksTab, ViewAggregationsTab, Instrument=#instrument{meter=Meter,
+add_instrument_(InstrumentsTab, CallbacksTab, StreamsTab, Instrument=#instrument{meter=Meter,
                                                                                           name=Name}, Views, Readers) ->
     case ets:insert_new(InstrumentsTab, {{Meter, Name}, Instrument}) of
         true ->
-            update_view_aggregations_(Instrument, CallbacksTab, ViewAggregationsTab, Views, Readers);
+            update_streams_(Instrument, CallbacksTab, StreamsTab, Views, Readers);
         false ->
             ?LOG_INFO("Instrument ~p already created. Ignoring attempt to create Instrument with the same name in the same Meter.", [Name]),
             ok
     end.
 
 %% used when a new View is added and the Views must be re-matched with each Instrument
-update_view_aggregations(InstrumentsTab, CallbacksTab, ViewAggregationsTab, Views, Readers) ->
+update_streams(InstrumentsTab, CallbacksTab, StreamsTab, Views, Readers) ->
     ets:foldl(fun({_, Instrument}, Acc) ->
-                      update_view_aggregations_(Instrument, CallbacksTab, ViewAggregationsTab, Views, Readers),
+                      update_streams_(Instrument, CallbacksTab, StreamsTab, Views, Readers),
                       Acc
               end, ok, InstrumentsTab).
 
-update_view_aggregations_(Instrument=#instrument{meter=Meter,
-                                                 name=Name}, CallbacksTab, ViewAggregationsTab, Views, Readers) ->
+update_streams_(Instrument=#instrument{meter=Meter,
+                                                 name=Name}, CallbacksTab, StreamsTab, Views, Readers) ->
     Key = {Meter, Name},
     ViewMatches = otel_view:match_instrument_to_views(Instrument, Views),
     lists:foreach(fun(Reader=#reader{id=ReaderId}) ->
                           Matches = per_reader_aggregations(Reader, Instrument, ViewMatches),
-                          [true = ets:insert(ViewAggregationsTab, {Key, M}) || M <- Matches],
+                          [true = ets:insert(StreamsTab, {Key, M}) || M <- Matches],
                           case {Instrument#instrument.callback, Instrument#instrument.callback_args} of
                               {undefined, _} ->
                                   ok;
@@ -357,43 +357,43 @@ metric_reader(ReaderId, ReaderPid, DefaultAggregationMapping, Temporality) ->
 
 
 %% a Measurement's Instrument is matched against Views
-%% each matched View+Reader becomes a ViewAggregation
-%% for each ViewAggregation a Measurement updates a Metric (`#metric')
-%% active metrics are indexed by the ViewAggregation name + the Measurement's Attributes
+%% each matched View+Reader becomes a Stream
+%% for each Stream a Measurement updates a Metric (`#metric')
+%% active metrics are indexed by the Stream name + the Measurement's Attributes
 
 handle_measurement(#measurement{instrument=#instrument{meter=Meter,
                                                        name=Name},
                                 value=Value,
                                 attributes=Attributes},
-                   ViewAggregationsTab, MetricsTab) ->
-    Matches = ets:match(ViewAggregationsTab, {{Meter, Name}, '$1'}),
+                   StreamsTab, MetricsTab) ->
+    Matches = ets:match(StreamsTab, {{Meter, Name}, '$1'}),
     update_aggregations(Value, Attributes, Matches, MetricsTab).
 
-handle_measurement(Meter, Name, Number, Attributes, ViewAggregationsTab, MetricsTab) ->
-    Matches = ets:match(ViewAggregationsTab, {{Meter, Name}, '$1'}),
+handle_measurement(Meter, Name, Number, Attributes, StreamsTab, MetricsTab) ->
+    Matches = ets:match(StreamsTab, {{Meter, Name}, '$1'}),
     update_aggregations(Number, Attributes, Matches, MetricsTab).
 
-update_aggregations(Value, Attributes, ViewAggregations, MetricsTab) ->
-    lists:foreach(fun([ViewAggregation=#view_aggregation{instrument=Instrument}]) ->
-                        maybe_init_aggregate(Value, Instrument, MetricsTab, ViewAggregation, Attributes);
+update_aggregations(Value, Attributes, Streams, MetricsTab) ->
+    lists:foreach(fun([Stream=#stream{instrument=Instrument}]) ->
+                        maybe_init_aggregate(Value, Instrument, MetricsTab, Stream, Attributes);
                      (_) ->
                           ok
-                  end, ViewAggregations).
+                  end, Streams).
 
-maybe_init_aggregate(Value, #instrument{kind=Kind} = Instrument, _MetricsTab, _ViewAggregation, _Attributes)
+maybe_init_aggregate(Value, #instrument{kind=Kind} = Instrument, _MetricsTab, _Stream, _Attributes)
         when Value < 0, Kind == ?KIND_COUNTER orelse Kind == ?KIND_HISTOGRAM ->
     ?LOG_INFO("Discarding negative value for instrument ~s of type ~s", [Instrument#instrument.name, Kind]),
     ok;
 
-maybe_init_aggregate(Value, _Instrument, MetricsTab, ViewAggregation, Attributes) ->
-    otel_aggregation:maybe_init_aggregate(MetricsTab, ViewAggregation, Value, Attributes).
+maybe_init_aggregate(Value, _Instrument, MetricsTab, Stream, Attributes) ->
+    otel_aggregation:maybe_init_aggregate(MetricsTab, Stream, Value, Attributes).
 
 %% create an aggregation for each Reader and its possibly unique aggregation/temporality
-per_reader_aggregations(Reader, Instrument, ViewAggregations) ->
-    [view_aggregation_for_reader(Instrument, ViewAggregation, View, Reader)
-     || {View, ViewAggregation} <- ViewAggregations].
+per_reader_aggregations(Reader, Instrument, Streams) ->
+    [stream_for_reader(Instrument, Stream, View, Reader)
+     || {View, Stream} <- Streams].
 
-view_aggregation_for_reader(Instrument=#instrument{kind=Kind}, ViewAggregation, View=#view{attribute_keys=AttributeKeys},
+stream_for_reader(Instrument=#instrument{kind=Kind}, Stream, View=#view{attribute_keys=AttributeKeys},
                             Reader=#reader{id=Id,
                                            default_temporality_mapping=ReaderTemporalityMapping}) ->
     AggregationModule = aggregation_module(Instrument, View, Reader),
@@ -401,13 +401,13 @@ view_aggregation_for_reader(Instrument=#instrument{kind=Kind}, ViewAggregation, 
 
     Forget = do_forget(Kind, Temporality),
 
-    ViewAggregation#view_aggregation{
+    Stream#stream{
       reader=Id,
       attribute_keys=AttributeKeys,
       aggregation_module=AggregationModule,
       forget=Forget,
       temporality=Temporality};
-view_aggregation_for_reader(Instrument=#instrument{kind=Kind}, ViewAggregation, View,
+stream_for_reader(Instrument=#instrument{kind=Kind}, Stream, View,
                             Reader=#reader{id=Id,
                                            default_temporality_mapping=ReaderTemporalityMapping}) ->
     AggregationModule = aggregation_module(Instrument, View, Reader),
@@ -415,7 +415,7 @@ view_aggregation_for_reader(Instrument=#instrument{kind=Kind}, ViewAggregation, 
 
     Forget = do_forget(Kind, Temporality),
 
-    ViewAggregation#view_aggregation{
+    Stream#stream{
       reader=Id,
       attribute_keys=undefined,
       aggregation_module=AggregationModule,

--- a/apps/opentelemetry_experimental/src/otel_view.erl
+++ b/apps/opentelemetry_experimental/src/otel_view.erl
@@ -87,7 +87,7 @@ do_new(Criteria, Config) ->
           aggregation_module=maps:get(aggregation_module, Config, undefined),
           aggregation_options=maps:get(aggregation_options, Config, #{})}.
 
--spec match_instrument_to_views(otel_instrument:t(), [t()]) -> [{t() | undefined, #view_aggregation{}}].
+-spec match_instrument_to_views(otel_instrument:t(), [t()]) -> [{t() | undefined, #stream{}}].
 match_instrument_to_views(Instrument=#instrument{name=InstrumentName,
                                                  meter=Meter,
                                                  description=Description,
@@ -105,29 +105,29 @@ match_instrument_to_views(Instrument=#instrument{name=InstrumentName,
                                          false;
                                      _ ->
                                          AggregationOptions1 = aggragation_options(AggregationOptions, AdvisoryParams),
-                                         {true, {View, #view_aggregation{name=value_or(ViewName,
-                                                                                       InstrumentName),
-                                                                         scope=Scope,
-                                                                         instrument=Instrument,
-                                                                         temporality=Temporality,
-                                                                         is_monotonic=IsMonotonic,
-                                                                         attribute_keys=AttributeKeys,
-                                                                         aggregation_options=AggregationOptions1,
-                                                                         description=value_or(ViewDescription,
-                                                                                              Description)
-                                                                        }}}
+                                         {true, {View, #stream{name=value_or(ViewName,
+                                                                             InstrumentName),
+                                                               scope=Scope,
+                                                               instrument=Instrument,
+                                                               temporality=Temporality,
+                                                               is_monotonic=IsMonotonic,
+                                                               attribute_keys=AttributeKeys,
+                                                               aggregation_options=AggregationOptions1,
+                                                               description=value_or(ViewDescription,
+                                                                                    Description)
+                                                              }}}
                                  end
                          end, Views) of
         [] ->
             AggregationOptions1 = aggragation_options(#{}, AdvisoryParams),
-            [{undefined, #view_aggregation{name=InstrumentName,
-                                           scope=Scope,
-                                           instrument=Instrument,
-                                           temporality=Temporality,
-                                           is_monotonic=IsMonotonic,
-                                           attribute_keys=undefined,
-                                           aggregation_options=AggregationOptions1,
-                                           description=Description}}];
+            [{undefined, #stream{name=InstrumentName,
+                                 scope=Scope,
+                                 instrument=Instrument,
+                                 temporality=Temporality,
+                                 is_monotonic=IsMonotonic,
+                                 attribute_keys=undefined,
+                                 aggregation_options=AggregationOptions1,
+                                 description=Description}}];
         Aggs ->
             Aggs
     end.
@@ -149,28 +149,28 @@ value_or(Value, _Other) ->
 -spec criteria_to_instrument_matchspec(map() | undefined) -> ets:comp_match_spec().
 criteria_to_instrument_matchspec(Criteria) when is_map(Criteria) ->
     Instrument =
-      maps:fold(fun(instrument_name, '*', InstrumentAcc) ->
-                        InstrumentAcc;
-                   (instrument_name, InstrumentName, InstrumentAcc) ->
-                        InstrumentAcc#instrument{name=InstrumentName};
-                   (instrument_kind, Kind, InstrumentAcc) ->
-                        InstrumentAcc#instrument{kind=Kind};
-                   (instrument_unit, Unit, InstrumentAcc) ->
-                        InstrumentAcc#instrument{unit=Unit};
-                   (meter_name, MeterName, InstrumentAcc) ->
-                        Meter = maybe_init_meter(InstrumentAcc),
-                        Meter1 = update_meter_name(MeterName, Meter),
-                        InstrumentAcc#instrument{meter=Meter1};
-                   (meter_version, MeterVersion, InstrumentAcc) ->
-                        Meter = maybe_init_meter(InstrumentAcc),
-                        Meter1 = update_meter_version(MeterVersion, Meter),
-                        InstrumentAcc#instrument{meter=Meter1};
-                   (meter_schema_url, SchemaUrl, InstrumentAcc) ->
-                        Meter = maybe_init_meter(InstrumentAcc),
-                        Meter1 = update_meter_schema_url(SchemaUrl, Meter),
-                        InstrumentAcc#instrument{meter=Meter1}
-                     %% eqwalizer:ignore using ignore as an ets matchspec workaround
-                end, #instrument{_='_'}, Criteria),
+        maps:fold(fun(instrument_name, '*', InstrumentAcc) ->
+                          InstrumentAcc;
+                     (instrument_name, InstrumentName, InstrumentAcc) ->
+                          InstrumentAcc#instrument{name=InstrumentName};
+                     (instrument_kind, Kind, InstrumentAcc) ->
+                          InstrumentAcc#instrument{kind=Kind};
+                     (instrument_unit, Unit, InstrumentAcc) ->
+                          InstrumentAcc#instrument{unit=Unit};
+                     (meter_name, MeterName, InstrumentAcc) ->
+                          Meter = maybe_init_meter(InstrumentAcc),
+                          Meter1 = update_meter_name(MeterName, Meter),
+                          InstrumentAcc#instrument{meter=Meter1};
+                     (meter_version, MeterVersion, InstrumentAcc) ->
+                          Meter = maybe_init_meter(InstrumentAcc),
+                          Meter1 = update_meter_version(MeterVersion, Meter),
+                          InstrumentAcc#instrument{meter=Meter1};
+                     (meter_schema_url, SchemaUrl, InstrumentAcc) ->
+                          Meter = maybe_init_meter(InstrumentAcc),
+                          Meter1 = update_meter_schema_url(SchemaUrl, Meter),
+                          InstrumentAcc#instrument{meter=Meter1}
+                          %% eqwalizer:ignore using ignore as an ets matchspec workaround
+                  end, #instrument{_='_'}, Criteria),
     ets:match_spec_compile([{Instrument, [], [true]}]);
 criteria_to_instrument_matchspec(_) ->
     %% eqwalizer:ignore using ignore as an ets matchspec workaround

--- a/apps/opentelemetry_experimental/src/otel_view.hrl
+++ b/apps/opentelemetry_experimental/src/otel_view.hrl
@@ -6,7 +6,7 @@
          aggregation_module      :: module(),
          aggregation_options=#{} :: map()}).
 
--record(view_aggregation,
+-record(stream,
         {%% name of the view or instrument if the view has no name
          name :: atom(),
          scope :: opentelemetry:instrumentation_scope(),


### PR DESCRIPTION
When our metric code was first written the spec	had no term for
the result of matching a View and an Instrument. It has since
been named a 'stream' so this patch replaces our term for the
spec term.

Spec section: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#stream-configuration