### PR TITLE
[Feature]: Add is_remote flag in exporter for spans and span links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **SDK**: Add span flags support for `isRemote` property in OTLP exporter
-  - Added `parent_span_is_remote` field to span record to store parent span context remote status
-  - Updated span creation logic to capture parent span's `is_remote` flag
-  - Implemented `build_span_flags` function that sets OTLP span flags based on parent span's `isRemote` property
-  - Updated span and link transformations to properly set flags field (0x100 for local, 0x300 for remote)
-  - Added comprehensive tests for span flags functionality
-
-- **OTLP Exporter**: Add span flags support for `isRemote` property
-  - Implemented `build_span_flags` function that sets OTLP span flags based on parent span's `isRemote` property
-  - Updated span and link transformations to properly set flags field (0x100 for local, 0x300 for remote)
-  - Added comprehensive tests for span flags functionality
+- [Add is_remote flag in exporter for spans and span links](https://github.com/open-telemetry/opentelemetry-erlang/pull/894)
 
 ## API 1.4.1 - 2025-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **SDK**: Add span flags support for `isRemote` property in OTLP exporter
+  - Added `parent_span_is_remote` field to span record to store parent span context remote status
+  - Updated span creation logic to capture parent span's `is_remote` flag
+  - Implemented `build_span_flags` function that sets OTLP span flags based on parent span's `isRemote` property
+  - Updated span and link transformations to properly set flags field (0x100 for local, 0x300 for remote)
+  - Added comprehensive tests for span flags functionality
+
+- **OTLP Exporter**: Add span flags support for `isRemote` property
+  - Implemented `build_span_flags` function that sets OTLP span flags based on parent span's `isRemote` property
+  - Updated span and link transformations to properly set flags field (0x100 for local, 0x300 for remote)
+  - Added comprehensive tests for span flags functionality
+
 ## API 1.4.1 - 2025-07-31
 
 ### Fixes

--- a/apps/opentelemetry/include/otel_span.hrl
+++ b/apps/opentelemetry/include/otel_span.hrl
@@ -28,6 +28,9 @@
           %% 64 bit int parent span
           parent_span_id          :: opentelemetry:span_id() | undefined | '_',
 
+          %% true if the parent span context came from a remote process
+          parent_span_is_remote   :: boolean() | undefined | '_',
+
           %% name of the span
           name                    :: unicode:unicode_binary() | atom() | '_',
 

--- a/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
+++ b/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
@@ -99,9 +99,13 @@ shutdown(_) ->
 %% helpers
 
 generate_span() ->
+    StartTime = opentelemetry:timestamp(),
+    EndTime = opentelemetry:timestamp(),
     #span{trace_id = otel_id_generator:generate_trace_id(),
           span_id = otel_id_generator:generate_span_id(),
           name = "test_span",
+          start_time = StartTime,
+          end_time = EndTime,
           trace_flags = 1,
           is_recording = true,
           parent_span_is_remote = undefined,

--- a/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
+++ b/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
@@ -104,4 +104,5 @@ generate_span() ->
           name = "test_span",
           trace_flags = 1,
           is_recording = true,
+          parent_span_is_remote = undefined,
           instrumentation_scope = #instrumentation_scope{name = "test"}}.

--- a/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
+++ b/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
@@ -109,4 +109,8 @@ generate_span() ->
           trace_flags = 1,
           is_recording = true,
           parent_span_is_remote = undefined,
+          attributes = otel_attributes:new([], 128, 128),
+          events = otel_events:new(128, 128, 128),
+          links = otel_links:new([], 128, 128, 128),
+          tracestate = otel_tracestate:new([]),
           instrumentation_scope = #instrumentation_scope{name = "test"}}.

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -348,6 +348,8 @@ span_flags(_Config) ->
     TraceId = otel_id_generator:generate_trace_id(),
     SpanId = otel_id_generator:generate_span_id(),
     ParentSpanId = otel_id_generator:generate_span_id(),
+    StartTime = opentelemetry:timestamp(),
+    EndTime = opentelemetry:timestamp(),
     
     LocalParentSpan = #span{name = <<"span-with-local-parent">>,
                            trace_id = TraceId,
@@ -355,6 +357,8 @@ span_flags(_Config) ->
                            parent_span_id = ParentSpanId,
                            parent_span_is_remote = false,
                            kind = ?SPAN_KIND_CLIENT,
+                           start_time = StartTime,
+                           end_time = EndTime,
                            trace_flags = 1,
                            is_recording = true},
     
