### PR TITLE
add otel_span:start_config typespec and use it in the SDK

### DIFF
--- a/apps/opentelemetry/src/otel_span_ets.erl
+++ b/apps/opentelemetry/src/otel_span_ets.erl
@@ -55,7 +55,7 @@ start_link(Opts) ->
 
 %% @doc Start a span and insert into the active span ets table.
 -spec start_span(otel_ctx:t(), opentelemetry:span_name(), otel_sampler:t(), otel_id_generator:t(),
-                 otel_span:start_opts(), fun(), otel_tracer_server:instrumentation_scope() | undefined)
+                 otel_span:start_config(), fun(), otel_tracer_server:instrumentation_scope() | undefined)
                 -> opentelemetry:span_ctx().
 start_span(Ctx, Name, Sampler, IdGeneratorModule, Opts, Processors, InstrumentationScope) ->
     case otel_span_utils:start_span(Ctx, Name, Sampler, IdGeneratorModule, Opts) of

--- a/apps/opentelemetry/src/otel_span_utils.erl
+++ b/apps/opentelemetry/src/otel_span_utils.erl
@@ -27,7 +27,7 @@
 -include("otel_span.hrl").
 
 -spec start_span(otel_ctx:t(), opentelemetry:span_name(), otel_sampler:t(), otel_id_generator:t(),
-                 otel_span:start_opts()) -> {opentelemetry:span_ctx(), opentelemetry:span() | undefined}.
+                 otel_span:start_config()) -> {opentelemetry:span_ctx(), opentelemetry:span() | undefined}.
 start_span(Ctx, Name, Sampler, IdGenerator, Opts) ->
     SpanAttributeCountLimit = otel_span_limits:attribute_count_limit(),
     SpanAttributeValueLengthLimit= otel_span_limits:attribute_value_length_limit(),
@@ -37,17 +37,17 @@ start_span(Ctx, Name, Sampler, IdGenerator, Opts) ->
     AttributePerLinkLimit = otel_span_limits:attribute_per_link_limit(),
 
 
