### PR TITLE
Fix invalid warning log causing FORMATTER CRASH

### DIFF
--- a/apps/opentelemetry/src/otel_exporter.erl
+++ b/apps/opentelemetry/src/otel_exporter.erl
@@ -97,8 +97,7 @@ init({ExporterModule, Config}) when is_atom(ExporterModule) ->
                     end;
                 {error, undef} when ExporterModule =:= opentelemetry_exporter ->
                     ?LOG_WARNING("OTLP exporter module `opentelemetry_exporter` not found. "
-                                 "Verify you have included the `opentelemetry_exporter` dependency.",
-                                 [ExporterModule]),
+                                 "Verify you have included the `opentelemetry_exporter` dependency."),
                     undefined;
                 {error, undef} ->
                     ?LOG_WARNING("Exporter module ~tp not found. Verify you have included "


### PR DESCRIPTION
When this warning is triggered due to `opentelemetry_exporter` not being installed, the warning causes a formatter crash error as below.

This is because format args are supplied but are not used in the format string.

```
2024-09-23T16:40:10.836262+01:00 warning: FORMATTER CRASH: {"OTLP exporter module `opentelemetry_exporter` not found. Verify you have included the `opentelemetry_exporter` dependency.",[opentelemetry_exporter]}
```