### PR TITLE
ci(labeler): updates .config/labeler.yml to v6 syntax

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,20 +1,32 @@
 language-elixir:
-  - apps/**/*.ex
-  - apps/**/*.exs
+  - changed-files:
+    - any-glob-to-any-file:
+      - apps/**/*.ex
+      - apps/**/*.exs
 
 language-erlang:
-  - apps/**/*.erl
-  - apps/**/*.hrl
-  - apps/**/rebar.config
+  - changed-files:
+    - any-glob-to-any-file:
+      - apps/**/*.erl
+      - apps/**/*.hrl
+      - apps/**/rebar.config
 
 scope-api:
-  - apps/opentelemetry_api/**
+  - changed-files:
+    - any-glob-to-any-file:
+      - apps/opentelemetry_api/**
 
 scope-sdk:
-  - apps/opentelemetry/**
+  - changed-files:
+    - any-glob-to-any-file:
+      - apps/opentelemetry/**
 
 scope-semconv:
-  - apps/opentelemetry_semantic_conventions/**
+  - changed-files:
+    - any-glob-to-any-file:
+      - apps/opentelemetry_semantic_conventions/**
 
 scope-ci:
-  - .github/workflows/**
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/workflows/**


### PR DESCRIPTION
Seems that "Pull Request Labeler" is failing on all recent pull requests.

The reason seems to be that:
- `actions/labeler` was updated from v4 to v6 a few days ago (https://github.com/open-telemetry/opentelemetry-erlang/pull/898)
- There were necessary changes in `.config/labeler.yml` to upgrade successfully (https://github.com/actions/labeler?tab=readme-ov-file#breaking-changes-in-v5)
- BUT the build didn't fail because of the limitation of `on: [pull_request_target]` as described in https://github.com/actions/labeler?tab=readme-ov-file#notes-regarding-pull_request_target-event