### PR TITLE
Support incubating semconv stability levels

### DIFF
--- a/apps/opentelemetry_semantic_conventions/makefile
+++ b/apps/opentelemetry_semantic_conventions/makefile
@@ -35,11 +35,11 @@ generate: generate-elixir generate-erlang format-and-test
 
 generate-elixir:
 	weaver registry generate --registry=semtmp/model --templates=templates --param output=lib/ --param stability=stable elixir .
-	weaver registry generate --registry=semtmp/model --templates=templates --param output=lib/incubating/ --param stability=experimental elixir .
+	weaver registry generate --registry=semtmp/model --templates=templates --param output=lib/incubating/ --param stability=incubating elixir .
 
 generate-erlang:
 	weaver registry generate --registry=semtmp/model --templates=templates --param output=include/ --param stability=stable erlang .
-	weaver registry generate --registry=semtmp/model --templates=templates --param output=include/incubating/ --param stability=experimental erlang .
+	weaver registry generate --registry=semtmp/model --templates=templates --param output=include/incubating/ --param stability=incubating erlang .
 
 format-and-test:
 	mix format

--- a/apps/opentelemetry_semantic_conventions/templates/registry/elixir/semantic_attributes.ex.j2
+++ b/apps/opentelemetry_semantic_conventions/templates/registry/elixir/semantic_attributes.ex.j2
@@ -6,7 +6,7 @@
 {%- set module_name = ctx.id | pascal_case | acronym ~ "Attributes" -%}
 {%- set incubating_module_namespace = "OpenTelemetry.SemConv.Incubating" -%}
 {%- set stable_module_namespace = "OpenTelemetry.SemConv" -%}
-{%- if params.stability == "experimental" -%}
+{%- if params.stability != "stable" -%}
 {%- set module_namespace = incubating_module_namespace -%}
 {%- else -%}
 {%- set module_namespace = stable_module_namespace -%}
@@ -16,7 +16,7 @@ defmodule {{ module_namespace }}.{{ module_name }} do
   @moduledoc """
   OpenTelemetry Semantic Conventions for {{ ctx.id | title | acronym }} attributes.
   """
-{%- if params.stability == "experimental" and (ctx.all_attributes | length) > (ctx.attributes | length) %}
+{%- if params.stability != "stable" and (ctx.all_attributes | length) > (ctx.attributes | length) %}
 {%- for attribute in ctx.all_attributes | sort(attribute="name") %}
   {%- if attribute is stable %}
   defdelegate {{ c.func_name(attribute.name) }}(), to: {{ stable_module_namespace }}.{{ module_name }}
@@ -34,7 +34,7 @@ defmodule {{ module_namespace }}.{{ module_name }} do
   ### Enum Values
   {% for member in attribute.type.members -%}
   * `{{ c.to_atom(member.id) }}`
