### PR TITLE
Fix warning by replacing charlist with string

### DIFF
--- a/apps/opentelemetry_api_experimental/mix.exs
+++ b/apps/opentelemetry_api_experimental/mix.exs
@@ -64,14 +64,14 @@ defmodule OpenTelemetryExperimental.MixProject do
   end
 
   defp load_config do
-    {:ok, config} = :file.consult('rebar.config')
+    {:ok, config} = :file.consult(~c"rebar.config")
 
     config
   end
 
   defp load_app do
     {:ok, [{:application, name, desc}]} =
-      :file.consult('src/opentelemetry_api_experimental.app.src')
+      :file.consult(~c"src/opentelemetry_api_experimental.app.src")
 
     {name, desc}
   end

--- a/apps/opentelemetry_semantic_conventions/mix.exs
+++ b/apps/opentelemetry_semantic_conventions/mix.exs
@@ -38,7 +38,7 @@ defmodule OpenTelemetry.SemanticConventions.MixProject do
 
   defp load_app do
     {:ok, [{:application, name, desc}]} =
-      :file.consult('src/opentelemetry_semantic_conventions.app.src')
+      :file.consult(~c"src/opentelemetry_semantic_conventions.app.src")
 
     {name, desc}
   end


### PR DESCRIPTION
This PR fixes `warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead`