### PR TITLE
fix: adjust `otel_metric_producer` callbacks

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_metric_producer.erl
+++ b/apps/opentelemetry_experimental/src/otel_metric_producer.erl
@@ -23,8 +23,8 @@
 -include("otel_metrics.hrl").
 -include_lib("kernel/include/logger.hrl").
 
--callback init(module(), term()) -> {ok, t()} | ignore.
--callback produce_batch(t()) -> [#metric{}].
+-callback init(term()) -> {ok, term()} | ignore.
+-callback produce_batch(term()) -> [#metric{}].
 
 -record(producer, {module :: module(),
                    state  :: term()}).


### PR DESCRIPTION
Updated callback typespec to match actual callback module invocations.