-    Attributes = otel_attributes:new(maps:get(attributes, Opts, #{}),
+    Attributes = otel_attributes:new(maps:get(attributes, Opts),
                                      SpanAttributeCountLimit,
                                      SpanAttributeValueLengthLimit),
-    Links = otel_links:new(maps:get(links, Opts, []),
+    Links = otel_links:new(maps:get(links, Opts),
                            LinkCountLimit,
                            AttributePerLinkLimit,
                            SpanAttributeValueLengthLimit),
     Events = otel_events:new(EventCountLimit, AttributePerEventLimit, SpanAttributeValueLengthLimit),
 
-    Kind = maps:get(kind, Opts, ?SPAN_KIND_INTERNAL),
-    StartTime = maps:get(start_time, Opts, opentelemetry:timestamp()),
+    Kind = maps:get(kind, Opts),
+    StartTime = maps:get(start_time, Opts),
 
     new_span(Ctx, Name, Sampler, IdGenerator, StartTime, Kind, Attributes, Events, Links).
 

--- a/apps/opentelemetry/src/otel_tracer_default.erl
+++ b/apps/opentelemetry/src/otel_tracer_default.erl
@@ -28,7 +28,7 @@
 
 %% @doc Starts an inactive Span and returns its SpanCtx.
 -spec start_span(otel_ctx:t(), opentelemetry:tracer(), opentelemetry:span_name(),
-                 otel_span:start_opts()) -> opentelemetry:span_ctx().
+                 otel_span:start_config()) -> opentelemetry:span_ctx().
 start_span(Ctx, {_, #tracer{on_start_processors=Processors,
                             on_end_processors=OnEndProcessors,
                             sampler=Sampler,
@@ -38,7 +38,7 @@ start_span(Ctx, {_, #tracer{on_start_processors=Processors,
     SpanCtx#span_ctx{span_sdk={otel_span_ets, OnEndProcessors}}.
 
 -spec with_span(otel_ctx:t(), opentelemetry:tracer(), opentelemetry:span_name(),
-                otel_span:start_opts(), otel_tracer:traced_fun(T)) -> T.
+                otel_span:start_config(), otel_tracer:traced_fun(T)) -> T.
 with_span(Ctx, Tracer, SpanName, Opts, Fun) ->
     SpanCtx = start_span(Ctx, Tracer, SpanName, Opts),
     Ctx1 = otel_tracer:set_current_span(Ctx, SpanCtx),

--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -32,6 +32,7 @@ defmodule OpenTelemetry.Span do
   require OpenTelemetry.SemanticConventions.Trace
 
   @type start_opts() :: :otel_span.start_opts()
+  @type start_config() :: :otel_span.start_config()
 
   @doc """
   Get the SpanId of a Span.

--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -45,17 +45,22 @@
 
 -define(is_recording(SpanCtx), SpanCtx =/= undefined andalso SpanCtx#span_ctx.is_recording =:= true).
 
--type start_opts() :: #{attributes := opentelemetry:attributes_map(),
-                        links := [opentelemetry:link()],
-                        is_recording := boolean(),
-                        start_time := opentelemetry:timestamp(),
-                        kind := opentelemetry:span_kind()}.
+-type start_opts() :: #{attributes => opentelemetry:attributes_map(),
+                        links => [opentelemetry:link()],
+                        is_recording => boolean(),
+                        start_time => opentelemetry:timestamp(),
+                        kind => opentelemetry:span_kind()}.
+-type start_config() :: #{attributes := opentelemetry:attributes_map(),
+                            links := [opentelemetry:link()],
+                            is_recording := boolean(),
+                            start_time := opentelemetry:timestamp(),
+                            kind := opentelemetry:span_kind()}.
 %% Start options for a span.
 
--export_type([start_opts/0]).
+-export_type([start_opts/0, start_config/0]).
 
 %% @doc Validates the start options for a span and fills in defaults.
--spec validate_start_opts(start_opts()) -> start_opts().
+-spec validate_start_opts(start_opts()) -> start_config().
 validate_start_opts(Opts) when is_map(Opts) ->
     Attributes = maps:get(attributes, Opts, #{}),
     Links = maps:get(links, Opts, []),

--- a/apps/opentelemetry_api/src/otel_tracer_noop.erl
+++ b/apps/opentelemetry_api/src/otel_tracer_noop.erl
@@ -37,7 +37,7 @@
 -define(NOOP_TRACER_CTX, []).
 
 -spec start_span(otel_ctx:t(), opentelemetry:tracer(), opentelemetry:span_name(),
-                 otel_span:start_opts()) -> opentelemetry:span_ctx().
+                 otel_span:start_config()) -> opentelemetry:span_ctx().
 start_span(Ctx, _, _SpanName, _) ->
     %% Spec: Behavior of the API in the absence of an installed SDK
     case otel_tracer:current_span_ctx(Ctx) of
@@ -50,7 +50,7 @@ start_span(Ctx, _, _SpanName, _) ->
     end.
 
 -spec with_span(otel_ctx:t(), opentelemetry:tracer(), opentelemetry:span_name(),
-                otel_span:start_opts(), otel_tracer:traced_fun(T)) -> T.
+                otel_span:start_config(), otel_tracer:traced_fun(T)) -> T.
 with_span(Ctx, Tracer, SpanName, Opts, Fun) ->
     SpanCtx = start_span(Ctx, Tracer, SpanName, Opts),
     Ctx1 = otel_tracer:set_current_span(Ctx, SpanCtx),


### PR DESCRIPTION
fixes #708

In the API functions, all members of start_opts() are optional.

Before passing the options on the SDK all options are set to sensible
defaults. That makes is possible to have a dedicated start_config()
type where all values are mandatory and optimize the usage of the
settings slightly.