### PR TITLE
Preserve processor-level exporter when global traces_exporter is set

### DIFF
--- a/apps/opentelemetry/src/otel_configuration.erl
+++ b/apps/opentelemetry/src/otel_configuration.erl
@@ -189,13 +189,27 @@ merge_processor_config(otel_batch_processor, Opts, ConfigMap, AppEnv) ->
                        {bsp_exporting_timeout_ms, exporting_timeout_ms},
                        {bsp_max_queue_size, max_queue_size},
                        {traces_exporter, exporter}],
-    maps:merge(?BATCH_PROCESSOR_DEFAULTS,
-               merge_processor_config_(BatchEnvMapping, Opts, ConfigMap, AppEnv));
+    Merged = maps:merge(?BATCH_PROCESSOR_DEFAULTS,
+                        merge_processor_config_(BatchEnvMapping, Opts, ConfigMap, AppEnv)),
+    %% A non-default exporter set directly in the processor opts must survive even when
+    %% OTEL_TRACES_EXPORTER (or traces_exporter in app env) points to something else.
+    %% We distinguish "user explicitly chose this exporter" from "it came from the
+    %% span_processor=batch shorthand default" by comparing against the default value.
+    DefaultExporter = maps:get(exporter, ?BATCH_PROCESSOR_DEFAULTS),
+    case maps:find(exporter, Opts) of
+        {ok, E} when E =/= DefaultExporter -> Merged#{exporter => E};
+        _                                  -> Merged
+    end;
 merge_processor_config(otel_simple_processor, Opts, ConfigMap, AppEnv) ->
     SimpleEnvMapping = [{ssp_exporting_timeout_ms, exporting_timeout_ms},
                         {traces_exporter, exporter}],
-    maps:merge(?SIMPLE_PROCESSOR_DEFAULTS,
-               merge_processor_config_(SimpleEnvMapping, Opts, ConfigMap, AppEnv));
+    Merged = maps:merge(?SIMPLE_PROCESSOR_DEFAULTS,
+                        merge_processor_config_(SimpleEnvMapping, Opts, ConfigMap, AppEnv)),
+    DefaultExporter = maps:get(exporter, ?SIMPLE_PROCESSOR_DEFAULTS),
+    case maps:find(exporter, Opts) of
+        {ok, E} when E =/= DefaultExporter -> Merged#{exporter => E};
+        _                                  -> Merged
+    end;
 merge_processor_config(_, Opts, _, _) ->
     Opts.
 

--- a/apps/opentelemetry/test/otel_configuration_SUITE.erl
+++ b/apps/opentelemetry/test/otel_configuration_SUITE.erl
@@ -412,6 +412,21 @@ span_processors(_Config) ->
                  otel_configuration:merge_with_os([{span_processor, simple},
                                                    {ssp_exporting_timeout_ms, 2}])),
 
+    %% Processor-level exporter must survive when OTEL_TRACES_EXPORTER is set
+    %% in the OS environment. Global traces_exporter must not silently clobber
+    %% an exporter that the caller set explicitly in the processor opts map.
+    os:putenv("OTEL_TRACES_EXPORTER", "otlp"),
+    try
+        ?assertMatch(
+           #{processors := [{otel_batch_processor,
+                              #{exporter := {otel_exporter_pid, _}}}]},
+           otel_configuration:merge_with_os(
+             [{processors, [{otel_batch_processor,
+                              #{exporter => {otel_exporter_pid, self()}}}]}]))
+    after
+        os:unsetenv("OTEL_TRACES_EXPORTER")
+    end,
+
     ok.
 
 %%


### PR DESCRIPTION
## Problem

When a span processor is configured with an explicit `exporter` option and `OTEL_TRACES_EXPORTER` (or `traces_exporter` in app env) is also set, the processor-level exporter was silently replaced by the global one.

The root cause was in `merge_processor_config_/4`: when `is_default` returned `false` (meaning the global `traces_exporter` was explicitly configured), the fold unconditionally overwrote whatever `exporter` was already in `Opts` — including a value the caller had intentionally set for that specific processor.

```erlang
%% with OTEL_TRACES_EXPORTER=otlp set, the explicit exporter is lost
otel_configuration:merge_with_os([{processors,
    [{otel_batch_processor, #{exporter => {my_exporter, #{}}}}]}])
%% => exporter becomes {opentelemetry_exporter, #{}} instead of {my_exporter, #{}}
```

Fixes #976.

## Changes

- **`otel_configuration.erl`** — after `maps:merge/2` in both `otel_batch_processor` and `otel_simple_processor` clauses of `merge_processor_config/4`, compare the exporter value already present in `Opts` against the module-level default (`{opentelemetry_exporter, #{}}`). If it differs, the user explicitly chose a non-default exporter for that processor and it is restored into the result. When `Opts` carries the default value — produced by the `span_processor=batch` or `span_processor=simple` shorthand — the global setting continues to take precedence as before.

- **`otel_configuration_SUITE.erl`** — extend the `span_processors` test to set `OTEL_TRACES_EXPORTER=otlp` while supplying an explicit processor-level exporter, and verify it survives the merge.

## How to test

```
rebar3 ct --suite apps/opentelemetry/test/otel_configuration_SUITE --case span_processors
```