### PR TITLE
fix(warning): prevents tls_certificate_check throwing application_either_not_started_or_not_ready

### DIFF
--- a/apps/opentelemetry_exporter/src/otel_exporter_otlp.erl
+++ b/apps/opentelemetry_exporter/src/otel_exporter_otlp.erl
@@ -326,6 +326,7 @@ maybe_add_scheme_port(Uri) ->
 
 %% if no ssl opts are defined by the user then use defaults from `tls_certificate_check'
 update_ssl_opts(Host, undefined) ->
+    {ok, _} = application:ensure_all_started(tls_certificate_check),
     tls_certificate_check:options(Host);
 update_ssl_opts(_, SSLOptions) ->
     SSLOptions.


### PR DESCRIPTION
Attempt to fix
- https://github.com/open-telemetry/opentelemetry-erlang/issues/419
- https://github.com/open-telemetry/opentelemetry-erlang/issues/532
- https://github.com/open-telemetry/opentelemetry-erlang/issues/545#issuecomment-1423357872

without the need for the user to manually change the order of applications.