### PR TITLE
fix: otp28 removes the ability to cache compiled regex in macros

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "26.2.5.6", "25.3.2.16"]
+        otp_version: ["28.1", "27.2", "26.2.5.6"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
     env:
@@ -91,7 +91,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2"]
+        otp_version: ["28.1"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
     steps:
@@ -119,7 +119,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2"]
+        otp_version: ["28.1"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
     steps:
@@ -152,7 +152,7 @@ jobs:
     name: Test SemConv on (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "25.3.2.16"]
+        otp_version: ["28.1", "26.2.5.6"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
     defaults:


### PR DESCRIPTION
the compiled regex is stored in a persistent term to not have to recompile on each tracestate creation or addition. Use of pterm also removes the need to pass the regexes around as either part of tracestate record or in the tracer.

Resolves #902 