### PR TITLE
Fix hex-encoded trace/span IDs in logs OTLP exporter

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
+++ b/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
@@ -89,23 +89,24 @@ log_record(#{level := Level,
     DroppedAttributesCount = maps:size(Attributes) - length(Attributes1),
     Flags = 0,
 
-    %% Note: otel_trace_id and otel_span_id from hex_span_ctx are now binaries, not charlists.
+    %% otel_trace_id and otel_span_id from hex_span_ctx are 32/16-char hex binaries.
+    %% OTLP protobuf requires raw bytes (16 bytes for trace_id, 8 bytes for span_id).
     LogRecord = case Metadata of
-        #{otel_trace_id := TraceId,
-          otel_span_id := SpanId,
+        #{otel_trace_id := TraceIdHex,
+          otel_span_id := SpanIdHex,
           otel_trace_flags := TraceFlagsHex} ->
             TraceFlags = case TraceFlagsHex of
                 <<_:0, _/binary>> when byte_size(TraceFlagsHex) == 2 ->
                     erlang:binary_to_integer(TraceFlagsHex, 16);
                 _ -> 0
             end,
-            #{trace_id => TraceId,
-              span_id => SpanId,
+            #{trace_id => binary:decode_hex(TraceIdHex),
+              span_id => binary:decode_hex(SpanIdHex),
               trace_flags => TraceFlags};
-        #{otel_trace_id := TraceId,
-          otel_span_id := SpanId} ->
-            #{trace_id => TraceId,
-              span_id => SpanId};
+        #{otel_trace_id := TraceIdHex,
+          otel_span_id := SpanIdHex} ->
+            #{trace_id => binary:decode_hex(TraceIdHex),
+              span_id => binary:decode_hex(SpanIdHex)};
         _ ->
             #{}
     end,

--- a/apps/opentelemetry_experimental/test/otel_exporter_metrics_otlp_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_exporter_metrics_otlp_SUITE.erl
@@ -16,7 +16,7 @@ all() ->
      {group, grpc}, {group, grpc_gzip}].
 
 groups() ->
-    [{functional, [], [configuration]},
+    [{functional, [], [configuration, log_record_trace_ids]},
      {grpc, [], [verify_export]},
      {grpc_gzip, [], [verify_export]},
      {http_protobuf, [], [verify_export]},
@@ -184,3 +184,32 @@ configuration(_Config) ->
         os:unsetenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS"),
         os:unsetenv("OTEL_EXPORTER_OTLP_PROTOCOL")
     end.
+
+%% Verify that trace_id and span_id in log records are exported as raw bytes,
+%% not as hex-encoded strings. otel_span:hex_span_ctx/1 stores them as hex
+%% binaries in logger metadata; OTLP protobuf requires 16-byte/8-byte values.
+log_record_trace_ids(_Config) ->
+    TraceIdHex = <<"0af7651916cd43dd8448eb211c80319c">>,
+    SpanIdHex  = <<"b7ad6b7169203331">>,
+
+    Metadata = #{time             => erlang:system_time(microsecond),
+                 otel_trace_id    => TraceIdHex,
+                 otel_span_id     => SpanIdHex,
+                 otel_trace_flags => <<"01">>},
+
+    Log = #{level => info,
+            msg   => {string, <<"test">>},
+            meta  => Metadata},
+
+    %% Logs are batched as a map from InstrumentationScope to list of events
+    Scope = #instrumentation_scope{name = <<"test">>, version = <<"1.0.0">>},
+    Batch = #{Scope => [Log]},
+
+    Resource = otel_resource:create([]),
+    #{resource_logs := [#{scope_logs := [#{log_records := [Record]}]}]} =
+        otel_otlp_logs:to_proto(Batch, Resource, #{}),
+
+    %% Must be raw bytes, not the original hex strings
+    ?assertEqual(binary:decode_hex(TraceIdHex), maps:get(trace_id, Record)),
+    ?assertEqual(binary:decode_hex(SpanIdHex),  maps:get(span_id, Record)),
+    ?assertEqual(1, maps:get(trace_flags, Record)).


### PR DESCRIPTION
## Problem

When OpenTelemetry context is attached to an Erlang logger call via `otel_ctx`, the `otel_trace_id` and `otel_span_id` values injected into logger metadata are 32/16-character hex-encoded binaries (e.g. `<<"0af7651916cd43dd8448eb211c80319c">>`).

The OTLP protobuf schema for `LogRecord` requires raw bytes — 16 bytes for `trace_id` and 8 bytes for `span_id`. Passing the hex string as-is means the exported log records carry the wrong bytes, silently breaking trace correlation in any downstream collector or backend.

Fixes #744.

## Changes

- **`otel_otlp_logs.erl`** — decode `otel_trace_id` and `otel_span_id` from hex to raw bytes using `binary:decode_hex/1` (available since OTP 23). Also convert `otel_trace_flags` from its two-character hex representation to an integer.

- **`otel_exporter_metrics_otlp_SUITE.erl`** — add a `log_record_trace_ids` test case that drives `otel_otlp_logs:to_proto/3` end-to-end and asserts the correct raw-byte values land in the `LogRecord`.

## How to test

```
rebar3 ct --suite apps/opentelemetry_experimental/test/otel_exporter_metrics_otlp_SUITE --case log_record_trace_ids
```