### PR TITLE
Otel declarative configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- 
+- Support `OTEL_EXPERIMENTAL_CONFIG_FILE` environment variable to specify a json
+  file assumed to already be validated against the Otel file configuration
+  jsonschema.
+- Support the new file configuration schema as Erlang application environment
+  configuration in addition to as json.
 
 #### Changes
 
@@ -19,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   structure resource attribute keys with dots. Meaning use a key of
   `service.name` instead of `#{service => #{name => ...}}` to represent
   `service.name` attribute in the resource.
+- Options passed to the start of a tracer server and span processor have changed
+  to correspond to the file configuration schema.
 
 ## Experimental API 0.5.2 - 2024-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### SDK 
 
-### 
+#### Added
 
-- []()
+- 
 
-### Changes
+#### Changes
+
+- *Deprecated*: Resource attribute configuration: No longer use maps to
+  structure resource attribute keys with dots. Meaning use a key of
+  `service.name` instead of `#{service => #{name => ...}}` to represent
+  `service.name` attribute in the resource.
 
 ## Experimental API 0.5.2 - 2024-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### SDK 
+
+### 
+
+- []()
+
+### Changes
+
 ## Experimental API 0.5.2 - 2024-11-22
 
 ### Added

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -31,10 +31,10 @@ start(_StartType, _StartArgs) ->
                          undefined ->
                              otel_configuration:merge_with_os(Env);
                          File ->
-                             otel_file_configuration:parse_file(File)
+                             otel_configuration:merge_with_env(otel_file_configuration:parse_file(File), Env)
                      end;
                  File ->
-                     otel_file_configuration:parse_file(File)
+                     otel_configuration:merge_with_env(otel_file_configuration:parse_file(File), Env)
              end,
 
     %% set the global propagators for HTTP based on the application env

--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -34,7 +34,7 @@ start(_StartType, _StartArgs) ->
     SupResult = opentelemetry_sup:start_link(Config),
 
     case Config of
-        #{sdk_disabled := true} ->
+        #{disabled := true} ->
             %% skip the rest if the SDK is disabled
             SupResult;
         _ ->
@@ -57,7 +57,8 @@ stop(_State) ->
 
 %% internal functions
 
-setup_text_map_propagators(#{text_map_propagators := List}) ->
+setup_text_map_propagators(Config) ->
+    List = maps:get(text_map_propagators, Config, []),
     CompositePropagator = otel_propagator_text_map_composite:create(List),
     opentelemetry:set_text_map_propagator(CompositePropagator).
 

--- a/apps/opentelemetry/src/opentelemetry_sup.erl
+++ b/apps/opentelemetry/src/opentelemetry_sup.erl
@@ -29,7 +29,7 @@
 start_link(Opts) ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, [Opts]).
 
