### PR TITLE
fix: decode hex trace and span ids in OTLP log records

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
+++ b/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
@@ -90,22 +90,15 @@ log_record(#{level := Level,
     Flags = 0,
 
     %% Note: otel_trace_id and otel_span_id from hex_span_ctx are now binaries, not charlists.
+    %% They are hex encoded, but the OTLP trace_id and span_id fields are the
+    %% raw 16/8 bytes, so they must be decoded before being put in the
+    %% LogRecord. If either id can't be decoded then the correlation fields
+    %% are omitted entirely rather than exporting garbage ids.
     LogRecord = case Metadata of
-        #{otel_trace_id := TraceId,
-          otel_span_id := SpanId,
-          otel_trace_flags := TraceFlagsHex} ->
-            TraceFlags = case TraceFlagsHex of
-                <<_:0, _/binary>> when byte_size(TraceFlagsHex) == 2 ->
-                    erlang:binary_to_integer(TraceFlagsHex, 16);
-                _ -> 0
-            end,
-            #{trace_id => TraceId,
-              span_id => SpanId,
-              trace_flags => TraceFlags};
-        #{otel_trace_id := TraceId,
-          otel_span_id := SpanId} ->
-            #{trace_id => TraceId,
-              span_id => SpanId};
+        #{otel_trace_id := MetaTraceId,
+          otel_span_id := MetaSpanId} ->
+            correlation_fields(MetaTraceId, MetaSpanId,
+                               maps:get(otel_trace_flags, Metadata, undefined));
         _ ->
             #{}
     end,
@@ -121,6 +114,82 @@ log_record(#{level := Level,
                dropped_attributes_count => DroppedAttributesCount,
                flags                   => Flags
               }.
