### PR TITLE
Fixes #688: Change service.instance.id serialization to string

### DIFF
--- a/apps/opentelemetry/src/otel_resource_detector.erl
+++ b/apps/opentelemetry/src/otel_resource_detector.erl
@@ -271,7 +271,7 @@ add_service_instance(Resource) ->
                     case erlang:node() of
                         nonode@nohost ->
                             ServiceInstanceId = otel_id_generator:generate_trace_id(),
-                            ServiceInstanceResource = otel_resource:create([{'service.instance.id', unicode:characters_to_binary(ServiceInstanceId)}]),
+                            ServiceInstanceResource = otel_resource:create([{'service.instance.id', integer_to_binary(ServiceInstanceId)}]),
                             otel_resource:merge(ServiceInstanceResource, Resource);
                         ServiceInstance ->
                             ServiceInstance1 = erlang:atom_to_binary(ServiceInstance, utf8),
@@ -290,7 +290,7 @@ add_service_instance(Resource) ->
             end;
         ServiceInstance ->
             ServiceInstanceResource = otel_resource:create([{'service.instance.id',
-                                                            unicode:characters_to_binary(ServiceInstance)}]),
+                                                                        otel_utils:assert_to_binary(ServiceInstance)}]),
             otel_resource:merge(ServiceInstanceResource, Resource)
     end.
 

--- a/apps/opentelemetry/src/otel_resource_detector.erl
+++ b/apps/opentelemetry/src/otel_resource_detector.erl
@@ -271,7 +271,7 @@ add_service_instance(Resource) ->
                     case erlang:node() of
                         nonode@nohost ->
                             ServiceInstanceId = otel_id_generator:generate_trace_id(),
-                            ServiceInstanceResource = otel_resource:create([{'service.instance.id', ServiceInstanceId}]),
+                            ServiceInstanceResource = otel_resource:create([{'service.instance.id', unicode:characters_to_binary(ServiceInstanceId)}]),
                             otel_resource:merge(ServiceInstanceResource, Resource);
                         ServiceInstance ->
                             ServiceInstance1 = erlang:atom_to_binary(ServiceInstance, utf8),
@@ -290,7 +290,7 @@ add_service_instance(Resource) ->
             end;
         ServiceInstance ->
             ServiceInstanceResource = otel_resource:create([{'service.instance.id',
-                                                             otel_utils:assert_to_binary(ServiceInstance)}]),
+                                                            unicode:characters_to_binary(ServiceInstance)}]),
             otel_resource:merge(ServiceInstanceResource, Resource)
     end.
 


### PR DESCRIPTION
Fixes #688

This PR aims to update Serialization Logic by:

Converting `service.instance.id ` to a string before it is sent in protobuf messages. Any occurrence of `service.instance.id` in [\otel_resource_detector.erl](https://github.com/open-telemetry/opentelemetry-erlang/blob/main/apps/opentelemetry/src/otel_resource_detector.erl) being assigned an integer value was modified to convert it to a binary string format, ensuring compliance with the expected data type.

Note: As a new contributor, I encountered difficulties in running tests due to a lack of documentation regarding the testing tools in the OpenTelemetry Erlang repository. Consequently, I am relying on CI/CD tests for my initial pull request. I would greatly appreciate any guidance on setting up the testing environment.

For your reference, I am using Windows with the following Erlang version: **Erlang (SMP, ASYNC_THREADS) (BEAM) emulator version 15.1.2**. I am currently facing challenges in setting up **Rebar3**.