-init([#{sdk_disabled := true}]) ->
+init([#{disabled := true}]) ->
     {ok, {#{}, []}};
 init([Opts]) ->
     SupFlags = #{strategy => one_for_one,

--- a/apps/opentelemetry/src/otel_batch_processor.erl
+++ b/apps/opentelemetry/src/otel_batch_processor.erl
@@ -147,8 +147,8 @@ init([Args=#{reg_name := RegName}]) ->
     process_flag(trap_exit, true),
 
     SizeLimit = maps:get(max_queue_size, Args, ?DEFAULT_MAX_QUEUE_SIZE),
-    ExportingTimeout = maps:get(exporting_timeout_ms, Args, ?DEFAULT_EXPORTER_TIMEOUT_MS),
-    ScheduledDelay = maps:get(scheduled_delay_ms, Args, ?DEFAULT_SCHEDULED_DELAY_MS),
+    ExportingTimeout = maps:get(export_timeout, Args, ?DEFAULT_EXPORTER_TIMEOUT_MS),
+    ScheduledDelay = maps:get(schedule_delay, Args, ?DEFAULT_SCHEDULED_DELAY_MS),
     CheckTableSize = maps:get(check_table_size_ms, Args, ?DEFAULT_CHECK_TABLE_SIZE_MS),
 
     %% TODO: this should be passed in from the tracer server

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -26,8 +26,8 @@
 
 -type log_level() :: atom().
 
--type attribute_limits() :: #{attribute_value_length_limit := integer() | undefined,
-                              attribute_count_limit := integer() | undefined
+-type attribute_limits() :: #{attribute_value_length_limit => integer() | undefined,
+                              attribute_count_limit => integer() | undefined
                              }.
 
 -type exporter_args() :: map().
@@ -227,20 +227,25 @@ convert_disabled(OldConfig, Config) ->
     end.
 
 convert_attribute_limits(OldConfig, Config) ->
-    OldConfig2 = case maps:take(attribute_count_limit, OldConfig) of
-                     {AttributeCountLimit, OldConfig1} ->
-                         OldConfig1#{attribute_limits => #{attribute_count_limit => AttributeCountLimit}};
-                     error ->
-                         OldConfig
-                 end,
+    case lists:keyfind(attribute_limits, 1, Config) of
+        {attribute_limits, Limits} ->
+            OldConfig#{attribute_limits => Limits};
+        false ->
+            OldConfig2 = case maps:take(attribute_count_limit, OldConfig) of
+                             {AttributeCountLimit, OldConfig1} ->
+                                 OldConfig1#{attribute_limits => #{attribute_count_limit => AttributeCountLimit}};
+                             error ->
+                                 OldConfig
+                         end,
 
 
-    case maps:take(attribute_value_length_limit, OldConfig2) of
-        {AttributeValueLengthLimit, OldConfig3} ->
-            AttributeLimitsMap = maps:get(attribute_limits, OldConfig3, #{}),
-            OldConfig3#{attribute_limits => AttributeLimitsMap#{attribute_value_length_limit => AttributeValueLengthLimit}};
-        error ->
-            OldConfig2
+            case maps:take(attribute_value_length_limit, OldConfig2) of
+                {AttributeValueLengthLimit, OldConfig3} ->
+                    AttributeLimitsMap = maps:get(attribute_limits, OldConfig3, #{}),
+                    OldConfig3#{attribute_limits => AttributeLimitsMap#{attribute_value_length_limit => AttributeValueLengthLimit}};
+                error ->
+                    OldConfig2
+            end
     end.
 
     %% ConfigMap = new(),

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -163,7 +163,7 @@ merge_with_os(AppEnv) ->
 
 -spec convert_to_new(#{}) -> t().
 convert_to_new(OldConfig) ->
-    convert_disabled(OldConfig).
+    convert_attribute_limits(convert_disabled(OldConfig)).
 
 convert_disabled(OldConfig) ->
     case maps:take(sdk_disabled, OldConfig) of
@@ -171,6 +171,23 @@ convert_disabled(OldConfig) ->
             OldConfig1#{disabled => Value};
         error ->
             OldConfig
+    end.
+
+convert_attribute_limits(OldConfig) ->
+    OldConfig2 = case maps:take(attribute_count_limit, OldConfig) of
+                     {AttributeCountLimit, OldConfig1} ->
+                         OldConfig1#{attribute_limits => #{attribute_count_limit => AttributeCountLimit}};
+                     error ->
+                         OldConfig
+                 end,
+
+
+    case maps:take(attribute_value_length_limit, OldConfig2) of
+        {AttributeValueLengthLimit, OldConfig3} ->
+            AttributeLimitsMap = maps:get(attribute_limits, OldConfig3, #{}),
+            OldConfig3#{attribute_limits => AttributeLimitsMap#{attribute_value_length_limit => AttributeValueLengthLimit}};
+        error ->
+            OldConfig2
     end.
 
     %% ConfigMap = new(),

--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -113,13 +113,44 @@ new() ->
 merge_with_os(AppEnv) ->
     ConfigMap = new(),
 
+    ConfigMap1 = lists:foldl(fun(F, Acc) ->
+                                     F(AppEnv, Acc)
+                             end, ConfigMap, [fun resource/2,
+                                              fun attribute_limits/2,
+                                              fun propagator/2,
+                                              fun tracer_provider/2,
+                                              fun sweeper/2]),
+
+    %% backwards compatability
     lists:foldl(fun(F, Acc) ->
                         F(AppEnv, Acc)
-                end, ConfigMap, [fun span_limits/2,
-                                 fun general/2,
-                                 fun sampler/2,
-                                 fun processors/2,
-                                 fun sweeper/2]).
+                end, ConfigMap1, [fun span_limits/2,
+                                  fun general/2,
+                                  fun sampler/2,
+                                  fun processors/2,
+                                  fun sweeper/2]).
+
+-spec resource(list(), t()) -> t().
+resource(AppEnv, ConfigMap) ->
+    Resource = proplists:get_value(resource, AppEnv, []),
+    ConfigMap.
+
+-spec attribute_limits(list(), t()) -> t().
+attribute_limits(AppEnv, ConfigMap) ->
+    AttributeLimits = proplists:get_value(attribute_limits, AppEnv, []),
+    ConfigMap.
+
+-spec propagator(list(), t()) -> t().
+propagator(AppEnv, ConfigMap) ->
+    Propagator = proplists:get_value(propagator, AppEnv, []),
+    ConfigMap.
+
+-spec tracer_provider(list(), t()) -> t().
+tracer_provider(AppEnv, ConfigMap) ->
+    TracerProvider = proplists:get_value(tracer_provider, AppEnv, []),
+    ConfigMap.
+
+%% backwards compatability
 
 -spec span_limits(list(), t()) -> t().
 span_limits(AppEnv, ConfigMap) ->

--- a/apps/opentelemetry/src/otel_exporter.erl
+++ b/apps/opentelemetry/src/otel_exporter.erl
@@ -44,6 +44,8 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+init(Exporter={Type, _}) when Type =:= otlp_grpc orelse Type =:= otlp_http ->
+    init(otel_configuration:convert_exporter(Exporter));
 init({ExporterModule, Config}) when is_atom(ExporterModule) ->
     try ExporterModule:init(Config) of
         {ok, ExporterState} when ExporterModule =:= opentelemetry_exporter ->

--- a/apps/opentelemetry/src/otel_file_configuration.erl
+++ b/apps/opentelemetry/src/otel_file_configuration.erl
@@ -1,0 +1,18 @@
+-module(otel_file_configuration).
+
+-export([parse_file/1,
+         parse_binary/1]).
+
+%%
+-spec parse_file(file:filename_all()) -> otel_configuration:t().
+parse_file(JsonFile) ->
+    {ok, File} = file:read_file(JsonFile),
+    parse_binary(File).
+
+%% TODO: Log a warning on failure to parse and return empty configuration
+-spec parse_binary(binary()) -> otel_configuration:t().
+parse_binary(Bin) ->
+    Push = fun(Key, Value, Acc) -> [{binary_to_atom(Key), Value} | Acc] end,
+    {Json, ok, <<>>} = json:decode(Bin, ok, #{object_push => Push, null => undefined}),
+
+    Json.

--- a/apps/opentelemetry/src/otel_resource.erl
+++ b/apps/opentelemetry/src/otel_resource.erl
@@ -123,7 +123,7 @@ is_key(_, _) ->
 -spec merge(t(), t()) -> t().
 merge(#resource{schema_url=NewSchemaUrl,
                 attributes=NewAttributes}, CurrentResource=#resource{schema_url=CurrentSchemaUrl,
-                                                             attributes=CurrentAttributes}) ->
+                                                                     attributes=CurrentAttributes}) ->
     SchameUrl = merge_schema_url(NewSchemaUrl, CurrentSchemaUrl),
     NewMap = otel_attributes:map(NewAttributes),
     CurrentResource#resource{schema_url=SchameUrl,

--- a/apps/opentelemetry/src/otel_resource_detector.erl
+++ b/apps/opentelemetry/src/otel_resource_detector.erl
@@ -82,9 +82,13 @@ get_resource(Timeout) ->
     end.
 
 %% @private
-init([#{resource_detectors := Detectors,
-        resource_detector_timeout := DetectorTimeout}]) ->
+init([Config]) ->
     process_flag(trap_exit, true),
+
+    Detectors = maps:get(resource_detectors, Config, [otel_resource_env_var, otel_resource_app_env]),
+    DetectorTimeout = maps:get(resource_detector_timeout, Config, 5000),
+
+
 
     {ok, collecting, #data{resource=otel_resource:create([]),
                            detectors=Detectors,

--- a/apps/opentelemetry/src/otel_sampler.erl
+++ b/apps/opentelemetry/src/otel_sampler.erl
@@ -100,7 +100,7 @@
 
 %% @doc Returns a sampler based on the given specification. This is left for backwards
 %% compatibility. The function `new/2' should be used instead.
--spec new(SamplerSpec :: sampler_spec()) -> t().
+-spec new(SamplerSpec :: sampler_spec() | always_on | always_off) -> t().
 new(always_on) ->
     new({otel_sampler_always_on, #{}});
 new(always_off) ->

--- a/apps/opentelemetry/src/otel_span_limits.erl
+++ b/apps/opentelemetry/src/otel_span_limits.erl
@@ -37,14 +37,14 @@ get() ->
 
 -spec set(otel_configuration:t()) -> ok.
 set(Config) ->
-    AttributeLimits = maps:get(attribute_limits, Config, #{}),
-    AttributeCountLimit = maps:get(attribute_count_limit, AttributeLimits, 128),
-    AttributeValueLengthLimit = maps:get(attribute_value_length_limit, AttributeLimits, infinity),
+    AttributeLimits = otel_configuration:defined_or_default(attribute_limits, Config, #{}),
+    AttributeCountLimit = otel_configuration:defined_or_default(attribute_count_limit, AttributeLimits, 128),
+    AttributeValueLengthLimit = otel_configuration:defined_or_default(attribute_value_length_limit, AttributeLimits, infinity),
 
-    EventCountLimit = maps:get(event_count_limit, Config, 128),
-    LinkCountLimit = maps:get(link_count_limit, Config, 128),
-    AttributePerEventLimit = maps:get(attribute_per_event_limit, Config, 128),
-    AttributePerLinkLimit = maps:get(attribute_per_link_limit, Config, 128),
+    EventCountLimit = otel_configuration:defined_or_default(event_count_limit, Config, 128),
+    LinkCountLimit = otel_configuration:defined_or_default(link_count_limit, Config, 128),
+    AttributePerEventLimit = otel_configuration:defined_or_default(attribute_per_event_limit, Config, 128),
+    AttributePerLinkLimit = otel_configuration:defined_or_default(attribute_per_link_limit, Config, 128),
     SpanLimits = #span_limits{attribute_count_limit=AttributeCountLimit,
                               attribute_value_length_limit=AttributeValueLengthLimit,
                               event_count_limit=EventCountLimit,
@@ -52,6 +52,7 @@ set(Config) ->
                               attribute_per_event_limit=AttributePerEventLimit,
                               attribute_per_link_limit=AttributePerLinkLimit},
     persistent_term:put(?SPAN_LIMITS_KEY, SpanLimits).
+
 
 attribute_count_limit() ->
     get_limit(attribute_count_limit, ?MODULE:get()).

--- a/apps/opentelemetry/src/otel_span_limits.erl
+++ b/apps/opentelemetry/src/otel_span_limits.erl
@@ -36,12 +36,13 @@ get() ->
     persistent_term:get(?SPAN_LIMITS_KEY).
 
 -spec set(otel_configuration:t()) -> ok.
-set(#{attribute_count_limit := AttributeCountLimit,
-      attribute_value_length_limit := AttributeValueLengthLimit,
-      event_count_limit := EventCountLimit,
-      link_count_limit := LinkCountLimit,
-      attribute_per_event_limit := AttributePerEventLimit,
-      attribute_per_link_limit := AttributePerLinkLimit}) ->
+set(Config) ->
+    AttributeCountLimit = maps:get(attribute_count_limit, Config, 128),
+    AttributeValueLengthLimit = maps:get(attribute_value_length_limit, Config, infinity),
+    EventCountLimit = maps:get(event_count_limit, Config, 128),
+    LinkCountLimit = maps:get(link_count_limit, Config, 128),
+    AttributePerEventLimit = maps:get(attribute_per_event_limit, Config, 128),
+    AttributePerLinkLimit = maps:get(attribute_per_link_limit, Config, 128),
     SpanLimits = #span_limits{attribute_count_limit=AttributeCountLimit,
                               attribute_value_length_limit=AttributeValueLengthLimit,
                               event_count_limit=EventCountLimit,

--- a/apps/opentelemetry/src/otel_span_limits.erl
+++ b/apps/opentelemetry/src/otel_span_limits.erl
@@ -37,8 +37,10 @@ get() ->
 
 -spec set(otel_configuration:t()) -> ok.
 set(Config) ->
-    AttributeCountLimit = maps:get(attribute_count_limit, Config, 128),
-    AttributeValueLengthLimit = maps:get(attribute_value_length_limit, Config, infinity),
+    AttributeLimits = maps:get(attribute_limits, Config, #{}),
+    AttributeCountLimit = maps:get(attribute_count_limit, AttributeLimits, 128),
+    AttributeValueLengthLimit = maps:get(attribute_value_length_limit, AttributeLimits, infinity),
+
     EventCountLimit = maps:get(event_count_limit, Config, 128),
     LinkCountLimit = maps:get(link_count_limit, Config, 128),
     AttributePerEventLimit = maps:get(attribute_per_event_limit, Config, 128),

--- a/apps/opentelemetry/src/otel_span_sup.erl
+++ b/apps/opentelemetry/src/otel_span_sup.erl
@@ -36,7 +36,7 @@ init([Config]) ->
                  intensity => 1,
                  period => 5},
 
-    SweeperConfig = maps:get(sweeper, Config),
+    SweeperConfig = maps:get(sweeper, Config, #{}),
     Sweeper = #{id => otel_span_sweeper,
                 start => {otel_span_sweeper, start_link, [SweeperConfig]},
                 restart => permanent,

--- a/apps/opentelemetry/src/otel_span_sweeper.erl
+++ b/apps/opentelemetry/src/otel_span_sweeper.erl
@@ -50,10 +50,11 @@ storage_size() ->
 start_link(Config) ->
     gen_statem:start_link({local, ?MODULE}, ?MODULE, [Config], []).
 
-init([#{interval := Interval,
-        strategy := Strategy,
-        span_ttl := TTL,
-        storage_size := StorageSize}]) ->
+init([Config]) ->
+    Interval = maps:get(interval, Config, timer:minutes(10)),
+    Strategy = maps:get(strategy, Config, drop),
+    TTL = maps:get(span_ttl, Config, timer:minutes(30)),
+    StorageSize = maps:get(storage_size, Config, infinity),
     {ok, ready, #data{interval=Interval,
                       strategy=Strategy,
                       ttl=maybe_convert_time_unit(TTL),

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -58,10 +58,12 @@
 start_link(Name, RegName, SpanProcessorSupRegName, Resource, Config) ->
     gen_server:start_link({local, RegName}, ?MODULE, [Name, SpanProcessorSupRegName, Resource, Config], []).
 
-init([Name, SpanProcessorSup, Resource, #{id_generator := IdGeneratorModule,
-                                          sampler := SamplerSpec,
-                                          processors := Processors,
-                                          deny_list := DenyList}]) ->
+init([Name, SpanProcessorSup, Resource, Config]) ->
+    IdGeneratorModule = maps:get(id_generator, Config, otel_id_generator),
+    SamplerSpec = maps:get(sampler, Config, {parent_based, #{root => always_on}}),
+    Processors = maps:get(processors, Config, [{otel_batch_processor, #{}}]),
+    DenyList = maps:get(deny_list, Config, []),
+
     Sampler = otel_sampler:new(SamplerSpec),
 
     Processors1 = init_processors(SpanProcessorSup, Processors),

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -62,7 +62,7 @@ init([Name, SpanProcessorSup, Resource, Config]) ->
     TracerProviderConfig = maps:get(tracer_provider, Config, #{}),
     IdGeneratorModule = maps:get(id_generator, TracerProviderConfig, otel_id_generator),
     SamplerSpec = maps:get(sampler, TracerProviderConfig, {parent_based, #{root => {always_on, #{}}}}),
-    ct:pal("Sampler ~p", [SamplerSpec]),
+
     DenyList = maps:get(deny_list, Config, []),
 
     Processors = maps:get(processors, TracerProviderConfig, [{otel_batch_processor, #{}}]),

--- a/apps/opentelemetry/src/otel_tracer_server.erl
+++ b/apps/opentelemetry/src/otel_tracer_server.erl
@@ -59,11 +59,12 @@ start_link(Name, RegName, SpanProcessorSupRegName, Resource, Config) ->
     gen_server:start_link({local, RegName}, ?MODULE, [Name, SpanProcessorSupRegName, Resource, Config], []).
 
 init([Name, SpanProcessorSup, Resource, Config]) ->
-    IdGeneratorModule = maps:get(id_generator, Config, otel_id_generator),
-    SamplerSpec = maps:get(sampler, Config, {parent_based, #{root => always_on}}),
+    TracerProviderConfig = maps:get(tracer_provider, Config, #{}),
+    IdGeneratorModule = maps:get(id_generator, TracerProviderConfig, otel_id_generator),
+    SamplerSpec = maps:get(sampler, TracerProviderConfig, {parent_based, #{root => {always_on, #{}}}}),
+    ct:pal("Sampler ~p", [SamplerSpec]),
     DenyList = maps:get(deny_list, Config, []),
 
-    TracerProviderConfig = maps:get(tracer_provider, Config, #{}),
     Processors = maps:get(processors, TracerProviderConfig, [{otel_batch_processor, #{}}]),
 
     Sampler = otel_sampler:new(SamplerSpec),

--- a/apps/opentelemetry/src/otel_tracer_server_sup.erl
+++ b/apps/opentelemetry/src/otel_tracer_server_sup.erl
@@ -36,7 +36,7 @@ init([Name, Resource, Opts]) ->
     %% supervisors and the tracer provider itself.
     %% in the case of the global provider the name is `global'
     SpanProcessorSupRegName = list_to_atom(lists:concat([otel_span_processor_sup, "_", Name])),
-    TracerServeRegName = list_to_atom(lists:concat([otel_tracer_provider, "_", Name])),
+    TracerServerRegName = list_to_atom(lists:concat([otel_tracer_provider, "_", Name])),
 
     SpanProcessorSup = #{id => otel_span_processor_sup,
                          start => {otel_span_processor_sup, start_link, [SpanProcessorSupRegName]},
@@ -47,7 +47,7 @@ init([Name, Resource, Opts]) ->
 
     TracerServer = #{id => otel_tracer_server,
                      start => {otel_tracer_server, start_link, [Name,
-                                                                TracerServeRegName,
+                                                                TracerServerRegName,
                                                                 SpanProcessorSupRegName,
                                                                 Resource,
                                                                 Opts]},

--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -671,9 +671,9 @@ multiple_tracer_providers(_Config) ->
                                                          Resource,
                                                          #{id_generator => otel_id_generator,
                                                            sampler => {otel_sampler_always_on, []},
-                                                           processors => [{otel_batch_processor, #{name => test_batch,
-                                                                                                   scheduled_delay_ms => 1,
-                                                                                                   exporter => {otel_exporter_pid, self()}}}],
+                                                           tracer_provider => #{processors => [{batch, #{name => test_batch,
+                                                                                                         schedule_delay => 1,
+                                                                                                         exporter => {otel_exporter_pid, self()}}}]},
                                                            deny_list => []})),
     ?assertEqual(Resource, otel_tracer_provider:resource(test_provider)),
 
