### PR TITLE
Resolve unused variable

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_aggregation_sum.erl
+++ b/apps/opentelemetry_experimental/src/otel_aggregation_sum.erl
@@ -116,7 +116,7 @@ aggregate(Ctx, Tab, ExemplarsTab, #stream{name=Name,
         1 ->
             otel_metric_exemplar_reservoir:offer(Ctx, ExemplarReservoir, ExemplarsTab, Key, Value, DroppedAttributes),
             true;
-        N ->
+        _N ->
             false
     end.
 


### PR DESCRIPTION
This resolves the compilation warning:

    src/otel_aggregation_sum.erl:119:9: Warning: variable 'N' is unused