### PR TITLE
feat(experimental): add metrics cardinality limit with overflow

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_aggregation.erl
+++ b/apps/opentelemetry_experimental/src/otel_aggregation.erl
@@ -45,16 +45,79 @@ maybe_init_aggregate(Ctx, MetricsTab, ExemplarsTab, Stream=#stream{aggregation_m
                                                                    attribute_keys=AttributeKeys},
                      Value, Attributes) ->
     {FilteredAttributes, DroppedAttributes} = filter_attributes(AttributeKeys, Attributes),
-    case AggregationModule:aggregate(Ctx, MetricsTab, ExemplarsTab, Stream, Value, term_to_binary(FilteredAttributes), DroppedAttributes) of
+    AttributesKey = term_to_binary(FilteredAttributes),
+    case AggregationModule:aggregate(Ctx, MetricsTab, ExemplarsTab, Stream, Value, AttributesKey, DroppedAttributes) of
         true ->
             true;
         false ->
-            %% entry doesn't exist, create it and rerun the aggregate function
-            Metric = AggregationModule:init(Stream, term_to_binary(FilteredAttributes)),
-            %% don't overwrite a possible concurrent measurement doing the same
-            _ = ets:insert_new(MetricsTab, Metric),
-            AggregationModule:aggregate(Ctx, MetricsTab, ExemplarsTab, Stream, Value, term_to_binary(FilteredAttributes), DroppedAttributes)
+            %% entry doesn't exist (Exists=false); apply the cardinality limit
+            %% before creating a new series. If the limit is reached the
+            %% measurement is redirected into the single overflow series.
+            maybe_init_new_series(Ctx, MetricsTab, ExemplarsTab, Stream, Value,
+                                  FilteredAttributes, AttributesKey, DroppedAttributes)
     end.
+
+maybe_init_new_series(Ctx, MetricsTab, ExemplarsTab,
+                      Stream=#stream{aggregation_module=AggregationModule,
+                                     cardinality_limit=Limit},
+                      Value, FilteredAttributes, AttributesKey, DroppedAttributes) ->
+    CurrentCount = series_count(MetricsTab, Stream),
+    case otel_metric_cardinality:limit_attributes(FilteredAttributes, CurrentCount, false, limit(Limit)) of
+        FilteredAttributes ->
+            %% under the limit: create the requested series and record into it
+            init_and_aggregate(Ctx, MetricsTab, ExemplarsTab, Stream, Value,
+                               AttributesKey, DroppedAttributes);
+        OverflowAttributes ->
+            %% over the limit: fold into the single overflow series. It may
+            %% already exist (and just needs updating) or need to be created
+            %% once and then reused.
+            OverflowKey = term_to_binary(OverflowAttributes),
+            case AggregationModule:aggregate(Ctx, MetricsTab, ExemplarsTab, Stream, Value, OverflowKey, DroppedAttributes) of
+                true ->
+                    true;
+                false ->
+                    init_and_aggregate(Ctx, MetricsTab, ExemplarsTab, Stream, Value,
+                                       OverflowKey, DroppedAttributes)
+            end
+    end.
+
+init_and_aggregate(Ctx, MetricsTab, ExemplarsTab,
+                   Stream=#stream{aggregation_module=AggregationModule}, Value,
+                   AttributesKey, DroppedAttributes) ->
+    %% entry doesn't exist, create it and rerun the aggregate function
+    Metric = AggregationModule:init(Stream, AttributesKey),
+    %% don't overwrite a possible concurrent measurement doing the same
+    _ = ets:insert_new(MetricsTab, Metric),
+    AggregationModule:aggregate(Ctx, MetricsTab, ExemplarsTab, Stream, Value, AttributesKey, DroppedAttributes).
+
+%% a limit of `undefined' (e.g. on a stream built before the field existed)
+%% falls back to the default limit
+limit(undefined) ->
+    otel_metric_cardinality:default_limit();
+limit(Limit) ->
+    Limit.
+
+%% Count the distinct series currently recorded for this stream (same metric
+%% name, reader, and generation). This runs only on the cold path when a new
+%% series would otherwise be created.
+series_count(MetricsTab, #stream{name=Name,
+                                 reader=ReaderId,
+                                 forget=Forget}) ->
+    Generation = case Forget of
+                     true ->
+                         otel_metric_reader:checkpoint_generation(ReaderId);
+                     _ ->
+                         0
+                 end,
+    %% all aggregation records store the key `{Name, Attributes, ReaderId,
+    %% Generation}' at element 2; match on the key shape regardless of the
+    %% record type (which have differing arities).
+    MS = [{'$1',
+           [{'=:=', {element, 1, {element, 2, '$1'}}, {const, Name}},
+            {'=:=', {element, 3, {element, 2, '$1'}}, {const, ReaderId}},
+            {'=:=', {element, 4, {element, 2, '$1'}}, {const, Generation}}],
+           [true]}],
+    ets:select_count(MetricsTab, MS).
 
 filter_attributes(undefined, Attributes) ->
     {Attributes, #{}};

--- a/apps/opentelemetry_experimental/src/otel_meter_server.erl
+++ b/apps/opentelemetry_experimental/src/otel_meter_server.erl
@@ -37,6 +37,7 @@
 -export([start_link/4,
          add_metric_reader/4,
          add_metric_reader/5,
+         add_metric_reader/6,
          get_readers/0,
          get_readers/1,
          add_instrument/1,
@@ -71,7 +72,8 @@
          pid                         :: pid(),
          monitor_ref                 :: reference(),
          default_aggregation_mapping :: map(),
-         default_temporality_mapping :: map()
+         default_temporality_mapping :: map(),
+         cardinality_limit           :: integer()
         }).
 
 -type reader() :: #reader{}.
@@ -129,7 +131,12 @@ add_metric_reader(ReaderId, ReaderPid, DefaultAggregationMapping, Temporality) -
                       DefaultAggregationMapping, Temporality).
 
 add_metric_reader(Provider, ReaderId, ReaderPid, DefaultAggregationMapping, Temporality) ->