@@ -681,9 +681,10 @@ multiple_tracer_providers(_Config) ->
     ?assertMatch({ok, _}, opentelemetry:start_tracer_provider(deprecated_test_provider_start,
                                                               #{id_generator => otel_id_generator,
                                                                 sampler => {otel_sampler_always_on, []},
-                                                                processors => [{otel_batch_processor, #{name => test_batch_2,
-                                                                                                        scheduled_delay_ms => 1000,
-                                                                                                        exporter => {otel_exporter_pid, self()}}}],
+                                                                tracer_provider =>
+                                                                    #{processors => [{batch, #{name => test_batch_2,
+                                                                                               schedule_delay => 1,
+                                                                                               exporter => {otel_exporter_pid, self()}}}]},
                                                                 deny_list => []})),
 
     ?assertEqual(otel_resource:create([]), otel_tracer_provider:resource(deprecated_test_provider_start)),
@@ -707,7 +708,7 @@ multiple_tracer_providers(_Config) ->
             ?assertEqual(<<"span-1">>, Span#span.name)
     after
         1000 ->
-            ct:fail(failed)
+            ct:fail(failed1)
     end,
 
     %% now a span with the tracer from the non-global tracer provider
@@ -723,7 +724,7 @@ multiple_tracer_providers(_Config) ->
             ?assertEqual(<<"span-2">>, Span1#span.name)
     after
         1000 ->
-            ct:fail(failed)
+            ct:fail(failed2)
     end,
 
     ok.

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -198,9 +198,7 @@ end_per_testcase(_, Config) ->
     ok.
 
 empty_os_environment(_Config) ->
-    ?assertMatch(#{log_level := info,
-                   text_map_propagators := [trace_context, baggage],
-                   sampler := {parent_based, #{root := always_on}}},
+    ?assertMatch(#{create_application_tracers := undefined},
                  otel_configuration:merge_with_os([])),
 
     ?assertMatch(#{log_level := error},
@@ -351,8 +349,7 @@ bad_span_limits(Config) ->
     compare_span_limits(Config).
 
 bad_app_config(_Config) ->
-    ?assertMatch(#{attribute_value_length_limit := infinity},
-                 otel_configuration:merge_with_os([{attribute_value_length_limit, "aaa"}])),
+    ?assertNot(maps:is_key(attribute_value_length_limit, otel_configuration:merge_with_os([{attribute_value_length_limit, "aaa"}]))),
 
     ok.
 
@@ -376,8 +373,7 @@ span_processors(_Config) ->
     ?assertMatch(#{processors := [{otel_simple_processor, #{}}]},
                  otel_configuration:merge_with_os([{span_processor, simple}])),
 
-    ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := {opentelemetry_exporter,#{}},
-                                                           exporting_timeout_ms := 2,
+    ?assertMatch(#{processors := [{otel_batch_processor, #{exporting_timeout_ms := 2,
                                                            max_queue_size := 1,
                                                            scheduled_delay_ms := 15000}}]},
                  otel_configuration:merge_with_os([{span_processor, batch},
@@ -389,10 +385,7 @@ span_processors(_Config) ->
                  otel_configuration:merge_with_os([{span_processor, batch},
                                                    {traces_exporter, none}])),
 
-    ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := {opentelemetry_exporter,#{}},
-                                                           exporting_timeout_ms := 30000,
-                                                           max_queue_size := 2048,
-                                                           scheduled_delay_ms := 5000}}]},
+    ?assertMatch(#{processors := [{otel_batch_processor, #{}}]},
                  otel_configuration:merge_with_os([{span_processor, batch}])),
 
     ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := {opentelemetry_exporter,
@@ -407,8 +400,7 @@ span_processors(_Config) ->
                                                    {bsp_exporting_timeout_ms, 2},
                                                    {bsp_max_queue_size, 1}])),
 
