### PR TITLE
Minor bumps

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["26.1.2", "25.3.2.7", "24.3.4.14"]
+        otp_version: ["27.1", "26.1.2", "25.3.2.7", "24.3.4.14"]
         rebar3_version: ["3.22.1"]
         os: [ubuntu-20.04]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Exporter 
+## Exporter 1.8.0 - 2024-10-05
 
 ### Fixes
 
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an attribute you must convert with `unicode:characters_to_binary` before
   adding to the
   attributes](https://github.com/open-telemetry/opentelemetry-erlang/pull/737)
+
+## API 1.4.0 - 2024-10-05
+
+### Changes
+
+- [Hard code semconv 0.2 values](https://github.com/open-telemetry/opentelemetry-erlang/pull/780)
+
+## SDK 1.5.0 - 2024-10-05
+
+### Changes
+
+- [Fix invalid warning log causing FORMATTER
+  CRASH](https://github.com/open-telemetry/opentelemetry-erlang/pull/774)
+- [Hard code semconv 0.2 values](https://github.com/open-telemetry/opentelemetry-erlang/pull/780)
 
 ## API 1.3.1 - 2024-09-03
 

--- a/apps/opentelemetry/src/opentelemetry.app.src
+++ b/apps/opentelemetry/src/opentelemetry.app.src
@@ -1,6 +1,6 @@
 {application, opentelemetry,
  [{description, "Implementation of stable OpenTelemetry signals"},
-  {vsn, "1.4.1"},
+  {vsn, "1.5.0"},
   {registered, [
                 %% global tracer provider supervisor for use by the API
                 otel_tracer_provider_sup

--- a/apps/opentelemetry/src/otel_exporter_traces.erl
+++ b/apps/opentelemetry/src/otel_exporter_traces.erl
@@ -38,8 +38,8 @@
 init(Opts) ->
     otel_exporter:init(Opts).
 
-export({ExporterModule, Config}, Metrics, Resource) ->
-    ExporterModule:export(Metrics, Resource, Config).
+export({ExporterModule, Config}, SpansTid, Resource) ->
+    ExporterModule:export(SpansTid, Resource, Config).
 
 shutdown(Exporter) ->
     otel_exporter:shutdown(Exporter).

--- a/apps/opentelemetry/src/otel_exporter_traces.erl
+++ b/apps/opentelemetry/src/otel_exporter_traces.erl
@@ -39,7 +39,7 @@ init(Opts) ->
     otel_exporter:init(Opts).
 
 export({ExporterModule, Config}, SpansTid, Resource) ->
-    ExporterModule:export(SpansTid, Resource, Config).
+    ExporterModule:export(traces, SpansTid, Resource, Config).
 
 shutdown(Exporter) ->
     otel_exporter:shutdown(Exporter).

--- a/apps/opentelemetry/src/otel_exporter_traces.erl
+++ b/apps/opentelemetry/src/otel_exporter_traces.erl
@@ -39,7 +39,7 @@ init(Opts) ->
     otel_exporter:init(Opts).
 
 export({ExporterModule, Config}, SpansTid, Resource) ->
-    ExporterModule:export(traces, SpansTid, Resource, Config).
+    ExporterModule:export(SpansTid, Resource, Config).
 
 shutdown(Exporter) ->
     otel_exporter:shutdown(Exporter).

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -679,6 +679,9 @@ multiple_tracer_providers(_Config) ->
     receive
         {span, Span} ->
             ?assertEqual(<<"span-1">>, Span#span.name)
+    after
+        1000 ->
+            ct:fail(failed)
     end,
 
     %% now a span with the tracer from the non-global tracer provider

--- a/apps/opentelemetry_api/src/opentelemetry_api.app.src
+++ b/apps/opentelemetry_api/src/opentelemetry_api.app.src
@@ -1,6 +1,6 @@
 {application, opentelemetry_api,
  [{description, "OpenTelemetry API"},
-  {vsn, "1.3.2"},
+  {vsn, "1.4.0"},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/opentelemetry_exporter/rebar.config
+++ b/apps/opentelemetry_exporter/rebar.config
@@ -1,8 +1,8 @@
 {erl_opts, [debug_info]}.
 {deps, [{grpcbox, ">= 0.0.0"},
         {tls_certificate_check, "~> 1.18"},
-        {opentelemetry, "~> 1.4.0"},
-        {opentelemetry_api, "~> 1.3.0"}]}.
+        {opentelemetry, "~> 1.5.0"},
+        {opentelemetry_api, "~> 1.4.0"}]}.
 
 {grpc, [{protos, ["opentelemetry-proto/opentelemetry/proto/collector/trace/v1",
                   "opentelemetry-proto/opentelemetry/proto/collector/metrics/v1",

--- a/apps/opentelemetry_exporter/src/opentelemetry_exporter.app.src
+++ b/apps/opentelemetry_exporter/src/opentelemetry_exporter.app.src
@@ -1,6 +1,6 @@
 {application, opentelemetry_exporter,
  [{description, "OpenTelemetry Protocol Exporter"},
-  {vsn, "1.7.0"},
+  {vsn, "1.8.0"},
   {registered, []},
   {applications,
    [kernel,

--- a/docs.sh
+++ b/docs.sh
@@ -9,11 +9,11 @@ set -e
 
 rebar3 compile
 rebar3 edoc
-sdk_version=1.4.1
-api_version=1.3.2
+sdk_version=1.5.0
+api_version=1.4.0
 exp_sdk_version=0.5.1
 exp_api_version=0.5.1
-otlp_version=1.7.0
+otlp_version=1.8.0
 zipkin_version=1.1.0
 semconv_version=0.2.0
 


### PR DESCRIPTION
I got scared after https://github.com/open-telemetry/opentelemetry-erlang/issues/784 and made these minor version bumps... API probably doesn't need to be at all. SDK now that its fixed to work with older export versions also could probably be a patch. But.. feels safer.

Note I retired the previous patch versions from hex.