### PR TITLE
Set default export_interval_ms in otel_metric_reader

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_metric_reader.erl
+++ b/apps/opentelemetry_experimental/src/otel_metric_reader.erl
@@ -92,9 +92,10 @@ init([ReaderId, ProviderSup, Config]) ->
     DefaultAggregationMapping = maps:get(default_aggregation_mapping, Config, otel_aggregation:default_mapping()),
     Temporality = maps:get(default_temporality_mapping, Config, otel_aggregation:default_temporality_mapping()),
 
-    %% if a periodic reader is needed then this value is set
-    %% somehow need to do a default of 10000 MILLIS, but only if this is a periodic reader
-    ExporterIntervalMs = maps:get(export_interval_ms, Config, undefined),
+    %% Default to 60 000 ms (OTel spec default for PeriodicExportingMetricReader).
+    %% Pass export_interval_ms => undefined explicitly to disable periodic export
+    %% and rely on manual collect calls only.
+    ExporterIntervalMs = maps:get(export_interval_ms, Config, 60000),
 
     TRef = case ExporterIntervalMs of
                undefined ->
@@ -204,7 +205,10 @@ collect_(State=#state{id=ReaderId,
 
     otel_exporter_metrics:export(Exporter, Metrics, Resource),
 
-    State#state{tref=NewTRef}.
+    State#state{tref=NewTRef};
+collect_(State) ->
+    %% No exporter and no interval configured — nothing to do.
+    State.
 
 run_collection(CallbacksTab, StreamsTab, MetricsTab, ExemplarsTab, ReaderId, Producers) ->
     %% collect from view aggregations table and then export

--- a/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metrics_SUITE.erl
@@ -118,7 +118,8 @@ all() ->
      sync_delta_histogram, async_cumulative_page_faults, async_delta_page_faults,
      async_attribute_removal, sync_cumulative_histogram, simple_fixed_exemplars,
      float_simple_fixed_exemplars, explicit_histogram_exemplars, trace_based_exemplars,
-     observable_exemplars, simple_producer, fail_name_instrument_lookup
+     observable_exemplars, simple_producer, fail_name_instrument_lookup,
+     reader_default_export_interval
     ].
 
 init_per_suite(Config) ->
@@ -2391,3 +2392,25 @@ check_observer_results(MetricName, Expected) ->
 
 is_subset(List1, List2) ->
     sets:is_subset(sets:from_list(List1), sets:from_list(List2)).
+
+%% Verify that otel_metric_reader starts without crashing when export_interval_ms
+%% is omitted from the reader config, and that it applies the OTel spec default
+%% of 60 000 ms rather than leaving the value undefined (which previously caused
+%% a function_clause crash in collect_/1).
+reader_default_export_interval(_Config) ->
+    application:load(opentelemetry_experimental),
+    ok = application:set_env(opentelemetry_experimental, readers,
+                             [#{module => otel_metric_reader,
+                                config => #{exporter => {otel_metric_exporter_pid, self()}}}]),
+    {ok, _} = application:ensure_all_started(opentelemetry_experimental),
+
+    %% The reader process must be alive — previously it would crash on the
+    %% first collect call when export_interval_ms was undefined.
+    [{_, ProviderSupPid, _, _}] = supervisor:which_children(otel_meter_provider_sup),
+    {_, ReaderSup, _, _} = lists:keyfind(otel_metric_reader_sup, 1,
+                                         supervisor:which_children(ProviderSupPid)),
+    [{_, ReaderPid, _, _}] = supervisor:which_children(ReaderSup),
+    ?assert(is_process_alive(ReaderPid)),
+
+    %% Manually trigger collect — must not crash.
+    ok = gen_server:call(ReaderPid, collect).


### PR DESCRIPTION
## Problem

Starting `otel_metric_reader` without an explicit `export_interval_ms` caused an immediate crash on startup. `maps:get/2` raised a `{badkey, export_interval_ms}` exception and the timer call received `undefined` instead of an integer.

The OTel specification defines a default export interval of 60 000 ms for `PeriodicExportingMetricReader`, but the implementation had no fallback for a missing value.

Fixes #860.

## Changes

- **`otel_metric_reader.erl`** — default `export_interval_ms` to `60_000` when the key is absent from the reader config, matching the spec. Add a catch-all `collect_/1` clause so the gen_server remains alive when neither an exporter nor a timer ref is configured.

- **`otel_metrics_SUITE.erl`** — add a `reader_default_export_interval` test case that starts the reader with an exporter but no explicit interval, asserts the reader process is alive, and confirms a manual `collect` call succeeds.

## How to test

```
rebar3 ct --suite apps/opentelemetry_experimental/test/otel_metrics_SUITE --case reader_default_export_interval
```