-    gen_server:call(Provider, {add_metric_reader, ReaderId, ReaderPid, DefaultAggregationMapping, Temporality}).
+    add_metric_reader(Provider, ReaderId, ReaderPid, DefaultAggregationMapping, Temporality,
+                      otel_metric_cardinality:default_limit()).
+
+add_metric_reader(Provider, ReaderId, ReaderPid, DefaultAggregationMapping, Temporality, CardinalityLimit) ->
+    gen_server:call(Provider, {add_metric_reader, ReaderId, ReaderPid, DefaultAggregationMapping,
+                               Temporality, CardinalityLimit}).
 
 get_readers() ->
     get_readers(?GLOBAL_METER_PROVIDER_REG_NAME).
@@ -220,7 +227,7 @@ init_producers(ProducerConfigs) ->
 handle_call(get_readers, _From, State=#state{readers=Readers}) ->
 
     {reply, Readers, State};
-handle_call({add_metric_reader, ReaderId, ReaderPid, DefaultAggregationMapping, Temporality},
+handle_call({add_metric_reader, ReaderId, ReaderPid, DefaultAggregationMapping, Temporality, CardinalityLimit},
             _From, State=#state{readers=Readers,
                                 views=Views,
                                 instruments_tab=InstrumentsTab,
@@ -235,7 +242,8 @@ handle_call({add_metric_reader, ReaderId, ReaderPid, DefaultAggregationMapping, 
     Reader = metric_reader(ReaderId,
                            ReaderPid,
                            DefaultAggregationMapping,
-                           Temporality),
+                           Temporality,
+                           CardinalityLimit),
     Readers1 = [Reader | Readers],
 
     %% create Streams entries for existing View/Instrument
@@ -363,7 +371,7 @@ register_callback_(CallbacksTab, Instruments, Callback, CallbackArgs, Readers) -
                       otel_metrics_tables:insert_callback(CallbacksTab, ReaderId, Callback, CallbackArgs, Instruments)
               end, Readers).
 
-metric_reader(ReaderId, ReaderPid, DefaultAggregationMapping, Temporality) ->
+metric_reader(ReaderId, ReaderPid, DefaultAggregationMapping, Temporality, CardinalityLimit) ->
     %% TODO: Uncomment when we can drop OTP-23 support
     %% Ref = erlang:monitor(process, ReaderPid, [{tag, 'DOWN_READER'}]),
     Ref = erlang:monitor(process, ReaderPid),
@@ -375,7 +383,8 @@ metric_reader(ReaderId, ReaderPid, DefaultAggregationMapping, Temporality) ->
             pid=ReaderPid,
             monitor_ref=Ref,
             default_aggregation_mapping=ReaderAggregationMapping,
-            default_temporality_mapping=Temporality}.
+            default_temporality_mapping=Temporality,
+            cardinality_limit=CardinalityLimit}.
 
 
 %% a Measurement's Instrument is matched against Views
@@ -410,7 +419,8 @@ per_reader_aggregations(Reader, Instrument, Streams) ->
 
 stream_for_reader(Instrument=#instrument{kind=Kind}, Stream, View=#view{attribute_keys=AttributeKeys},
                   Reader=#reader{id=Id,
-                                 default_temporality_mapping=ReaderTemporalityMapping}) ->
+                                 default_temporality_mapping=ReaderTemporalityMapping,
+                                 cardinality_limit=CardinalityLimit}) ->
     AggregationModule = aggregation_module(Instrument, View, Reader),
     Temporality = maps:get(Kind, ReaderTemporalityMapping, ?TEMPORALITY_CUMULATIVE),
 
