### PR TITLE
update collector example with debug exporter

### DIFF
--- a/config/otel-collector-config.yaml
+++ b/config/otel-collector-config.yaml
@@ -20,7 +20,7 @@ exporters:
       insecure: true
 
   debug:
-    verbosity: debug
+    verbosity: detailed
     sampling_initial: 1
     sampling_thereafter: 1
 extensions:

--- a/config/otel-collector-config.yaml
+++ b/config/otel-collector-config.yaml
@@ -19,8 +19,8 @@ exporters:
     tls:
       insecure: true
 
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: debug
     sampling_initial: 1
     sampling_thereafter: 1
 extensions:
@@ -31,12 +31,12 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, zipkin, otlp/jaeger]
+      exporters: [debug, zipkin, otlp/jaeger]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
The logging exporter was renamed debug in 2023, the logging exporter will be removed in the near future, updating the example accordingly.