### PR TITLE
fix batch export interval to match spec at 5 sec

### DIFF
--- a/apps/opentelemetry/src/otel_batch_processor.erl
+++ b/apps/opentelemetry/src/otel_batch_processor.erl
@@ -84,7 +84,7 @@
 
 -define(DEFAULT_MAX_QUEUE_SIZE, 2048).
 -define(DEFAULT_SCHEDULED_DELAY_MS, timer:seconds(5)).
--define(DEFAULT_EXPORTER_TIMEOUT_MS, timer:minutes(5)).
+-define(DEFAULT_EXPORTER_TIMEOUT_MS, timer:seconds(30)).
 -define(DEFAULT_CHECK_TABLE_SIZE_MS, timer:seconds(1)).
 
 -define(ENABLED_KEY(RegName), {?MODULE, enabled_key, RegName}).


### PR DESCRIPTION
somehow was way off on this :) https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#batching-processor