-    ?assertMatch(#{processors := [{otel_simple_processor, #{exporter := {opentelemetry_exporter,#{}},
-                                                            exporting_timeout_ms := 2}}]},
+    ?assertMatch(#{processors := [{otel_simple_processor, #{exporting_timeout_ms := 2}}]},
                  otel_configuration:merge_with_os([{span_processor, simple},
                                                    {ssp_exporting_timeout_ms, 2}])),
 

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -250,21 +250,21 @@ log_level(_Config) ->
 
 propagators(_Config) ->
     ?assertMatch(#{log_level := error,
-                   text_map_propagators := [baggage]},
+                   propagator := #{composite := [baggage]}},
                  otel_configuration:merge_with_os([{log_level, error}])),
 
     ok.
 
 propagators_b3(_Config) ->
     ?assertMatch(#{log_level := error,
-                   text_map_propagators := [b3]},
+                   propagator := #{composite := [b3]}},
                  otel_configuration:merge_with_os([{log_level, error}])),
 
     ok.
 
 propagators_b3multi(_Config) ->
     ?assertMatch(#{log_level := error,
-                   text_map_propagators := [b3multi]},
+                   propagator := #{composite := [b3multi]}},
                  otel_configuration:merge_with_os([{log_level, error}])),
 
     ok.

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -149,8 +149,8 @@ init_per_testcase(span_limits, Config) ->
 
     setup_env(Vars),
 
