### PR TITLE
chore: make commitlint failure not block merging

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,6 +9,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     name: Conventional Commitlint
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
this is necessary since I can't force a merge anymore and commits from renovate at times have commit messages longer than commitlint allows