@@ -421,10 +431,12 @@ stream_for_reader(Instrument=#instrument{kind=Kind}, Stream, View=#view{attribut
       attribute_keys=AttributeKeys,
       aggregation_module=AggregationModule,
       forget=Forget,
-      temporality=Temporality};
+      temporality=Temporality,
+      cardinality_limit=CardinalityLimit};
 stream_for_reader(Instrument=#instrument{kind=Kind}, Stream, View,
                             Reader=#reader{id=Id,
-                                           default_temporality_mapping=ReaderTemporalityMapping}) ->
+                                           default_temporality_mapping=ReaderTemporalityMapping,
+                                           cardinality_limit=CardinalityLimit}) ->
     AggregationModule = aggregation_module(Instrument, View, Reader),
     Temporality = maps:get(Kind, ReaderTemporalityMapping, ?TEMPORALITY_CUMULATIVE),
 
@@ -435,7 +447,8 @@ stream_for_reader(Instrument=#instrument{kind=Kind}, Stream, View,
       attribute_keys=undefined,
       aggregation_module=AggregationModule,
       forget=Forget,
-      temporality=Temporality}.
+      temporality=Temporality,
+      cardinality_limit=CardinalityLimit}.
 
 
 %% no aggregation defined for the View, so get the aggregation from the Reader

--- a/apps/opentelemetry_experimental/src/otel_metric_cardinality.erl
+++ b/apps/opentelemetry_experimental/src/otel_metric_cardinality.erl
@@ -1,0 +1,71 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2024, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Pure decision helper for the metrics cardinality limit + overflow.
+%%
+%% Mirrors the semantics of opentelemetry-go's
+%% sdk/metric/internal/aggregate/limit.go and opentelemetry-java's
+%% MetricStorage cardinality overflow handling.
+%%
+%% With a limit of N, up to N-1 distinct "real" series are admitted and the
+%% Nth distinct attribute set (and every distinct set after it) is folded into
+%% a single overflow series tagged `#{<<"otel.metric.overflow">> => true}'.
+%% The `N-1' reservation matches Go's `len(measurements) >= aggLimit-1' and
+%% keeps one slot for the overflow series itself.
+%%
+%% A limit `=< 0' disables the cap (Go semantics; note Go treats `<= 0' as
+%% unlimited, unlike Java which rejects it).
+%% @end
+%%%-------------------------------------------------------------------------
+-module(otel_metric_cardinality).
+
+-export([default_limit/0,
+         overflow_attributes/0,
+         limit_attributes/4]).
+
+-define(OVERFLOW_KEY, <<"otel.metric.overflow">>).
+
+%% @doc The default per-stream cardinality limit when none is configured.
+-spec default_limit() -> 2000.
+default_limit() ->
+    2000.
+
+%% @doc The attribute set used for the single overflow series.
+-spec overflow_attributes() -> #{binary() => true}.
+overflow_attributes() ->
+    #{?OVERFLOW_KEY => true}.
+
+%% @doc Decide which attribute set a measurement should be recorded under.
+%%
+%%   * `Limit =< 0'           -> unlimited; always return `Attributes'
+%%   * `Exists =:= true'      -> series already counted; return `Attributes'
+%%   * not Exists and `CurrentCount >= Limit - 1' -> return overflow attributes
+%%   * otherwise              -> return `Attributes'
+-spec limit_attributes(Attributes, CurrentCount, Exists, Limit) -> Attributes | OverflowAttributes when
+      Attributes :: opentelemetry:attributes_map(),
+      CurrentCount :: non_neg_integer(),
+      Exists :: boolean(),
+      Limit :: integer(),
+      OverflowAttributes :: #{binary() => true}.
+limit_attributes(Attributes, _CurrentCount, _Exists, Limit) when Limit =< 0 ->
+    %% unlimited
+    Attributes;
+limit_attributes(Attributes, _CurrentCount, true, _Limit) ->
+    %% already-counted series are always allowed through; this is what lets the
+    %% single overflow series keep accumulating spillover measurements
+    Attributes;
+limit_attributes(_Attributes, CurrentCount, _Exists, Limit) when CurrentCount >= Limit - 1 ->
+    overflow_attributes();
+limit_attributes(Attributes, _CurrentCount, _Exists, _Limit) ->
+    Attributes.