+
+%% Decode a trace or span id from logger metadata into the raw bytes the
+%% OTLP LogRecord expects. The metadata value is a lowercase hex encoded
+%% binary when set by `otel_span:hex_span_ctx/1' (a hex encoded charlist
+%% in older versions of the API) but raw ids are also accepted in case
+%% the user set the metadata themselves.
+%% Decode both correlation ids together: either both are valid and the
+%% correlation fields are returned (trace_flags added only when the
+%% metadata carried it), or all correlation fields are omitted.
+correlation_fields(MetaTraceId, MetaSpanId, TraceFlagsHex) ->
+    case {decode_id(MetaTraceId, 16), decode_id(MetaSpanId, 8)} of
+        {{ok, TraceId}, {ok, SpanId}} ->
+            Base = #{trace_id => TraceId,
+                     span_id => SpanId},
+            case decode_trace_flags(TraceFlagsHex) of
+                undefined ->
+                    Base;
+                TraceFlags ->
+                    Base#{trace_flags => TraceFlags}
+            end;
+        _ ->
+            #{}
+    end.
+
+%% Absent flags metadata omits the field entirely; present but
+%% malformed flags (wrong size, non-binary, non-hex digits) fall back
+%% to 0 rather than raising from binary_to_integer/2.
+decode_trace_flags(undefined) ->
+    undefined;
+decode_trace_flags(TraceFlagsHex) when is_binary(TraceFlagsHex),
+                                       byte_size(TraceFlagsHex) =:= 2 ->
+    try
+        erlang:binary_to_integer(TraceFlagsHex, 16)
+    catch
+        _:_ ->
+            0
+    end;
+decode_trace_flags(_) ->
+    0.
+
+-spec decode_id(term(), pos_integer()) -> {ok, binary()} | error.
+decode_id(Id, NumBytes) when is_list(Id) ->
+    %% logger metadata is arbitrary user data: characters_to_binary/1
+    %% raises badarg for non-chardata lists (improper lists, atoms in
+    %% lists), which must omit the ids rather than crash the export.
+    try unicode:characters_to_binary(Id) of
+        Bin when is_binary(Bin) ->
+            decode_id(Bin, NumBytes);
+        _ ->
+            error
+    catch
+        _:_ ->
+            error
+    end;
+decode_id(Id, NumBytes) when is_binary(Id), byte_size(Id) =:= NumBytes ->
+    %% already the raw bytes
+    {ok, Id};
+decode_id(Id, NumBytes) when is_binary(Id), byte_size(Id) =:= 2 * NumBytes ->
+    try
+        {ok, decode_hex(Id)}
+    catch
+        _:_ ->
+            error
+    end;
+decode_id(_, _) ->
+    error.
+
+%% binary:decode_hex/1 requires OTP 24 and only accepts mixed case hex
+%% digits starting from OTP 26.2, so decode by hand like
+%% otel_utils:encode_hex/1 does for encoding on older OTP versions.
+decode_hex(Hex) ->
+    << <<(hex_nibble(Nibble)):4>> || <<Nibble>> <= Hex >>.
+
+hex_nibble(N) when N >= $0, N =< $9 -> N - $0;
+hex_nibble(N) when N >= $a, N =< $f -> N - $a + 10;
+hex_nibble(N) when N >= $A, N =< $F -> N - $A + 10.
 
 format_msg({string, Chardata}, Meta, Config) ->
     format_msg({"~ts", [Chardata]}, Meta, Config);

--- a/apps/opentelemetry_experimental/test/otel_otlp_logs_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_otlp_logs_SUITE.erl
@@ -1,0 +1,137 @@
+-module(otel_otlp_logs_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
+
+-define(TRACE_ID, <<16#abcdef0123456789abcdef0123456789:128>>).
+-define(SPAN_ID, <<16#a1b2c3d4e5f60718:64>>).
+-define(HEX_TRACE_ID, <<"abcdef0123456789abcdef0123456789">>).
+-define(HEX_SPAN_ID, <<"a1b2c3d4e5f60718">>).
+
+all() ->
+    [hex_binary_ids,
+     uppercase_hex_binary_ids,
+     charlist_ids,
+     raw_binary_ids,
+     ids_without_trace_flags,
+     non_hex_ids_dropped,
+     wrong_size_ids_dropped,
+     partially_invalid_ids_dropped,
+     no_span_ctx_metadata,
+     non_chardata_list_ids_dropped,
+     non_hex_trace_flags_default_to_zero].
+
+%% ids set by `otel_span:hex_span_ctx/1' are lowercase hex binaries and
+%% must be decoded to the raw bytes the OTLP LogRecord expects
+hex_binary_ids(_Config) ->
+    LogRecord = export_log_record(#{otel_trace_id => ?HEX_TRACE_ID,
+                                    otel_span_id => ?HEX_SPAN_ID,
+                                    otel_trace_flags => <<"01">>}),
+    ?assertMatch(#{trace_id := ?TRACE_ID,
+                   span_id := ?SPAN_ID,
+                   trace_flags := 1}, LogRecord).
+
+uppercase_hex_binary_ids(_Config) ->
+    LogRecord = export_log_record(#{otel_trace_id => <<"ABCDEF0123456789ABCDEF0123456789">>,
+                                    otel_span_id => <<"A1B2C3D4E5F60718">>,
+                                    otel_trace_flags => <<"01">>}),
+    ?assertMatch(#{trace_id := ?TRACE_ID,
+                   span_id := ?SPAN_ID,
+                   trace_flags := 1}, LogRecord).
+
+%% older versions of `otel_span:hex_span_ctx/1' returned charlists
+charlist_ids(_Config) ->
+    LogRecord = export_log_record(#{otel_trace_id => "abcdef0123456789abcdef0123456789",
+                                    otel_span_id => "a1b2c3d4e5f60718",
+                                    otel_trace_flags => <<"01">>}),
+    ?assertMatch(#{trace_id := ?TRACE_ID,
+                   span_id := ?SPAN_ID,
+                   trace_flags := 1}, LogRecord).
+
+%% raw ids pass through unchanged
+raw_binary_ids(_Config) ->
+    LogRecord = export_log_record(#{otel_trace_id => ?TRACE_ID,
+                                    otel_span_id => ?SPAN_ID,
+                                    otel_trace_flags => <<"00">>}),
+    ?assertMatch(#{trace_id := ?TRACE_ID,
+                   span_id := ?SPAN_ID,
+                   trace_flags := 0}, LogRecord).
+
+ids_without_trace_flags(_Config) ->
+    LogRecord = export_log_record(#{otel_trace_id => ?HEX_TRACE_ID,
+                                    otel_span_id => ?HEX_SPAN_ID}),
+    ?assertMatch(#{trace_id := ?TRACE_ID,
+                   span_id := ?SPAN_ID}, LogRecord),
+    ?assertNot(maps:is_key(trace_flags, LogRecord)).
+
+%% ids that can't be decoded must be dropped, along with the trace
+%% flags, instead of being exported as garbage
+non_hex_ids_dropped(_Config) ->
+    LogRecord = export_log_record(#{otel_trace_id => binary:copy(<<"zz">>, 16),
+                                    otel_span_id => binary:copy(<<"zz">>, 8),
+                                    otel_trace_flags => <<"01">>}),
+    assert_no_span_ctx(LogRecord).
+
+wrong_size_ids_dropped(_Config) ->
+    %% odd number of hex digits
+    LogRecord = export_log_record(#{otel_trace_id => <<"abcdef0123456789abcdef012345678">>,
+                                    otel_span_id => <<"a1b2c3d4e5f6071">>,
+                                    otel_trace_flags => <<"01">>}),
+    assert_no_span_ctx(LogRecord).
+
+partially_invalid_ids_dropped(_Config) ->
+    %% a valid trace id with an invalid span id must drop both ids
+    LogRecord = export_log_record(#{otel_trace_id => ?HEX_TRACE_ID,
+                                    otel_span_id => <<"not a span id">>,
+                                    otel_trace_flags => <<"01">>}),
+    assert_no_span_ctx(LogRecord).
+
+no_span_ctx_metadata(_Config) ->
+    LogRecord = export_log_record(#{}),
+    assert_no_span_ctx(LogRecord),
+    %% the rest of the LogRecord is built as usual
+    ?assertMatch(#{body := _,
+                   severity_number := 'SEVERITY_NUMBER_INFO',
+                   time_unix_nano := _}, LogRecord).
+
+%%
+
+export_log_record(SpanCtxMetadata) ->
+    Metadata = SpanCtxMetadata#{time => erlang:system_time(microsecond)},
+    LogEvent = #{level => info,
+                 msg => {string, "hello"},
+                 meta => Metadata},
+    Scope = #instrumentation_scope{name = <<"test_scope">>,
+                                   version = <<"1.0.0">>},
+    Resource = otel_resource:create([]),
+    #{resource_logs :=
+          [#{scope_logs :=
+                 [#{log_records := [LogRecord]}]}]} =
+        otel_otlp_logs:to_proto(#{Scope => [LogEvent]}, Resource, #{}),
+    LogRecord.
+
+assert_no_span_ctx(LogRecord) ->
+    ?assertNot(maps:is_key(trace_id, LogRecord)),
+    ?assertNot(maps:is_key(span_id, LogRecord)),
+    ?assertNot(maps:is_key(trace_flags, LogRecord)).
+
+non_chardata_list_ids_dropped(_Config) ->
+    LogRecord = export_log_record(#{otel_trace_id => [an_atom, "abc"],
+                                    otel_span_id => "6d4d6b6532a1c2d3"}),
+    ?assertNot(maps:is_key(trace_id, LogRecord)),
+    ?assertNot(maps:is_key(span_id, LogRecord)),
+    ok.
+
+non_hex_trace_flags_default_to_zero(_Config) ->
+    %% present-but-garbage flags must not raise from binary_to_integer/2.
+    LogRecord = export_log_record(#{otel_trace_id => <<"00112233445566778899aabbccddeeff">>,
+                                    otel_span_id => <<"0011223344556677">>,
+                                    otel_trace_flags => <<"zz">>}),
+    ?assertEqual(<<16#00112233445566778899aabbccddeeff:128>>, maps:get(trace_id, LogRecord)),
+    ?assertEqual(<<16#0011223344556677:64>>, maps:get(span_id, LogRecord)),
+    ?assertEqual(0, maps:get(trace_flags, LogRecord)),
+    ok.


### PR DESCRIPTION
# fix: decode hex trace and span ids in OTLP log records

Fixes #<issue-number>.

## What / Why

The OTLP `LogRecord.trace_id` / `LogRecord.span_id` fields are raw bytes
(16 / 8) on the wire, but `otel_otlp_logs:log_record/2` copied the
`otel_trace_id` / `otel_span_id` logger metadata — the 32/16-char lowercase hex
binaries produced by `otel_span:hex_span_ctx/1` — verbatim into the proto map.
Every OTLP backend therefore received ASCII hex as the id bytes and stored
"double-hexed" 64-char trace ids, silently breaking trace↔log correlation for
all Erlang/Elixir applications using the experimental OTLP log exporter.

The same block already hex-decodes `otel_trace_flags`
(`erlang:binary_to_integer(TraceFlagsHex, 16)`); the ids were simply missed.
The traces exporter shows the expected representation:
`otel_otlp_traces.erl` encodes `trace_id => <<TraceId:128>>`,
`span_id => <<SpanId:64>>`.

## The fix

`log_record/2` now decodes the id metadata to raw bytes before building the
LogRecord, via a new private `decode_id/2`:

- lowercase **or** uppercase hex binary of exactly 2N chars → N raw bytes;
- hex charlist (what older versions of `otel_span:hex_span_ctx/1` returned —
  the existing code comment in this function already notes the
  charlist→binary change) → converted to binary, then decoded;
- already-raw N-byte binary → passed through unchanged;
- anything else / decode failure → `trace_id`, `span_id` **and** `trace_flags`
  are omitted from the LogRecord entirely, rather than exporting garbage ids
  (an absent id is "invalid/unset" per the proto docs; a wrong-length or
  ASCII id is corrupt data).

The hex decode is hand-rolled (a 5-line nibble comprehension) instead of using
`binary:decode_hex/1` because that BIF requires OTP 24 and only handles mixed
case from OTP 26.2, while this repo still documents OTP 23+ support
(README "Erlang/OTP 23+") — same approach as the version-conditional fallbacks
in `otel_utils:encode_hex/1`.

## Test coverage

New `apps/opentelemetry_experimental/test/otel_otlp_logs_SUITE.erl`
(9 cases, exercised through `otel_otlp_logs:to_proto/3`):

- lowercase hex binary ids → exact raw bytes (+ `trace_flags` 1 from `<<"01">>`)
- uppercase hex binary ids → exact raw bytes
- charlist ids → exact raw bytes
- already-raw binary ids → passed through
- ids present without `otel_trace_flags` → ids decoded, no `trace_flags` key
- non-hex ids of the correct length → all three fields omitted
- wrong-length (odd) ids → all three fields omitted
- valid trace id + invalid span id → both ids (and flags) omitted
- no span-ctx metadata → no id fields, rest of the LogRecord unchanged

`rebar3 ct --suite apps/opentelemetry_experimental/test/otel_otlp_logs_SUITE`:
all 9 pass. The pre-existing experimental metric suites and `rebar3 xref` are
unaffected.

## Backward compatibility

- Anyone who worked around this locally by putting **raw** 16/8-byte ids into
  `otel_trace_id`/`otel_span_id` metadata is unaffected: raw ids pass through
  unchanged.
- Consumers that adapted to the buggy double-hex ids on the backend side will
  see correctly correlated ids after upgrading (i.e. the bug stops being
  observable — that is the point of the fix).
- Records whose metadata cannot be decoded now omit the correlation fields
  instead of carrying corrupt ids; the rest of the LogRecord is exported as
  before.
- No public API changes; the new functions are private to `otel_otlp_logs`.


Fixes #1000