-  {%- if member is experimental %} ^[e](`m:OpenTelemetry.SemConv#experimental`)^{% endif %}{% if member.brief != none %} - {% if member is deprecated %}**deprecated** ~~{% endif %}{{ member.brief }}{% if member is deprecated %}~~{% endif %}{% endif %}
+  {%- if member.stability is defined and member.stability != "stable" %} ^[e](`m:OpenTelemetry.SemConv#experimental`)^{% endif %}{% if member.brief != none %} - {% if member is deprecated %}**deprecated** ~~{% endif %}{{ member.brief }}{% if member is deprecated %}~~{% endif %}{% endif %}
   {% endfor -%}
   """
   @type {{ c.func_name(attribute.name) }}_values() :: {{ c.enum_to_map(attribute.type.members) }}

--- a/apps/opentelemetry_semantic_conventions/templates/registry/elixir/semantic_metrics.ex.j2
+++ b/apps/opentelemetry_semantic_conventions/templates/registry/elixir/semantic_metrics.ex.j2
@@ -5,7 +5,7 @@
 {{ template.set_file_name(file_name) }}
 
 {%- set module_name = ctx.id | pascal_case | acronym ~ "Metrics" -%}
-{%- if params.stability == "experimental" -%}
+{%- if params.stability != "stable" -%}
 {%- set module_namespace = "OpenTelemetry.SemConv.Incubating.Metrics" -%}
 {%- else -%}
 {%- set module_namespace = "OpenTelemetry.SemConv.Metrics" -%}

--- a/apps/opentelemetry_semantic_conventions/templates/registry/elixir/weaver.yaml
+++ b/apps/opentelemetry_semantic_conventions/templates/registry/elixir/weaver.yaml
@@ -10,11 +10,11 @@ templates:
       | map(select(.type == "attribute_group"))
       | map(select(.id | startswith("registry.")))
       | map({ id: .id, group_id: .id | split(".") | .[1], attributes: .attributes})
-      | map(select([.attributes[] | select(.stability == $stability)] | any))
+      | map(select([.attributes[] | select(($stability == "stable" and .stability == "stable") or ($stability != "stable" and .stability != "stable"))] | any))
       | group_by(.group_id)
       | map({ 
         id: .[0].group_id,
-        attributes: [.[].attributes[] | select(.stability == $stability) | (select( .name as $id | any( $excluded_attrs[]; . == $id ) | not ))] | sort_by(.id),
+        attributes: [.[].attributes[] | select(($stability == "stable" and .stability == "stable") or ($stability != "stable" and .stability != "stable")) | (select( .name as $id | any( $excluded_attrs[]; . == $id ) | not ))] | sort_by(.id),
         all_attributes: [.[].attributes[]] | sort_by(.id),
         output: $output + "/attributes/"
       })
@@ -25,7 +25,7 @@ templates:
     filter: >
       .groups
       | map(select(.type == "metric"))
-      | map(select(.stability == $stability))
+      | map(select(($stability == "stable" and .stability == "stable") or ($stability != "stable" and .stability != "stable")))
       | map({ id: .id, group_id: .id | split(".") | .[1], brief, unit, stability, deprecated, instrument, metric_name, note})
       | group_by(.group_id)
       | map({

--- a/apps/opentelemetry_semantic_conventions/templates/registry/erlang/semantic_attributes.hrl.j2
+++ b/apps/opentelemetry_semantic_conventions/templates/registry/erlang/semantic_attributes.hrl.j2
@@ -15,7 +15,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%%-------------------------------------------------------------------------
-{%- if params.stability == "experimental" and (ctx.all_attributes | length) > (ctx.attributes | length) %}
+{%- if params.stability != "stable" and (ctx.all_attributes | length) > (ctx.attributes | length) %}
 -include_lib("opentelemetry_semantic_conventions/include/attributes/{{ c.file_name(ctx.id) }}_attributes.hrl").
 {% endif -%}
 {%- for attribute in ctx.attributes | sort(attribute="name") %}

--- a/apps/opentelemetry_semantic_conventions/templates/registry/erlang/weaver.yaml
+++ b/apps/opentelemetry_semantic_conventions/templates/registry/erlang/weaver.yaml
@@ -10,11 +10,11 @@ templates:
       | map(select(.type == "attribute_group"))
       | map(select(.id | startswith("registry.")))
       | map({ id: .id, group_id: .id | split(".") | .[1], attributes: .attributes})
-      | map(select([.attributes[] | select(.stability == $stability)] | any))
+      | map(select([.attributes[] | select(($stability == "stable" and .stability == "stable") or ($stability != "stable" and .stability != "stable"))] | any))
       | group_by(.group_id)
       | map({ 
         id: .[0].group_id,
-        attributes: [.[].attributes[] | select(.stability == $stability) | (select( .name as $id | any( $excluded_attrs[]; . == $id ) | not ))] | sort_by(.id),
+        attributes: [.[].attributes[] | select(($stability == "stable" and .stability == "stable") or ($stability != "stable" and .stability != "stable")) | (select( .name as $id | any( $excluded_attrs[]; . == $id ) | not ))] | sort_by(.id),
         all_attributes: [.[].attributes[]],
         output: $output + "/attributes/"
       })
@@ -25,7 +25,7 @@ templates:
     filter: >
       .groups
       | map(select(.type == "metric"))
-      | map(select(.stability == $stability))
+      | map(select(($stability == "stable" and .stability == "stable") or ($stability != "stable" and .stability != "stable")))
       | map({ id: .id, group_id: .id | split(".") | .[1], brief, unit, stability, deprecated, instrument, metric_name, note})
       | group_by(.group_id)
       | map({


### PR DESCRIPTION
## Summary

- treat the generated `incubating` semantic-convention pass as "all non-stable" instead of matching only `experimental`
- update Elixir and Erlang semconv templates so incubating output still uses incubating namespaces/includes for `development`, `rc`, and `experimental` stability levels
- keep stable generation as an exact `stable` match

Fixes #823.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file("apps/opentelemetry_semantic_conventions/templates/registry/elixir/weaver.yaml"); YAML.load_file("apps/opentelemetry_semantic_conventions/templates/registry/erlang/weaver.yaml")'`
- `jq -n --arg stability stable '[{stability:"stable"},{stability:"development"},{stability:"rc"},{stability:"experimental"}] | map(select(($stability == "stable" and .stability == "stable") or ($stability != "stable" and .stability != "stable")))'`
- `jq -n --arg stability incubating '[{stability:"stable"},{stability:"development"},{stability:"rc"},{stability:"experimental"}] | map(select(($stability == "stable" and .stability == "stable") or ($stability != "stable" and .stability != "stable")))'`
- `git diff --check`
- `mix deps.get`
- `mix test`
- `mix format --check-formatted`

Note: I did not regenerate semantic-convention output in this branch; this changes the generator filters/templates only.
