### PR TITLE
fix: preserve boolean OTLP attribute encoding

### DIFF
--- a/apps/opentelemetry_exporter/src/otel_otlp_common.erl
+++ b/apps/opentelemetry_exporter/src/otel_otlp_common.erl
@@ -60,14 +60,14 @@ to_any_value(Value) when is_binary(Value) ->
         String ->
             #{value => {string_value, String}}
     end;
+to_any_value(Value) when is_boolean(Value) ->
+    #{value => {bool_value, Value}};
 to_any_value(Value) when is_atom(Value) ->
     #{value => {string_value, to_binary(Value)}};
 to_any_value(Value) when is_integer(Value) ->
     #{value => {int_value, Value}};
 to_any_value(Value) when is_float(Value) ->
     #{value => {double_value, Value}};
-to_any_value(Value) when is_boolean(Value) ->
-    #{value => {bool_value, Value}};
 to_any_value(Value) when is_map(Value) ->
     #{value => {kvlist_value, to_key_value_list(maps:to_list(Value))}};
 to_any_value(Value) when is_tuple(Value) ->

--- a/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
+++ b/apps/opentelemetry_exporter/test/opentelemetry_exporter_SUITE.erl
@@ -14,7 +14,7 @@ all() ->
      {group, grpc}, {group, grpc_gzip}].
 
 groups() ->
-    [{functional, [], [configuration, span_round_trip, span_flags, ets_instrumentation_info, to_attributes]},
+    [{functional, [], [configuration, span_round_trip, span_flags, ets_instrumentation_info, to_any_value_boolean, to_attributes]},
      {grpc, [], [verify_export]},
      {grpc_gzip, [], [verify_export]},
      {http_protobuf, [], [verify_export, user_agent]},
@@ -407,6 +407,14 @@ span_flags(_Config) ->
     PbSpanNoParent = otel_otlp_traces:to_proto(NoParentSpan),
     ?assertEqual(16#101, maps:get(flags, PbSpanNoParent)), %% 0x101 - no parent with sampled flag
 
+    ok.
+
+%% test boolean conversion to the OTLP AnyValue representation
+to_any_value_boolean(_Config) ->
+    ?assertEqual(#{value => {bool_value, true}},
+                 otel_otlp_common:to_any_value(true)),
+    ?assertEqual(#{value => {bool_value, false}},
+                 otel_otlp_common:to_any_value(false)),
     ok.
 
 %% test conversion of attributes to the map representation of the OTLP protobuf


### PR DESCRIPTION
## Summary

- preserve boolean OTLP attributes as `bool_value` instead of converting them to strings
- add a focused regression test for `otel_otlp_common:to_any_value/1`

Fixes #990.

## Root cause

`otel_otlp_common:to_any_value/1` matched `is_atom(Value)` before `is_boolean(Value)`.
In Erlang, `true` and `false` are atoms, so boolean attributes always took the string branch and were exported as `string_value`.

## Validation

- added a common test case covering `true` and `false`
- did not run the Erlang test suite locally because this environment does not have `erl`, `rebar3`, `mix`, or `elixir` installed
