### PR TITLE
Fix the inconsistent hex value encoding for log metadata

### DIFF
--- a/apps/opentelemetry_api/lib/open_telemetry.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry.ex
@@ -63,7 +63,6 @@ defmodule OpenTelemetry do
   """
   @type hex_span_id() :: :opentelemetry.hex_span_id()
 
-
   @type attribute_key() :: :opentelemetry.attribute_key()
   @type attribute_value() :: :opentelemetry.attribute_value()
 

--- a/apps/opentelemetry_api/lib/open_telemetry.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry.ex
@@ -53,6 +53,17 @@ defmodule OpenTelemetry do
   """
   @type span_id() :: non_neg_integer()
 
+  @typedoc """
+  Hex-encoded TraceId as a 32-character lowercase binary string.
+  """
+  @type hex_trace_id() :: :opentelemetry.hex_trace_id()
+
+  @typedoc """
+  Hex-encoded SpanId as a 16-character lowercase binary string.
+  """
+  @type hex_span_id() :: :opentelemetry.hex_span_id()
+
+
   @type attribute_key() :: :opentelemetry.attribute_key()
   @type attribute_value() :: :opentelemetry.attribute_value()
 

--- a/apps/opentelemetry_api/lib/open_telemetry/span.ex
+++ b/apps/opentelemetry_api/lib/open_telemetry/span.ex
@@ -41,21 +41,33 @@ defmodule OpenTelemetry.Span do
   defdelegate span_id(span), to: :otel_span
 
   @doc """
+  Get the hex-encoded trace context.
+  """
+  @spec hex_span_ctx(OpenTelemetry.span_ctx() | nil) ::
+          %{
+            otel_trace_id: OpenTelemetry.hex_trace_id(),
+            otel_span_id: OpenTelemetry.hex_span_id(),
+            otel_trace_flags: binary()
+          }
+          | %{}
+  defdelegate hex_span_ctx(span_ctx), to: :otel_span
+
+  @doc """
+  Get the lowercase hex encoded span ID.
+  """
+  @spec hex_span_id(OpenTelemetry.span_ctx()) :: OpenTelemetry.hex_span_id()
+  defdelegate hex_span_id(span), to: :otel_span
+
+  @doc """
   Get the TraceId of a Span.
   """
   @spec trace_id(OpenTelemetry.span_ctx()) :: OpenTelemetry.trace_id()
   defdelegate trace_id(span), to: :otel_span
 
   @doc """
-  Get the lowercase hex encoded span ID.
-  """
-  @spec hex_span_id(OpenTelemetry.span_ctx()) :: binary()
-  defdelegate hex_span_id(span), to: :otel_span
-
-  @doc """
   Get the lowercase hex encoded trace ID.
   """
-  @spec hex_trace_id(OpenTelemetry.span_ctx()) :: binary()
+  @spec hex_trace_id(OpenTelemetry.span_ctx()) :: OpenTelemetry.hex_trace_id()
   defdelegate hex_trace_id(span), to: :otel_span
 
   @doc """

--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -112,15 +112,16 @@ span_id(#span_ctx{span_id=SpanId}) ->
     SpanId.
 
 %% keys are prefixed with `otel_' because the main use of this function is logger metadata
--spec hex_span_ctx(opentelemetry:span_ctx() | undefined) -> #{otel_trace_id := unicode:charlist(),
-                                                              otel_span_id := unicode:charlist(),
-                                                              otel_trace_flags := unicode:charlist()} | #{}.
-hex_span_ctx(#span_ctx{trace_id=TraceId,
-                       span_id=SpanId,
-                       trace_flags=TraceFlags}) ->
-    #{otel_trace_id => io_lib:format("~32.16.0b", [TraceId]),
-      otel_span_id => io_lib:format("~16.16.0b", [SpanId]),
-      otel_trace_flags => case TraceFlags band 1 of 1 -> "01"; _ -> "00" end};
+-spec hex_span_ctx(opentelemetry:span_ctx() | undefined) -> #{otel_trace_id := opentelemetry:hex_trace_id(),
+                                                              otel_span_id := opentelemetry:hex_span_id(),
+                                                              otel_trace_flags := binary()} | #{}.
+hex_span_ctx(SpanCtx = #span_ctx{trace_flags=TraceFlags}) ->
+    TraceIdBin = hex_trace_id(SpanCtx),
+    SpanIdBin = hex_span_id(SpanCtx),
+    TraceFlagsBin = case TraceFlags band 1 of 1 -> <<"01">>; _ -> <<"00">> end,
+    #{otel_trace_id => TraceIdBin,
+      otel_span_id => SpanIdBin,
+      otel_trace_flags => TraceFlagsBin};
 hex_span_ctx(_) ->
     #{}.
 

--- a/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
+++ b/apps/opentelemetry_api/test/opentelemetry_api_SUITE.erl
@@ -247,7 +247,13 @@ noop_with_span(_Config) ->
     ok.
 
 hex_trace_ids(_Config) ->
+    HexTraceId = <<"0000000000000000000000000000a1b2">>,
+    HexSpanId = <<"000000000000c3d4">>,
     SpanCtx=#span_ctx{trace_id=41394, span_id=50132},
-    ?assertEqual(<<"0000000000000000000000000000a1b2">>, otel_span:hex_trace_id(SpanCtx)),
-    ?assertEqual(<<"000000000000c3d4">>, otel_span:hex_span_id(SpanCtx)),
+    ?assertEqual(HexTraceId, otel_span:hex_trace_id(SpanCtx)),
+    ?assertEqual(HexSpanId, otel_span:hex_span_id(SpanCtx)),
+    ?assertEqual(#{otel_trace_id => HexTraceId,
+                   otel_span_id => HexSpanId,
+                   otel_trace_flags => <<"00">>},
+                 otel_span:hex_span_ctx(SpanCtx)),
     ok.

--- a/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
+++ b/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
@@ -96,7 +96,7 @@ log_record(#{level := Level,
           otel_trace_flags := TraceFlagsHex} ->
             TraceFlags = case TraceFlagsHex of
                 <<_:0, _/binary>> when byte_size(TraceFlagsHex) == 2 ->
-                    binary:decode_unsigned(TraceFlagsHex, 16);
+                    erlang:binary_to_integer(TraceFlagsHex, 16);
                 _ -> 0
             end,
             #{trace_id => TraceId,


### PR DESCRIPTION
This corrects a longstanding inconsistency we've had where `span:hex_span_ctx/1` returned charlists for trace_id and span_id while `hex_trace_id/1` and `hex_span_id/1` returned binaries. This created an additional issue of Elixir logs not formatting the ids as strings with standard formatters, instead being output as charlists (an array of numbers), breaking basic correlation for folks.

LogRecord was updated to include the trace flags and encode it per the [data model spec](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-traceflags).