-    ExpectedOpts = #{attribute_count_limit => 111,
-                     attribute_value_length_limit => 9,
+    ExpectedOpts = #{attribute_limits => #{attribute_count_limit => 111,
+                                           attribute_value_length_limit => 9},
                      event_count_limit => 200,
                      link_count_limit => 1101,
                      attribute_per_event_limit => 400,

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -409,7 +409,9 @@ span_processors(_Config) ->
 
     ?assertMatch(#{tracer_provider :=
                        #{processors := [{batch, #{exporter := {opentelemetry_exporter,
-                                                               #{endpoints := ["https://example.com"]}},
+                                                               #{endpoints := [#{scheme := "https",
+                                                                                 path := "/v1/traces",
+                                                                                 host := "example.com"}]}},
                                                   export_timeout := 2,
                                                   max_queue_size := 1,
                                                   schedule_delay := 15000}}]}},

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -289,10 +289,10 @@ none_exporter(_Config) ->
     ?assertMatch(none,
                  maps:get(traces_exporter, otel_configuration:merge_with_os([]))),
 
-    ?assertMatch(#{processors := [{otel_simple_processor, #{exporter := none}}]},
+    ?assertMatch(#{tracer_provider := #{processors := [{simple, #{exporter := none}}]}},
                  otel_configuration:merge_with_os([{span_processor, simple}])),
 
-    ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := none}}]},
+    ?assertMatch(#{tracer_provider := #{processors := [{batch, #{exporter := none}}]}},
                  otel_configuration:merge_with_os([{span_processor, batch}])),
 
     ok.
@@ -370,37 +370,39 @@ compare_span_limits(Config) ->
     ok.
 
 span_processors(_Config) ->
-    ?assertMatch(#{processors := [{otel_simple_processor, #{}}]},
+    ?assertMatch(#{tracer_provider := #{processors := [{simple, #{}}]}},
                  otel_configuration:merge_with_os([{span_processor, simple}])),
 
-    ?assertMatch(#{processors := [{otel_batch_processor, #{exporting_timeout_ms := 2,
-                                                           max_queue_size := 1,
-                                                           scheduled_delay_ms := 15000}}]},
+    ?assertMatch(#{tracer_provider :=
+                       #{processors := [{batch, #{export_timeout := 2,
+                                                  max_queue_size := 1,
+                                                  schedule_delay := 15000}}]}},
                  otel_configuration:merge_with_os([{span_processor, batch},
                                                    {bsp_scheduled_delay_ms, 15000},
                                                    {bsp_exporting_timeout_ms, 2},
                                                    {bsp_max_queue_size, 1}])),
 
-    ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := none}}]},
+    ?assertMatch(#{tracer_provider := #{processors := [{batch, #{exporter := none}}]}},
                  otel_configuration:merge_with_os([{span_processor, batch},
                                                    {traces_exporter, none}])),
 
-    ?assertMatch(#{processors := [{otel_batch_processor, #{}}]},
+    ?assertMatch(#{tracer_provider := #{processors := [{batch, #{}}]}},
                  otel_configuration:merge_with_os([{span_processor, batch}])),
 
-    ?assertMatch(#{processors := [{otel_batch_processor, #{exporter := {opentelemetry_exporter,
-                                                                        #{endpoints := ["https://example.com"]}},
-                                                           exporting_timeout_ms := 2,
-                                                           max_queue_size := 1,
-                                                           scheduled_delay_ms := 15000}}]},
-                 otel_configuration:merge_with_os([{processors, [{otel_batch_processor, #{exporter => {opentelemetry_exporter,#{endpoints => ["https://example.com"]}},
-                                                                                          scheduled_delay_ms => 15000,
+    ?assertMatch(#{tracer_provider :=
+                       #{processors := [{batch, #{exporter := {opentelemetry_exporter,
+                                                               #{endpoints := ["https://example.com"]}},
+                                                  export_timeout := 2,
+                                                  max_queue_size := 1,
+                                                  schedule_delay := 15000}}]}},
+                 otel_configuration:merge_with_os([{processors, [{otel_batch_processor, #{exporter => {opentelemetry_exporter, #{endpoints => ["https://example.com"]}},
+                                                                                          schedule_delay => 15000,
                                                                                           max_queue_size => 4,
-                                                                                          exporting_timeout_ms => 3}}]},
+                                                                                          export_timeout => 3}}]},
                                                    {bsp_exporting_timeout_ms, 2},
                                                    {bsp_max_queue_size, 1}])),
 
