### PR TITLE
Group modules in the docs for opentelemetry_api

### DIFF
--- a/apps/opentelemetry_api/docs.config
+++ b/apps/opentelemetry_api/docs.config
@@ -2,3 +2,19 @@
 {extras, [<<"apps/opentelemetry_api/README.md">>, <<"apps/opentelemetry_api/LICENSE">>, <<"VERSIONING.md">>]}.
 {main, <<"readme">>}.
 {proglang, erlang}.
+{groups_for_modules, [
+    {'Tracer', [otel_tracer,
+                otel_tracer_noop,
+                otel_tracer_provider,
+                otel_tracestate,
+                'Elixir.OpenTelemetry.Tracer']},
+    {'Propagators', [otel_propagator,
+                     otel_propagator_baggage,
+                     otel_propagator_b3,
+                     otel_propagator_b3multi,
+                     otel_propagator_b3single,
+                     otel_propagator_text_map,
+                     otel_propagator_text_map_composite,
+                     otel_propagator_text_map_noop,
+                     otel_propagator_trace_context]}
+]}.


### PR DESCRIPTION
Looks like this:

![CleanShot 2024-04-01 at 21 47 24@2x](https://github.com/open-telemetry/opentelemetry-erlang/assets/3890250/926901c2-a964-40bb-960f-c45562bf5402)

We can do this in other apps too. cc @tsloughter 