### PR TITLE
Group and hide modules in "opentelemetry" app

### DIFF
--- a/apps/opentelemetry/docs.config
+++ b/apps/opentelemetry/docs.config
@@ -2,3 +2,24 @@
 {extras, [<<"apps/opentelemetry/README.md">>, <<"apps/opentelemetry/LICENSE">>, <<"VERSIONING.md">>]}.
 {main, <<"readme">>}.
 {proglang, erlang}.
+{groups_for_modules, [
+    {'Span', [otel_span_ets,
+              otel_span_limits,
+              otel_span_sweeper]},
+    {'Span Processing', [otel_span_processor,
+                         otel_simple_processor,
+                         otel_batch_processor]},
+    {'Exporter', [otel_exporter,
+                  otel_exporter_pid,
+                  otel_exporter_stdout,
+                  otel_exporter_tab]},
+    {'Resource', [otel_resource,
+                  otel_resource_detector,
+                  otel_resource_app_env,
+                  otel_resource_env_var]},
+    {'Sampling', [otel_sampler,
+                  otel_sampler_always_on,
+                  otel_sampler_always_off,
+                  otel_sampler_parent_based,
+                  otel_sampler_trace_id_ratio_based]}
+]}.

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -12,8 +12,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc
-%% @end
+%% @private
 %%%-------------------------------------------------------------------------
 -module(opentelemetry_app).
 

--- a/apps/opentelemetry/src/opentelemetry_sup.erl
+++ b/apps/opentelemetry/src/opentelemetry_sup.erl
@@ -12,8 +12,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc
-%% @end
+%% @private
 %%%-------------------------------------------------------------------------
 -module(opentelemetry_sup).
 

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -12,10 +12,10 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc Merges environment variable configuration values with application
+%% Merges environment variable configuration values with application
 %% configuration. The OS environment variables take precedence over the
 %% application environment.
-%% @end
+%% @private
 %%%-------------------------------------------------------------------------
 -module(otel_configuration).
 

--- a/apps/opentelemetry/src/otel_span_sup.erl
+++ b/apps/opentelemetry/src/otel_span_sup.erl
@@ -12,8 +12,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc
-%% @end
+%% @private
 %%%-------------------------------------------------------------------------
 -module(otel_span_sup).
 

--- a/apps/opentelemetry/src/otel_span_utils.erl
+++ b/apps/opentelemetry/src/otel_span_utils.erl
@@ -12,9 +12,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc
-%% Functional interface for span_ctx and span records.
-%% @end
+%% @private
 %%%-------------------------------------------------------------------------
 -module(otel_span_utils).
 

--- a/apps/opentelemetry/src/otel_tracer_provider_sup.erl
+++ b/apps/opentelemetry/src/otel_tracer_provider_sup.erl
@@ -12,8 +12,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc
-%% @end
+%% @private
 %%%-------------------------------------------------------------------------
 -module(otel_tracer_provider_sup).
 

--- a/apps/opentelemetry/src/otel_tracer_server_sup.erl
+++ b/apps/opentelemetry/src/otel_tracer_server_sup.erl
@@ -12,8 +12,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc
-%% @end
+%% @private
 %%%-------------------------------------------------------------------------
 -module(otel_tracer_server_sup).
 


### PR DESCRIPTION
- Hid several modules (`_utils` and friends) from the public API
- Grouped mods into sections in the docs

![CleanShot 2024-04-07 at 16 24 37@2x](https://github.com/open-telemetry/opentelemetry-erlang/assets/3890250/41169d54-47b2-436e-a003-5fcc7646d039)