-    ?assertMatch(#{processors := [{otel_simple_processor, #{exporting_timeout_ms := 2}}]},
+    ?assertMatch(#{tracer_provider := #{processors := [{simple, #{export_timeout := 2}}]}},
                  otel_configuration:merge_with_os([{span_processor, simple},
                                                    {ssp_exporting_timeout_ms, 2}])),
 

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -370,8 +370,14 @@ compare_span_limits(Config) ->
     ok.
 
 span_processors(_Config) ->
-    ?assertMatch(#{tracer_provider := #{processors := [{simple, #{}}]}},
-                 otel_configuration:merge_with_os([{span_processor, simple}])),
+    ?assertMatch(#{tracer_provider := #{processors := [{simple, #{}}],
+                                        limits := #{attribute_value_length_limit := 10,
+                                                    event_attribute_count_limit := 400,
+                                                    event_count_limit := 20}}},
+                 otel_configuration:merge_with_os([{span_processor, simple},
+                                                   {attribute_value_length_limit, 10},
+                                                   {attribute_per_event_limit, 400},
+                                                   {event_count_limit, 20}])),
 
     ?assertMatch(#{tracer_provider :=
                        #{processors := [{batch, #{export_timeout := 2,

--- a/apps/opentelemetry/test/otel_file_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_file_configuration_SUITE.erl
@@ -1,0 +1,55 @@
+-module(otel_file_configuration_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    [parse_test, app_env_test, os_env_test].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+parse_test(Config) ->
+    DataDir = ?config(data_dir, Config),
+    JsonFile = filename:join(DataDir, "out.json"),
+
+    Json = otel_file_configuration:parse_file(JsonFile),
+
+    ?assertMatch(#{disabled := false}, Json).
+
+app_env_test(Config) ->
+    try
+        DataDir = ?config(data_dir, Config),
+        JsonFile = filename:join(DataDir, "out.json"),
+
+        application:load(opentelemetry),
+        application:set_env(opentelemetry, config_file, JsonFile),
+
+        {ok, _} = application:ensure_all_started(opentelemetry)
+
+    after
+        application:unset_env(opentelemetry, config_file),
+        application:stop(opentelemetry)
+    end,
+
+    ok.
+
+os_env_test(Config) ->
+    try
+        DataDir = ?config(data_dir, Config),
+        JsonFile = filename:join(DataDir, "out.json"),
+
+        os:putenv("OTEL_EXPERIMENTAL_CONFIG_FILE", JsonFile),
+
+        {ok, _} = application:ensure_all_started(opentelemetry)
+    after
+        os:unsetenv("OTEL_EXPERIMENTAL_CONFIG_FILE"),
+        application:stop(opentelemetry)
+    end,
+
+    ok.

--- a/apps/opentelemetry_api/include/opentelemetry.hrl
+++ b/apps/opentelemetry_api/include/opentelemetry.hrl
@@ -18,6 +18,8 @@
 -define(REG_NAME(Name), list_to_atom(lists:concat([?MODULE, "_", Name]))).
 -define(GLOBAL_TRACER_PROVIDER_NAME, global).
 -define(GLOBAL_TRACER_PROVIDER_REG_NAME, otel_tracer_provider_global).
+-define(GLOBAL_CONFIG_PROVIDER_NAME, global).
+-define(GLOBAL_CONFIG_PROVIDER_REG_NAME, otel_config_provider_global).
 
 %% These records are based on protos found in the opentelemetry-proto repo:
 %% src/opentelemetry/proto/trace/v1/trace.proto

--- a/apps/opentelemetry_exporter/src/otel_exporter_otlp.erl
+++ b/apps/opentelemetry_exporter/src/otel_exporter_otlp.erl
@@ -52,7 +52,8 @@
 -type opts() :: #{endpoints => [endpoint()],
                   headers => headers(),
                   protocol => protocol(),
-                  ssl_options => list()}.
+                  ssl_options => list(),
+                  insecure => boolean()}.
 
 -export_type([opts/0,
               headers/0,

--- a/apps/opentelemetry_exporter/src/otel_exporter_traces_otlp.erl
+++ b/apps/opentelemetry_exporter/src/otel_exporter_traces_otlp.erl
@@ -119,8 +119,7 @@
 %% @doc Initialize the exporter based on the provided configuration.
 -spec init(otel_exporter_otlp:opts()) -> {ok, #state{}}.
 init(Opts) ->
-    Opts1 = merge_with_environment(Opts),
-    case otel_exporter_otlp:init(Opts1) of
+    case otel_exporter_otlp:init(Opts) of
         {ok, #{channel := Channel,
                channel_pid := ChannelPid,
                endpoints := Endpoints,

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -373,14 +373,16 @@ verify_export(Config) ->
                http_protobuf ->
                    4318
            end,
-    {ok, State} = opentelemetry_exporter:init(#{protocol => Protocol,
-                                                compression => Compression,
-                                                endpoints => [{http, "localhost", Port, []}]}),
+    ExporterOpts = otel_exporter_traces_otlp:merge_with_environment(#{protocol => Protocol,
+                                                                      compression => Compression,
+                                                                      endpoints => [{http, "localhost", Port, []}]}),
+    {ok, State} = opentelemetry_exporter:init(ExporterOpts),
 
+    ExporterOpts1 = otel_exporter_traces_otlp:merge_with_environment(#{protocol => Protocol,
+                                                                       compression => Compression,
+                                                                       endpoints => [{http, "localhost", Port, []}]}),
     %% regression test. adding the httpc profile meant that init'ing more than once would crash
-    {ok, _State} = opentelemetry_exporter:init(#{protocol => Protocol,
-                                                compression => Compression,
-                                                endpoints => [{http, "localhost", Port, []}]}),
+    {ok, _State} = opentelemetry_exporter:init(ExporterOpts1),
 
     Tid = ets:new(span_tab, [duplicate_bag, {keypos, #span.instrumentation_scope}]),
 

--- a/config/sdk-config.yaml
+++ b/config/sdk-config.yaml
@@ -1,0 +1,270 @@
+# sdk-config.yaml is a typical starting point for configuring the SDK, including exporting to
+# localhost via OTLP.
+
+# NOTE: With the exception of env var substitution syntax (i.e. ${MY_ENV}), SDKs ignore
+# environment variables when interpreting config files. This including ignoring all env
+# vars defined in https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/.
+
+# The file format version.
+# The yaml format is documented at
+# https://github.com/open-telemetry/opentelemetry-configuration/tree/main/schema
+file_format: "1.0-rc.1"
+# Configure if the SDK is disabled or not.
+# If omitted or null, false is used.
+disabled: false
+# Configure the log level of the internal logger used by the SDK.
+# If omitted, info is used.
+log_level: info
+# Configure resource for all signals.
+# If omitted, the default resource is used.
+resource:
+  # Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.
+  # Entries must contain .name and .value, and may optionally include .type. If an entry's .type omitted or null, string is used.
+  # The .value's type must match the .type. Values for .type include: string, bool, int, double, string_array, bool_array, int_array, double_array.
+  attributes:
+    - name: service.name
+      value: unknown_service
+# Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
+attribute_limits:
+  # Configure max attribute value size. 
+  # Value must be non-negative.
+  # If omitted or null, there is no limit.
+  attribute_value_length_limit:
+  # Configure max attribute count. 
+  # Value must be non-negative.
+  # If omitted or null, 128 is used.
+  attribute_count_limit: 128
+# Configure text map context propagators.
+# If omitted, a noop propagator is used.
+propagator:
+  # Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.
+  # Built-in propagator keys include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party keys include: xray. 
+  # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
+  composite:
+    - # Include the w3c trace context propagator.
+      tracecontext:
+    - # Include the w3c baggage propagator.
+      baggage:
+# Configure tracer provider.
+# If omitted, a noop tracer provider is used.
+tracer_provider:
+  # Configure span processors.
+  processors:
+    - # Configure a batch span processor.
+      batch:
+        # Configure delay interval (in milliseconds) between two consecutive exports. 
+        # Value must be non-negative.
+        # If omitted or null, 5000 is used.
+        schedule_delay: 5000
+        # Configure maximum allowed time (in milliseconds) to export data. 
+        # Value must be non-negative. A value of 0 indicates no limit (infinity).
+        # If omitted or null, 30000 is used.
+        export_timeout: 30000
+        # Configure maximum queue size. Value must be positive.
+        # If omitted or null, 2048 is used.
+        max_queue_size: 2048
+        # Configure maximum batch size. Value must be positive.
+        # If omitted or null, 512 is used.
+        max_export_batch_size: 512
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the trace specific path.
+            # If omitted or null, http://localhost:4318/v1/traces is used.
+            endpoint: http://localhost:4318/v1/traces
+            # Configure certificate used to verify a server's TLS credentials. 
+            # Absolute path to certificate file in PEM format.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate_file:
+            # Configure mTLS private client key. 
+            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key_file:
+            # Configure mTLS client certificate. 
+            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate_file:
+            # Configure compression.
+            # Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates no limit (infinity).
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers: []
+  # Configure span limits. See also attribute_limits.
+  limits:
+    # Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. 
+    # Value must be non-negative.
+    # If omitted or null, there is no limit.
+    attribute_value_length_limit:
+    # Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    attribute_count_limit: 128
+    # Configure max span event count. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    event_count_limit: 128
+    # Configure max span link count. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    link_count_limit: 128
+    # Configure max attributes per span event. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    event_attribute_count_limit: 128
+    # Configure max attributes per span link. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    link_attribute_count_limit: 128
+  # Configure the sampler.
+  # If omitted, parent based sampler with a root of always_on is used.
+  sampler:
+    # Configure sampler to be parent_based.
+    parent_based:
+      # Configure root sampler.
+      # If omitted or null, always_on is used.
+      root:
+        # Configure sampler to be always_on.
+        always_on:
+      # Configure remote_parent_sampled sampler.
+      # If omitted or null, always_on is used.
+      remote_parent_sampled:
+        # Configure sampler to be always_on.
+        always_on:
+      # Configure remote_parent_not_sampled sampler.
+      # If omitted or null, always_off is used.
+      remote_parent_not_sampled:
+        # Configure sampler to be always_off.
+        always_off:
+      # Configure local_parent_sampled sampler.
+      # If omitted or null, always_on is used.
+      local_parent_sampled:
+        # Configure sampler to be always_on.
+        always_on:
+      # Configure local_parent_not_sampled sampler.
+      # If omitted or null, always_off is used.
+      local_parent_not_sampled:
+        # Configure sampler to be always_off.
+        always_off:
+# Configure meter provider.
+# If omitted, a noop meter provider is used.
+meter_provider:
+  # Configure metric readers.
+  readers:
+    - # Configure a periodic metric reader.
+      periodic:
+        # Configure delay interval (in milliseconds) between start of two consecutive exports. 
+        # Value must be non-negative.
+        # If omitted or null, 60000 is used.
+        interval: 60000
+        # Configure maximum allowed time (in milliseconds) to export data. 
+        # Value must be non-negative. A value of 0 indicates no limit (infinity).
+        # If omitted or null, 30000 is used.
+        timeout: 30000
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the metric specific path.
+            # If omitted or null, http://localhost:4318/v1/metrics is used.
+            endpoint: http://localhost:4318/v1/metrics
+            # Configure certificate used to verify a server's TLS credentials. 
+            # Absolute path to certificate file in PEM format.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate_file:
+            # Configure mTLS private client key. 
+            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key_file:
+            # Configure mTLS client certificate. 
+            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate_file:
+            # Configure compression.
+            # Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates no limit (infinity).
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers: []
+            # Configure temporality preference. 
+            # Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, cumulative is used.
+            temporality_preference: cumulative
+            # Configure default histogram aggregation. 
+            # Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, explicit_bucket_histogram is used.
+            default_histogram_aggregation: explicit_bucket_histogram
+  # Configure the exemplar filter. 
+  # Values include: trace_based, always_on, always_off. For behavior of values see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#metrics-sdk-configuration.
+  # If omitted or null, trace_based is used.
+  exemplar_filter: trace_based
+# Configure logger provider.
+# If omitted, a noop logger provider is used.
+logger_provider:
+  # Configure log record processors.
+  processors:
+    - # Configure a batch log record processor.
+      batch:
+        # Configure delay interval (in milliseconds) between two consecutive exports. 
+        # Value must be non-negative.
+        # If omitted or null, 1000 is used.
+        schedule_delay: 1000
+        # Configure maximum allowed time (in milliseconds) to export data. 
+        # Value must be non-negative. A value of 0 indicates no limit (infinity).
+        # If omitted or null, 30000 is used.
+        export_timeout: 30000
+        # Configure maximum queue size. Value must be positive.
+        # If omitted or null, 2048 is used.
+        max_queue_size: 2048
+        # Configure maximum batch size. Value must be positive.
+        # If omitted or null, 512 is used.
+        max_export_batch_size: 512
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            endpoint: http://localhost:4318/v1/logs
+            # Configure certificate used to verify a server's TLS credentials. 
+            # Absolute path to certificate file in PEM format.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate_file:
+            # Configure mTLS private client key. 
+            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key_file:
+            # Configure mTLS client certificate. 
+            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate_file:
+            # Configure compression.
+            # Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates no limit (infinity).
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers: []
+  # Configure log record limits. See also attribute_limits.
+  limits:
+    # Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. 
+    # Value must be non-negative.
+    # If omitted or null, there is no limit.
+    attribute_value_length_limit:
+    # Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    attribute_count_limit: 128

--- a/config/sdk.config
+++ b/config/sdk.config
@@ -1,0 +1,105 @@
+[
+ {file_format, "1.0-rc.1"},
+ {disabled, false},
+ {log_level, info},
+ {resource, [
+             {attributes, [
+                           #{name => <<"service.name">>, value => <<"unknown_service">>}
+                          ]}
+            ]},
+ {attribute_limits, [
+                     {attribute_value_length_limit, undefined},
+                     {attribute_count_limit, 128}
+                    ]},
+ {propagator, [
+               {composite, [tracecontext, baggage]}
+              ]},
+
+ {tracer_provider, [
+                    {processors, [
+                                  {batch, [
+                                           {schedule_delay, 5000},
+                                           {export_timeout, 30000},
+                                           {max_queue_size, 2048},
+                                           {max_export_batch_size, 512},
+                                           {exporter, [
+                                                       {otlp_http, [
+                                                                    {endpoint, "http://localhost:4318/v1/traces"},
+                                                                    {certificate_file, undefined},
+                                                                    {client_key_file, undefined},
+                                                                    {client_certificate_file, undefined},
+                                                                    {compression, gzip},
+                                                                    {timeout, 10000},
+                                                                    {headers, []}
+                                                                   ]}
+                                                      ]}
+                                          ]}
+                                 ]},
+                    {limits, [
+                              {attribute_value_length_limit, undefined},
+                              {attribute_count_limit, 128},
+                              {event_count_limit, 128},
+                              {link_count_limit, 128},
+                              {event_attribute_count_limit, 128},
+                              {link_attribute_count_limit, 128}
+                             ]},
+                    {sampler, [
+                               {parent_based, [
+                                               {root, always_on},
+                                               {remote_parent_sampled, always_on},
+                                               {remote_parent_not_sampled, always_off},
+                                               {local_parent_sampled, always_on},
+                                               {local_parent_not_sampled, always_off}
+                                              ]}
+                              ]}
+                   ]},
+
+ {meter_provider, [
+                   {readers, [
+                              {periodic, [
+                                          {interval, 60000},
+                                          {timeout, 30000},
+                                          {exporter, [
+                                                      {otlp_http, [
+                                                                   {endpoint, "http://localhost:4318/v1/metrics"},
+                                                                   {certificate_file, undefined},
+                                                                   {client_key_file, undefined},
+                                                                   {client_certificate_file, undefined},
+                                                                   {compression, gzip},
+                                                                   {timeout, 10000},
+                                                                   {headers, []},
+                                                                   {temporality_preference, cumulative},
+                                                                   {default_histogram_aggregation, explicit_bucket_histogram}
+                                                                  ]}
+                                                     ]}
+                                         ]}
+                             ]},
+                   {exemplar_filter, trace_based}
+                  ]},
+
+ {logger_provider, [
+                    {processors, [
+                                  {batch, [
+                                           {schedule_delay, 1000},
+                                           {export_timeout, 30000},
+                                           {max_queue_size, 2048},
+                                           {max_export_batch_size, 512},
+                                           {exporter, [
+                                                       {otlp_http, [
+                                                                    {endpoint, "http://localhost:4318/v1/logs"},
+                                                                    {certificate_file, undefined},
+                                                                    {client_key_file, undefined},
+                                                                    {client_certificate_file, undefined},
+                                                                    {compression, gzip},
+                                                                    {timeout, 10000},
+                                                                    {headers, []}
+                                                                   ]}
+                                                      ]}
+                                          ]}
+                                 ]},
+                    {limits, [
+                              {attribute_value_length_limit, undefined},
+                              {attribute_count_limit, 128}
+                             ]}
+                   ]}
+].

--- a/config/sdk.config
+++ b/config/sdk.config
@@ -2,18 +2,14 @@
  {file_format, "1.0-rc.1"},
  {disabled, false},
  {log_level, info},
- {resource, [
-             {attributes, [
+ {resource, #{attributes, [
                            #{name => <<"service.name">>, value => <<"unknown_service">>}
-                          ]}
-            ]},
- {attribute_limits, [
-                     {attribute_value_length_limit, undefined},
-                     {attribute_count_limit, 128}
-                    ]},
- {propagator, [
-               {composite, [tracecontext, baggage]}
-              ]},
+                          ]}},
+ {attribute_limits, #{attribute_value_length_limit => undefined,
+                      attribute_count_limit => 128}},
+
+ {propagator, #{composite => [tracecontext, baggage],
+                composite_list => ""},
 
  {tracer_provider, [
                     {processors, [

--- a/config/sdk.config
+++ b/config/sdk.config
@@ -2,9 +2,9 @@
  {file_format, "1.0-rc.1"},
  {disabled, false},
  {log_level, info},
- {resource, #{attributes, [
-                           #{name => <<"service.name">>, value => <<"unknown_service">>}
-                          ]}},
+ {resource, #{attributes => [
+                             #{name => <<"service.name">>, value => <<"unknown_service">>}
+                            ]}},
  {attribute_limits, #{attribute_value_length_limit => undefined,
                       attribute_count_limit => 128}},
 


### PR DESCRIPTION
I can't figure out a good way to do this change. This is a mess. The issue is we already have file configuration, and worse, it is used layers deep (as in, things like span processors are passed configuration that is passed to tracer provider).

In this PR I have changed those components like span processor to work on structure similar to those in the otel declarative configuration. This isn't required but I felt that structure was better so wanted to use it. This means anyone calling those directory would have broken code. I could, and may, change it to convert the new config to match the old layout instead.

Previous configs people have are meant to continue working as this change will convert those to the new format. The issue there is we have to make a choice between which config we are using. So what it does is check if a key from the new config, like `tracer_provider` is found and then assumes new config and ignores the old config values.

As I said, a mess.

I'm opening this less to merge and more to discuss strategy.