### PR TITLE
fix: key for otlp traces protocol app configuration

### DIFF
--- a/apps/opentelemetry_exporter/src/otel_exporter_traces_otlp.erl
+++ b/apps/opentelemetry_exporter/src/otel_exporter_traces_otlp.erl
@@ -238,7 +238,7 @@ config_mapping() ->
      {"OTEL_EXPORTER_OTLP_TRACES_HEADERS", otlp_traces_headers, key_value_list},
 
      {"OTEL_EXPORTER_OTLP_PROTOCOL", otlp_protocol, otlp_protocol},
-     {"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", exporter_otlp_traces_protocol, otlp_protocol},
+     {"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", otlp_traces_protocol, otlp_protocol},
 
      {"OTEL_EXPORTER_OTLP_COMPRESSION", otlp_compression, existing_atom},
      {"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION", otlp_traces_compression, existing_atom},

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -187,8 +187,11 @@ configuration(_Config) ->
         %% test all supported protocols
         application:unset_env(opentelemetry_exporter, otlp_protocol),
         os:putenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc"),
+        %% regression test for issue #788
+        os:putenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc"),
         ?assertMatch(#{protocol := grpc},
                      otel_exporter_traces_otlp:merge_with_environment(#{})),
+        os:unsetenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"),
 
         %% the specification defines the value as "http/protobuf"
         %% https://github.com/open-telemetry/opentelemetry-specification/blob/82707fd9f7b1266f1246b02ff3e00bebdee6b538/specification/protocol/exporter.md#specify-protocol


### PR DESCRIPTION
Fix for #788 

This was broken by a find-replace I did when breaking things up across modules. Looking at adding a regression test still.