### PR TITLE
fix(exporter): encode log record body as string instead of int array

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
+++ b/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
@@ -77,7 +77,7 @@ log_record(#{level := Level,
                             lists:reverse(
                               trim(S, false)), true)),
                     re:replace(T,",?\r?\n\s*",", ",
-                               [{return,list}, global, unicode]);
+                               [{return,binary}, global, unicode]);
                 M ->
                     M
             end,


### PR DESCRIPTION
## Description

Currently, log record bodies are encoded as integer arrays before exporting. This causes downstream log backends to render the logs as raw byte lists rather than human-readable text strings.
e.g.,
<img width="317" height="18" alt="image" src="https://github.com/user-attachments/assets/a0659740-bde8-4c2e-bc85-7774463e7a5e" />

This change switches the regex replacement to use `{return, binary}`, ensuring the exporter generates a `string_value`.

### Root cause
As seen in the shell output below, `otel_otlp_common:to_any_value/1` converts a list string into an `array_value` of integers, while a binary becomes a `string_value`.
```erl
Erlang/OTP 28 [erts-16.1.1] [source] [64-bit] [smp:22:22] [ds:22:22:10] [async-threads:1] [jit:ns]

Eshell V16.1.1 (press Ctrl+G to abort, type help(). for help)
1> otel_otlp_common:to_any_value("test").
#{value =>
      {array_value,#{values =>
                         [#{value => {int_value,116}},
                          #{value => {int_value,101}},
                          #{value => {int_value,115}},
                          #{value => {int_value,116}}]}}}
2> otel_otlp_common:to_any_value(<<"test">>).
#{value => {string_value,<<"test">>}}
```