### PR TITLE
chore: upgrade gha to ubuntu-24.04

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -37,7 +37,7 @@ jobs:
         otp_version: ['25.0.3', '24.1.2', '23.3.4.2']
         elixir_version: ['1.14', '1.13.4']
         rebar3_version: ['3.17.0']
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir_version }}
@@ -63,7 +63,7 @@ jobs:
         otp_version: ['25.0.3', '24.1.2', '23.3.4.2']
         elixir_version: ['1.14', '1.13.4']
         rebar3_version: ['3.17.0']
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         version-type: 'strict'
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
@@ -107,7 +107,7 @@ jobs:
       matrix:
         otp_version: ['25.0.3']
         elixir_version: ['1.14']
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir_version }}

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         otp_version: ['25.0.3', '24.1.2', '23.3.4.16']
         rebar3_version: ['3.19.0']
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
     steps:
@@ -89,7 +89,7 @@ jobs:
       matrix:
         otp_version: ['25.0.3']
         rebar3_version: ['3.19.0']
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         version-type: 'strict'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/w3c_interop.yml
+++ b/.github/workflows/w3c_interop.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   interop_tests:
     name: Run W3C Trace Context Interop Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       OTP_VERSION:
     steps:


### PR DESCRIPTION
GitHub is retiring 20.04 runners in april.