--- a/apps/opentelemetry_experimental/src/otel_metric_reader.erl
+++ b/apps/opentelemetry_experimental/src/otel_metric_reader.erl
@@ -54,6 +54,7 @@
          streams_tab :: ets:table(),
          metrics_tab :: ets:table(),
          exemplars_tab :: ets:table(),
+         cardinality_limit :: integer(),
          config :: #{},
          resource :: otel_resource:t() | undefined,
          generation_ref :: atomics:atomics_ref(),
@@ -91,6 +92,7 @@ init([ReaderId, ProviderSup, Config]) ->
 
     DefaultAggregationMapping = maps:get(default_aggregation_mapping, Config, otel_aggregation:default_mapping()),
     Temporality = maps:get(default_temporality_mapping, Config, otel_aggregation:default_temporality_mapping()),
+    CardinalityLimit = maps:get(cardinality_limit, Config, otel_metric_cardinality:default_limit()),
 
     %% if a periodic reader is needed then this value is set
     %% somehow need to do a default of 10000 MILLIS, but only if this is a periodic reader
@@ -119,6 +121,7 @@ init([ReaderId, ProviderSup, Config]) ->
                 temporality_mapping=Temporality,
                 export_interval_ms=ExporterIntervalMs,
                 tref=TRef,
+                cardinality_limit=CardinalityLimit,
                 generation_ref=GenerationRef,
                 producers=[],
                 config=Config}, {continue, register_with_server}}.
