### PR TITLE
fix: parse without string trim if at all possible

### DIFF
--- a/apps/opentelemetry_api/src/otel_propagator_trace_context.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_trace_context.erl
@@ -86,7 +86,7 @@ extract(Ctx, Carrier, _CarrierKeysFun, CarrierGet, _Options) ->
         undefined ->
             Ctx;
         SpanCtxString ->
-            case decode(string:trim(SpanCtxString)) of
+            case decode(SpanCtxString) of
                 undefined ->
                     Ctx;
                 SpanCtx ->
@@ -112,20 +112,29 @@ encode_traceparent(TraceId, SpanId, TraceOptions) ->
     otel_utils:assert_to_binary([?VERSION, "-", EncodedTraceId, "-",
                                  EncodedSpanId, "-", Options]).
 
+decode(SpanCtxString) ->
+    % Parse without the string trim first to avoid its cost
+    case decode_(SpanCtxString) of
+        undefined ->
+            decode_(string:trim(SpanCtxString));
+        SpanCtx ->
+            SpanCtx
+    end.
+
 %% note: version ff (255) not allowed by spec
-decode(TraceContext) when is_list(TraceContext) ->
-    decode(list_to_binary(TraceContext));
-decode(<<_:2/binary, "-", TraceId:32/binary, "-", SpanId:16/binary, _/binary>>)
+decode_(TraceContext) when is_list(TraceContext) ->
+    decode_(list_to_binary(TraceContext));
+decode_(<<_:2/binary, "-", TraceId:32/binary, "-", SpanId:16/binary, _/binary>>)
   when TraceId =:= ?ZERO_TRACEID orelse SpanId =:= ?ZERO_SPANID ->
     undefined;
-decode(<<Version:2/binary, "-", TraceId:32/binary, "-", SpanId:16/binary, "-", Opts:2/binary>>)
+decode_(<<Version:2/binary, "-", TraceId:32/binary, "-", SpanId:16/binary, "-", Opts:2/binary>>)
   when Version >= ?VERSION andalso Version =/= <<"ff">> ->
     to_span_ctx(Version, TraceId, SpanId, Opts);
 %% future versions could have more after Opts, so allow for a trailing -
-decode(<<Version:2/binary, "-", TraceId:32/binary, "-", SpanId:16/binary, "-", Opts:2/binary, "-", _/binary>>)
+decode_(<<Version:2/binary, "-", TraceId:32/binary, "-", SpanId:16/binary, "-", Opts:2/binary, "-", _/binary>>)
   when Version > ?VERSION andalso Version =/= <<"ff">> ->
     to_span_ctx(Version, TraceId, SpanId, Opts);
-decode(_) ->
+decode_(_) ->
     undefined.
 
 to_span_ctx(Version, TraceId, SpanId, Opts) ->


### PR DESCRIPTION
In production, I've observed that `string:trim`s take a significant amount of time when parsing textmap contexts. This is technically required to pass [the interop tests](https://github.com/w3c/trace-context/blob/34b10ac5af7f0caeb28efe35fe51cd4763ec5771/test/test.py#L407), but is an uncommon case, so given the perf gains, we might as well optimize for the common one.

Before
```
Operating System: Linux
CPU Information: AMD Ryzen 9 9900X 12-Core Processor
Number of Available Cores: 24
Available memory: 60.43 GB
Elixir 1.18.4
Erlang 28.1
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 7 s
Excluding outliers: false

Benchmarking decode ...
Calculating statistics...
Formatting results...

Name             ips        average  deviation         median         99th %
decode      362.29 K        2.76 μs   ±238.77%        2.61 μs        3.77 μs
```

After
```
Operating System: Linux
CPU Information: AMD Ryzen 9 9900X 12-Core Processor
Number of Available Cores: 24
Available memory: 60.43 GB
Elixir 1.18.4
Erlang 28.1
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 7 s
Excluding outliers: false

Benchmarking decode ...
Calculating statistics...
Formatting results...

Name             ips        average  deviation         median         99th %
decode      846.24 K        1.18 μs   ±502.24%        1.04 μs        1.83 μs
```