### PR TITLE
Fix `OpenTelemetry.Tracer.end_span` return type spec

### DIFF
--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -289,7 +289,7 @@ update_name(_, _) ->
 %% If `SpanCtx' is not recording, this function doesn't do anything.
 %% Returns the updated span context.
 -spec end_span(SpanCtx) -> SpanCtx when
-      SpanCtx :: opentelemetry:span_ctx().
+      SpanCtx :: opentelemetry:span_ctx() | undefined.
 end_span(SpanCtx=#span_ctx{span_sdk={Module, _}}) when ?is_recording(SpanCtx) ->
     _ = Module:end_span(SpanCtx, undefined),
     SpanCtx#span_ctx{is_recording=false};


### PR DESCRIPTION
Hi there!

Based on the specs of `otel_span:end_span/0,1` this `Tracer.end_span/0,1` is supposed to always return span context (`:undefined` is not an option for the return)

See here:
https://github.com/open-telemetry/opentelemetry-erlang/blob/0a38bd4765c9f3efbf5e5b40e95783b9df97e2a7/apps/opentelemetry_api/src/otel_span.erl#L291-L306