### PR TITLE
Use erl_error:format_exception for exception.stacktrace (closes #248)

### DIFF
--- a/apps/opentelemetry/test/opentelemetry_SUITE.erl
+++ b/apps/opentelemetry/test/opentelemetry_SUITE.erl
@@ -956,10 +956,16 @@ record_exception_works(Config) ->
             [Span] = assert_exported(Tid, SpanCtx),
             [Event] = otel_events:list(Span#span.events),
             ?assertEqual(exception, Event#event.name),
+            {ok, ExpectedStack} = otel_utils:unicode_to_binary(otel_utils:format_exception(Class, Term, Stacktrace)),
             ?assertEqual(#{'exception.type' => <<"throw:my_error">>,
-                           'exception.stacktrace' => list_to_binary(io_lib:format("~p", [Stacktrace], [{chars_limit, 50}])),
+                           'exception.stacktrace' => ExpectedStack,
                            <<"some-attribute">> => <<"value">>},
                          otel_attributes:map(Event#event.attributes)),
+            %% Regression guard: the stacktrace must not be the legacy
+            %% 50-char truncated form. It must contain at least one resolved
+            %% MFA from this test module.
+            ?assert(byte_size(ExpectedStack) > 50),
+            ?assertNotEqual(nomatch, binary:match(ExpectedStack, <<"opentelemetry_SUITE">>)),
             ok
     end.
 
@@ -976,12 +982,15 @@ record_exception_with_message_works(Config) ->
             [Span] = assert_exported(Tid, SpanCtx),
             [Event] = otel_events:list(Span#span.events),
             ?assertEqual(exception, Event#event.name),
+            {ok, ExpectedStack} = otel_utils:unicode_to_binary(otel_utils:format_exception(Class, Term, Stacktrace)),
             ?assertEqual(#{'exception.type' => <<"throw:my_error">>,
-                           'exception.stacktrace' => list_to_binary(io_lib:format("~p", [Stacktrace], [{chars_limit, 50}])),
+                           'exception.stacktrace' => ExpectedStack,
                            'exception.message' => <<"My message">>,
                            <<"some-attribute">> => <<"value">>},
                          otel_attributes:map(Event#event.attributes)
                         ),
+            ?assert(byte_size(ExpectedStack) > 50),
+            ?assertNotEqual(nomatch, binary:match(ExpectedStack, <<"opentelemetry_SUITE">>)),
             ok
     end.
 

--- a/apps/opentelemetry_api/src/otel_span.erl
+++ b/apps/opentelemetry_api/src/otel_span.erl
@@ -210,8 +210,8 @@ add_events(_, _) ->
 record_exception(SpanCtx, Class, Term, Stacktrace, Attributes) when is_list(Attributes) ->
     record_exception(SpanCtx, Class, Term, Stacktrace, maps:from_list(Attributes));
 record_exception(SpanCtx, Class, Term, Stacktrace, Attributes) when is_map(Attributes) ->
-    {ok, ExceptionType} = otel_utils:format_binary_string("~0tP:~0tP", [Class, 10, Term, 10], [{chars_limit, 50}]),
-    {ok, StacktraceString} = otel_utils:format_binary_string("~0tP", [Stacktrace, 10], [{chars_limit, 50}]),
+    {ok, ExceptionType} = otel_utils:format_binary_string("~0tP:~0tP", [Class, 10, Term, 10], [{chars_limit, 1024}]),
+    {ok, StacktraceString} = otel_utils:unicode_to_binary(otel_utils:format_exception(Class, Term, Stacktrace)),
     ExceptionAttributes = #{'exception.type' => ExceptionType,
                             'exception.stacktrace' => StacktraceString},
     add_event(SpanCtx, 'exception', maps:merge(ExceptionAttributes, Attributes));
@@ -228,8 +228,8 @@ record_exception(_, _, _, _, _) ->
 record_exception(SpanCtx, Class, Term, Message, Stacktrace, Attributes) when is_list(Attributes) ->
     record_exception(SpanCtx, Class, Term, Message, Stacktrace, maps:from_list(Attributes));
 record_exception(SpanCtx, Class, Term, Message, Stacktrace, Attributes) when is_map(Attributes) ->
-    {ok, ExceptionType} = otel_utils:format_binary_string("~0tP:~0tP", [Class, 10, Term, 10], [{chars_limit, 50}]),
-    {ok, StacktraceString} = otel_utils:format_binary_string("~0tP", [Stacktrace, 10], [{chars_limit, 50}]),
+    {ok, ExceptionType} = otel_utils:format_binary_string("~0tP:~0tP", [Class, 10, Term, 10], [{chars_limit, 1024}]),
+    {ok, StacktraceString} = otel_utils:unicode_to_binary(otel_utils:format_exception(Class, Term, Stacktrace)),
     ExceptionAttributes = #{'exception.type' => ExceptionType,
                             'exception.stacktrace' => StacktraceString,
                             'exception.message' => Message},


### PR DESCRIPTION
Closes #248.

## Problem

`otel_span:record_exception/5` and `record_exception/6` format the `Stacktrace` argument via `io_lib`'s term printer with `chars_limit, 50`:

```erlang
{ok, StacktraceString} = otel_utils:format_binary_string("~0tP", [Stacktrace, 10], [{chars_limit, 50}]),
```

50 characters might be too little to capture a meaningful stacktrace.

## Fix

Issue #248 — opened in 2021 by @tsloughter — already noted that `otel_span:record_exception` should use `erl_error:format_exception/3` on OTP-24+. The helper for that already exists in this repo at [`otel_utils:format_exception/3`](apps/opentelemetry_api/src/otel_utils.erl) and is unused.

- **`exception.stacktrace`**: switch from the truncated term-printer call to `otel_utils:unicode_to_binary(otel_utils:format_exception(Class, Term, Stacktrace))`. This produces the natural multi-line Erlang representation, e.g.:
  ```
  ** exception throw: my_error
       in function  opentelemetry_SUITE:record_exception_works/1
       ...
  ```
- **`exception.type`**: raise `chars_limit` from 50 → 1024. Happy to discuss the limit

CI matrix is OTP 26.2 / 27.2 / 28.1 (all ≥ 24), so `otel_utils:format_exception/3`'s `erl_error` branch is always live; no conditional code is needed.

## Tests

`record_exception_works` and `record_exception_with_message_works` in `apps/opentelemetry/test/opentelemetry_SUITE.erl` previously baked the `chars_limit, 50` formatting into their expected values. Updated both tests to compute the expected stacktrace via `otel_utils:format_exception`.

## Impact

- **For users**: `exception.stacktrace` can capture more stacktrace information.
- **For backends**: attribute size goes up. For most exception sites the new output is ~few hundred bytes to a few KB.
- **Backward compatibility**: the `exception.type` / `exception.stacktrace` / `exception.message` attribute schema is unchanged; only the string content shape changes.

## How I noticed

I work at an OTel vendor and a customer complained about truncated stacktraces.