@@ -368,6 +372,8 @@ span_flags(_Config) ->
                             parent_span_id = ParentSpanId,
                             parent_span_is_remote = true,
                             kind = ?SPAN_KIND_CLIENT,
+                            start_time = StartTime,
+                            end_time = EndTime,
                             trace_flags = 1,
                             is_recording = true},
     
@@ -381,6 +387,8 @@ span_flags(_Config) ->
                         parent_span_id = undefined,
                         parent_span_is_remote = undefined,
                         kind = ?SPAN_KIND_CLIENT,
+                        start_time = StartTime,
+                        end_time = EndTime,
                         trace_flags = 1,
                         is_recording = true},
     

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -360,7 +360,11 @@ span_flags(_Config) ->
                            start_time = StartTime,
                            end_time = EndTime,
                            trace_flags = 1,
-                           is_recording = true},
+                           is_recording = true,
+                           attributes = otel_attributes:new([], 128, 128),
+                           events = otel_events:new(128, 128, 128),
+                           links = otel_links:new([], 128, 128, 128),
+                           tracestate = otel_tracestate:new([])},
     
     PbSpanLocal = otel_otlp_traces:to_proto(LocalParentSpan),
     ?assertEqual(16#101, maps:get(flags, PbSpanLocal)), %% 0x101 - local parent with sampled flag
@@ -375,7 +379,11 @@ span_flags(_Config) ->
                             start_time = StartTime,
                             end_time = EndTime,
                             trace_flags = 1,
-                            is_recording = true},
+                            is_recording = true,
+                            attributes = otel_attributes:new([], 128, 128),
+                            events = otel_events:new(128, 128, 128),
+                            links = otel_links:new([], 128, 128, 128),
+                            tracestate = otel_tracestate:new([])},
     
     PbSpanRemote = otel_otlp_traces:to_proto(RemoteParentSpan),
     ?assertEqual(16#301, maps:get(flags, PbSpanRemote)), %% 0x301 - remote parent with sampled flag
@@ -390,7 +398,11 @@ span_flags(_Config) ->
                         start_time = StartTime,
                         end_time = EndTime,
                         trace_flags = 1,
-                        is_recording = true},
+                        is_recording = true,
+                        attributes = otel_attributes:new([], 128, 128),
+                        events = otel_events:new(128, 128, 128),
+                        links = otel_links:new([], 128, 128, 128),
+                        tracestate = otel_tracestate:new([])},
     
     PbSpanNoParent = otel_otlp_traces:to_proto(NoParentSpan),
     ?assertEqual(16#101, maps:get(flags, PbSpanNoParent)), %% 0x101 - no parent with sampled flag

--- a/apps/opentelemetry_zipkin/test/opentelemetry_zipkin_SUITE.erl
+++ b/apps/opentelemetry_zipkin/test/opentelemetry_zipkin_SUITE.erl
@@ -46,7 +46,8 @@ verify_export(_Config) ->
                                                 {<<"map-key-1">>, #{<<"map-key-1">> => 123}},
                                                 {<<"list-key-1">>, [3.14, 9.345]}
                                                 ], 128, 128),
-              status=opentelemetry:status(?SPAN_KIND_INTERNAL, <<"some message about status">>)},
+              status=opentelemetry:status(?SPAN_KIND_INTERNAL, <<"some message about status">>),
+              parent_span_is_remote = undefined},
     true = ets:insert(Tid, ParentSpan),
 
     ChildSpan = #span{name = <<"span-2">>,
@@ -66,7 +67,8 @@ verify_export(_Config) ->
                                                         {attr_3, true},
                                                         {<<"map-key-1">>, #{<<"map-key-1">> => 123}},
                                                         {<<"list-key-1">>, [3.14, 9.345]}
-                                                       ], 128, 128)},
+                                                       ], 128, 128),
+                      parent_span_is_remote = false},
     true = ets:insert(Tid, ChildSpan),
 
     ?assertMatch(ok, opentelemetry_zipkin:export(traces, Tid, Resource, State)),


### PR DESCRIPTION
After updating protobuf schema, we can set the is_remote_parent flag when exporting spans and span links with OTLP.

Closes #893

Describe the solution you'd like:
Update OTLP exporter to fill the relevant bits in SpanFlags.

Considered Alternatives
None

Additional Context
Example:
Proto schema PR: https://github.com/open-telemetry/opentelemetry-proto/pull/484
Go implementation: https://github.com/open-telemetry/opentelemetry-go/pull/5194/files
Python implementation: https://github.com/open-telemetry/opentelemetry-python/pull/3881/files