### PR TITLE
fix support for attribute lists of strings to not flatten them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Exporter 
+
+### Fixes
+
+- [BREAKING: Fixes support for attribute values that are lists when the elements
+  are strings. Lists of strings in attribute values are no longer flattened but
+  remain lists. Meaning to use an Erlang charlist string or iolist as a value in
+  an attribute you must convert with `unicode:characters_to_binary` before
+  adding to the
+  attributes](https://github.com/open-telemetry/opentelemetry-erlang/pull/737)
+
 ## Experimental API 0.5.1 - 2024-03-18
 
 ### Added

--- a/apps/opentelemetry/src/otel_links.erl
+++ b/apps/opentelemetry/src/otel_links.erl
@@ -76,14 +76,8 @@ new_link({TraceId, SpanId, Attributes, TraceState}, AttributePerLinkLimit, Attri
           span_id=SpanId,
           tracestate=TraceState,
           attributes=otel_attributes:new(Attributes, AttributePerLinkLimit, AttributeValueLengthLimit)};
-new_link(#link{trace_id=TraceId,
-               span_id=SpanId,
-               tracestate=TraceState,
-               attributes=Attributes}, AttributePerLinkLimit, AttributeValueLengthLimit) ->
-    #link{trace_id=TraceId,
-          span_id=SpanId,
-          tracestate=TraceState,
-          attributes=otel_attributes:new(Attributes, AttributePerLinkLimit, AttributeValueLengthLimit)};
+new_link(Link=#link{}, _AttributePerLinkLimit, _AttributeValueLengthLimit) ->
+    Link;
 new_link(#{trace_id := TraceId,
            span_id := SpanId,
            tracestate := TraceState,

--- a/apps/opentelemetry_api/src/otel_attributes.erl
+++ b/apps/opentelemetry_api/src/otel_attributes.erl
@@ -50,7 +50,7 @@
 %% `Pairs' can be a list of key-value pairs or a map. If `Pairs' is not a list or map, the
 %% function returns an empty `Attributes'.
 -spec new(
-    [opentelemetry:attribute()] | opentelemetry:attributes_map() | term(),
+    [opentelemetry:attribute()] | opentelemetry:attributes_map(),
     integer(),
     integer() | infinity
 ) -> t().
@@ -72,7 +72,7 @@ new(_, CountLimit, ValueLengthLimit) ->
 %%
 %% `NewListOrMap' can be a list of key-value pairs or a map. If `NewListOrMap' is not a list
 %% or map, the function returns `Attributes' as is. Returns the updated `Attributes'.
--spec set([opentelemetry:attribute()] | opentelemetry:attributes_map() | term(), t()) -> t().
+-spec set([opentelemetry:attribute()] | opentelemetry:attributes_map(), t()) -> t().
 set(NewListOrMap, Attributes) when is_list(NewListOrMap) ->
     set(maps:from_list(NewListOrMap), Attributes);
 set(NewMap, Attributes) when is_map(NewMap) ->

--- a/apps/opentelemetry_exporter/src/otel_otlp_common.erl
+++ b/apps/opentelemetry_exporter/src/otel_otlp_common.erl
@@ -73,16 +73,7 @@ to_any_value(Value) when is_map(Value) ->
 to_any_value(Value) when is_tuple(Value) ->
     #{value => {array_value, to_array_value(tuple_to_list(Value))}};
 to_any_value(Value) when is_list(Value) ->
-    try unicode:characters_to_binary(Value) of
-        {Failure, _, _} when Failure =:= error ;
-                             Failure =:= incomplete ->
-            to_array_or_kvlist(Value);
-        String ->
-            #{value => {string_value, String}}
-    catch
-        _:_ ->
-            to_array_or_kvlist(Value)
-    end;
+    to_array_or_kvlist(Value);
 to_any_value(Value) ->
     #{value => {string_value, to_binary(io_lib:format("~p", [Value]))}}.
 


### PR DESCRIPTION
No longer are attribute values that are lists of strings converted to a single string. This means Erlang charlists will be sent in OTLP as a list of integers and iolists as a list of strings. The user must use characters_to_binary to convert to a binary string if they wish to set the value to a string when they have a value of those types now.