@@ -126,12 +129,14 @@ init([ReaderId, ProviderSup, Config]) ->
 handle_continue(register_with_server, State=#state{provider_sup=ProviderSup,
                                                    id=ReaderId,
                                                    default_aggregation_mapping=DefaultAggregationMapping,
-                                                   temporality_mapping=Temporality}) ->
+                                                   temporality_mapping=Temporality,
+                                                   cardinality_limit=CardinalityLimit}) ->
     ServerPid = otel_meter_server_sup:provider_pid(ProviderSup),
     {CallbacksTab, StreamsTab, MetricsTab, ExemplarsTab, Resource, Producers} =
         otel_meter_server:add_metric_reader(ServerPid, ReaderId, self(),
                                             DefaultAggregationMapping,
-                                            Temporality),
+                                            Temporality,
+                                            CardinalityLimit),
     {noreply, State#state{callbacks_tab=CallbacksTab,
                           streams_tab=StreamsTab,
                           metrics_tab=MetricsTab,

--- a/apps/opentelemetry_experimental/src/otel_view.hrl
+++ b/apps/opentelemetry_experimental/src/otel_view.hrl
@@ -29,6 +29,11 @@
          %% temporality metrics
          forget :: boolean() | undefined,
 
+         %% the per-stream cardinality limit; the maximum number of distinct
+         %% attribute sets recorded before further sets overflow into a single
+         %% overflow series. `=< 0' disables the limit.
+         cardinality_limit :: integer() | undefined,
+
          %%
          exemplar_reservoir :: term()
         }).

--- a/apps/opentelemetry_experimental/test/otel_metric_cardinality_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_metric_cardinality_SUITE.erl
@@ -1,0 +1,210 @@
+%% Common Test integration suite for the metrics cardinality limit + overflow.
+%%
+%% Exercises the end-to-end behaviour through a real meter + reader, mirroring
+%% the intent of opentelemetry-go's aggregate overflow tests and
+%% opentelemetry-java's *SynchronousMetricStorage overflow tests:
+%%
+%%   * a reader-level `cardinality_limit` option caps distinct series per stream
+%%   * once the limit is reached, further distinct attribute sets are folded
+%%     into a single overflow series tagged {<<"otel.metric.overflow">>, true}
+%%   * the overflow series aggregates the spillover (sum / histogram count)
+%%   * an already-seen series keeps updating even after overflow has started
+%%   * `cardinality_limit => 0` disables the limit (Go semantics)
+%%   * the default limit (2000) does not overflow for a handful of series
+%%
+%% Reader config knob under test (to be implemented):
+%%   #{module => otel_metric_reader,
+%%     config => #{exporter => {otel_metric_exporter_pid, self()},
+%%                 cardinality_limit => N}}    %% N =< 0 disables; default 2000
+-module(otel_metric_cardinality_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("opentelemetry_api_experimental/include/otel_metrics.hrl").
+-include("otel_metrics.hrl").
+
+-define(OVERFLOW, #{<<"otel.metric.overflow">> => true}).
+
+all() ->
+    [counter_overflow,
+     existing_series_keeps_updating_after_overflow,
+     zero_limit_is_unlimited,
+     default_limit_does_not_overflow,
+     histogram_overflow].
+
+init_per_suite(Config) ->
+    application:load(opentelemetry_experimental),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(TestCase, Config) ->
+    application:load(opentelemetry_experimental),
+    CardinalityOpts =
+        case TestCase of
+            zero_limit_is_unlimited        -> #{cardinality_limit => 0};
+            default_limit_does_not_overflow -> #{};            %% rely on default 2000
+            _                              -> #{cardinality_limit => 3}
+        end,
+    ReaderConfig = maps:merge(#{exporter => {otel_metric_exporter_pid, self()},
+                                default_temporality_mapping => default_temporality_mapping()},
+                              CardinalityOpts),
+    ok = application:set_env(opentelemetry_experimental, readers,
+                             [#{module => otel_metric_reader,
+                                config => ReaderConfig}]),
+    {ok, _} = application:ensure_all_started(opentelemetry_experimental),
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok = application:stop(opentelemetry_experimental),
+    _ = application:unload(opentelemetry_experimental),
+    ok.
+
+%% limit => 3 means 2 real series are allowed; the 3rd+ distinct sets overflow
+%% and their values are summed into the single overflow series.
+counter_overflow(_Config) ->
+    Meter = opentelemetry_experimental:get_meter(),
+    Name = overflow_counter,
+    Desc = <<"counter description">>,
+    Unit = kb,
+    _ = otel_counter:create(Meter, Name, #{description => Desc, unit => Unit}),
+    Ctx = otel_ctx:new(),
+
+    ok = otel_counter:add(Ctx, Meter, Name, 1, #{<<"k">> => <<"s1">>}),
+    ok = otel_counter:add(Ctx, Meter, Name, 2, #{<<"k">> => <<"s2">>}),
+    %% s3 and s4 exceed the 2-real-series budget -> overflow (4 + 8 = 12)
+    ok = otel_counter:add(Ctx, Meter, Name, 4, #{<<"k">> => <<"s3">>}),
+    ok = otel_counter:add(Ctx, Meter, Name, 8, #{<<"k">> => <<"s4">>}),
+
+    otel_meter_server:force_flush(),
+
+    Datapoints = recv_sum(Name),
+    ?assertEqual(lists:sort([{1, #{<<"k">> => <<"s1">>}},
+                             {2, #{<<"k">> => <<"s2">>}},
+                             {12, ?OVERFLOW}]),
+                 lists:sort(Datapoints)).
+
+%% A series that was admitted before the limit was hit must keep updating even
+%% after overflow has begun; only *new* distinct sets are redirected.
+existing_series_keeps_updating_after_overflow(_Config) ->
+    Meter = opentelemetry_experimental:get_meter(),
+    Name = existing_after_overflow_counter,
+    Desc = <<"counter description">>,
+    Unit = kb,
+    _ = otel_counter:create(Meter, Name, #{description => Desc, unit => Unit}),
+    Ctx = otel_ctx:new(),
+
+    ok = otel_counter:add(Ctx, Meter, Name, 1, #{<<"k">> => <<"s1">>}),
+    ok = otel_counter:add(Ctx, Meter, Name, 2, #{<<"k">> => <<"s2">>}),
+    ok = otel_counter:add(Ctx, Meter, Name, 4, #{<<"k">> => <<"s3">>}),  %% overflow
+    ok = otel_counter:add(Ctx, Meter, Name, 10, #{<<"k">> => <<"s1">>}), %% existing -> s1 = 11
+    ok = otel_counter:add(Ctx, Meter, Name, 8, #{<<"k">> => <<"s4">>}),  %% overflow -> 4 + 8 = 12
+
+    otel_meter_server:force_flush(),
+
+    Datapoints = recv_sum(Name),
+    ?assertEqual(lists:sort([{11, #{<<"k">> => <<"s1">>}},
+                             {2, #{<<"k">> => <<"s2">>}},
+                             {12, ?OVERFLOW}]),
+                 lists:sort(Datapoints)).
+
+%% cardinality_limit => 0 disables the cap: every distinct set gets its own
+%% series and no overflow series is produced.
+zero_limit_is_unlimited(_Config) ->
+    Meter = opentelemetry_experimental:get_meter(),
+    Name = unlimited_counter,
+    Desc = <<"counter description">>,
+    Unit = kb,
+    _ = otel_counter:create(Meter, Name, #{description => Desc, unit => Unit}),
+    Ctx = otel_ctx:new(),
+
+    Sets = [{N, #{<<"k">> => integer_to_binary(N)}} || N <- lists:seq(1, 6)],
+    [ok = otel_counter:add(Ctx, Meter, Name, N, Attrs) || {N, Attrs} <- Sets],
+
+    otel_meter_server:force_flush(),
+
+    Datapoints = recv_sum(Name),
+    ?assertEqual(lists:sort(Sets), lists:sort(Datapoints)),
+    ?assertNot(has_overflow(Datapoints)).
+
+%% With no cardinality_limit configured the default (2000) applies, so a
+%% handful of series must all be recorded individually with no overflow.
+default_limit_does_not_overflow(_Config) ->
+    Meter = opentelemetry_experimental:get_meter(),
+    Name = default_limit_counter,
+    Desc = <<"counter description">>,
+    Unit = kb,
+    _ = otel_counter:create(Meter, Name, #{description => Desc, unit => Unit}),
+    Ctx = otel_ctx:new(),
+
+    Sets = [{N, #{<<"k">> => integer_to_binary(N)}} || N <- lists:seq(1, 5)],
+    [ok = otel_counter:add(Ctx, Meter, Name, N, Attrs) || {N, Attrs} <- Sets],
+
+    otel_meter_server:force_flush(),
+
+    Datapoints = recv_sum(Name),
+    ?assertEqual(lists:sort(Sets), lists:sort(Datapoints)),
+    ?assertNot(has_overflow(Datapoints)).
+
+%% Histograms overflow the same way: spillover measurements land in a single
+%% overflow histogram series whose count equals the number of overflowed records.
+histogram_overflow(_Config) ->
+    Meter = opentelemetry_experimental:get_meter(),
+    Name = overflow_histogram,
+    Desc = <<"histogram description">>,
+    Unit = ms,
+    _ = otel_meter:create_histogram(Meter, Name, #{description => Desc, unit => Unit}),
+    Ctx = otel_ctx:new(),
+
+    ok = otel_histogram:record(Ctx, Meter, Name, 1, #{<<"k">> => <<"s1">>}),
+    ok = otel_histogram:record(Ctx, Meter, Name, 2, #{<<"k">> => <<"s2">>}),
+    %% two overflowing records -> overflow series count = 2
+    ok = otel_histogram:record(Ctx, Meter, Name, 5, #{<<"k">> => <<"s3">>}),
+    ok = otel_histogram:record(Ctx, Meter, Name, 7, #{<<"k">> => <<"s4">>}),
+
+    otel_meter_server:force_flush(),
+
+    Counts = recv_histogram_counts(Name),
+    %% overflow series present with a combined count of 2
+    ?assertEqual(2, proplists:get_value(?OVERFLOW, Counts)),
+    %% and the two real series are still there individually
+    ?assertEqual(1, proplists:get_value(#{<<"k">> => <<"s1">>}, Counts)),
+    ?assertEqual(1, proplists:get_value(#{<<"k">> => <<"s2">>}, Counts)).
+
+%% --- helpers ----------------------------------------------------------------
+
+%% Receive a sum metric for Name and return [{Value, Attributes}].
+recv_sum(Name) ->
+    receive
+        {otel_metric, #metric{name = MetricName, data = #sum{datapoints = DPs}}}
+          when MetricName =:= Name ->
+            [{V, A} || #datapoint{value = V, attributes = A} <- DPs]
+    after
+        5000 ->
+            ct:fail({metric_receive_timeout, Name})
+    end.
+
+%% Receive a histogram metric for Name and return [{Attributes, Count}].
+recv_histogram_counts(Name) ->
+    receive
+        {otel_metric, #metric{name = MetricName, data = #histogram{datapoints = DPs}}}
+          when MetricName =:= Name ->
+            [{A, C} || #histogram_datapoint{attributes = A, count = C} <- DPs]
+    after
+        5000 ->
+            ct:fail({metric_receive_timeout, Name})
+    end.
+
+has_overflow(Datapoints) ->
+    lists:any(fun({_V, Attrs}) -> Attrs =:= ?OVERFLOW end, Datapoints).
+
+default_temporality_mapping() ->
+    #{?KIND_COUNTER => ?TEMPORALITY_DELTA,
+      ?KIND_OBSERVABLE_COUNTER => ?TEMPORALITY_CUMULATIVE,
+      ?KIND_UPDOWN_COUNTER => ?TEMPORALITY_DELTA,
+      ?KIND_OBSERVABLE_UPDOWNCOUNTER => ?TEMPORALITY_CUMULATIVE,
+      ?KIND_HISTOGRAM => ?TEMPORALITY_DELTA,
+      ?KIND_OBSERVABLE_GAUGE => ?TEMPORALITY_CUMULATIVE}.

--- a/apps/opentelemetry_experimental/test/otel_metric_cardinality_tests.erl
+++ b/apps/opentelemetry_experimental/test/otel_metric_cardinality_tests.erl
@@ -1,0 +1,91 @@
+%% EUnit tests for the pure cardinality-limit decision helper.
+%%
+%% These mirror the "meat" of opentelemetry-go's
+%% sdk/metric/internal/aggregate/limit_test.go (TestLimiterAttributes) and the
+%% cardinality-limit semantics shared by opentelemetry-java
+%% (MetricStorage.DEFAULT_MAX_CARDINALITY / CARDINALITY_OVERFLOW).
+%%
+%% Contract under test (designed for this repo's ETS-keyed aggregation, where
+%% the caller supplies the current distinct-series count and an existence flag
+%% rather than passing a whole map like Go does):
+%%
+%%   otel_metric_cardinality:limit_attributes(Attributes, CurrentCount, Exists, Limit)
+%%       -> Attributes | OverflowAttributes
+%%
+%%     * Limit =< 0          -> unlimited; always return Attributes (Go semantics)
+%%     * Exists =:= true     -> series already counted; return Attributes
+%%     * not Exists and CurrentCount >= Limit - 1 -> return OverflowAttributes
+%%     * otherwise           -> return Attributes
+%%
+%%   otel_metric_cardinality:overflow_attributes() -> #{<<"otel.metric.overflow">> => true}
+%%   otel_metric_cardinality:default_limit()       -> 2000
+%%
+%% The `Limit - 1` reservation matches Go's `len(measurements) >= aggLimit-1`:
+%% with limit N you get up to N-1 real series plus 1 overflow series (N total).
+-module(otel_metric_cardinality_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+alice() -> #{<<"user">> => <<"alice">>}.
+bob()   -> #{<<"user">> => <<"bob">>}.
+
+overflow() -> #{<<"otel.metric.overflow">> => true}.
+
+limit(Attrs, Count, Exists, Limit) ->
+    otel_metric_cardinality:limit_attributes(Attrs, Count, Exists, Limit).
+
+%% --- Go limit_test.go parity -------------------------------------------------
+%% Go's measurement map always holds exactly one entry (alice), so across these
+%% cases CurrentCount = 1 and Exists = (Attrs == alice).
+
+%% t.Run("NoLimit")
+no_limit_test() ->
+    ?assertEqual(alice(), limit(alice(), 1, true, 0)),
+    ?assertEqual(bob(),   limit(bob(),   1, false, 0)).
+
+%% t.Run("NotAtLimit/Exists")
+not_at_limit_exists_test() ->
+    ?assertEqual(alice(), limit(alice(), 1, true, 3)).
+
+%% t.Run("NotAtLimit/DoesNotExist")
+not_at_limit_new_test() ->
+    ?assertEqual(bob(), limit(bob(), 1, false, 3)).
+
+%% t.Run("AtLimit/Exists")
+at_limit_exists_test() ->
+    ?assertEqual(alice(), limit(alice(), 1, true, 2)).
+
+%% t.Run("AtLimit/DoesNotExist")
+at_limit_new_test() ->
+    ?assertEqual(overflow(), limit(bob(), 1, false, 2)).
+
+%% --- contract extras ---------------------------------------------------------
+
+%% With limit N only N-1 distinct real series are allowed; the Nth distinct set
+%% overflows. (One slot reserved for the overflow series itself.)
+reserves_one_slot_for_overflow_test() ->
+    %% limit 3 => 2 real series allowed
+    ?assertEqual(bob(),      limit(bob(), 1, false, 3)),   %% count 1 < 2 -> allowed
+    ?assertEqual(overflow(), limit(bob(), 2, false, 3)).   %% count 2 >= 2 -> overflow
+
+%% Once an attribute set is already present it is always allowed through,
+%% regardless of how far over the limit the count is. This is what lets the
+%% single overflow series keep accumulating spillover measurements.
+existing_series_always_allowed_test() ->
+    ?assertEqual(overflow(), limit(overflow(), 50, true, 3)),
+    ?assertEqual(alice(),    limit(alice(),   50, true, 3)).
+
+%% A negative limit is treated the same as 0 (unlimited), per Go semantics.
+negative_limit_is_unlimited_test() ->
+    ?assertEqual(bob(), limit(bob(), 999999, false, -1)).
+
+%% limit of 1 means zero real series: the very first distinct set overflows.
+limit_one_overflows_immediately_test() ->
+    ?assertEqual(overflow(), limit(alice(), 0, false, 1)).
+
+default_limit_is_2000_test() ->
+    ?assertEqual(2000, otel_metric_cardinality:default_limit()).
+
+overflow_marker_attribute_test() ->
+    ?assertEqual(#{<<"otel.metric.overflow">> => true},
+                 otel_metric_cardinality:overflow_attributes()).


### PR DESCRIPTION
Adds a per-stream cardinality limit to the metrics SDK. When the number of distinct attribute sets for a stream reaches the limit, further distinct sets are folded into a single overflow series tagged
`#{<<"otel.metric.overflow">> => true}`, matching the OpenTelemetry spec and the Go/Java SDKs.

- otel_metric_cardinality: pure decision helper (default limit 2000, overflow attributes, limit_attributes/4). A limit =< 0 disables the cap (Go semantics).
- otel_aggregation: applies the limit on the new-series cold path of maybe_init_aggregate/6, redirecting spillover into the overflow series.
- otel_metric_reader / otel_meter_server: thread a reader-level `cardinality_limit` option (default 2000) into each #stream{}.

Applies uniformly across sum, last_value, and explicit histogram aggregations.

Tests: otel_metric_cardinality_tests (EUnit, 11 cases mirroring opentelemetry-go limit_test.go) and otel_metric_cardinality_SUITE (CT, 5 end-to-end cases).