### PR TITLE
fix(experimental): keep otel_log_handler exporting after an idle interval

### DIFF
--- a/apps/opentelemetry_experimental/src/otel_log_handler.erl
+++ b/apps/opentelemetry_experimental/src/otel_log_handler.erl
@@ -189,6 +189,12 @@ exporting(internal, export, Data=#data{exporter=Exporter,
                                        batch=Batch}) when map_size(Batch) =/= 0 ->
     _ = export(Exporter, Resource, Batch, Config),
     {next_state, idle, Data#data{batch=#{}}};
+exporting(internal, export, Data=#data{batch=Batch}) when map_size(Batch) =:= 0 ->
+    %% Nothing accumulated this interval. Return to `idle` so its `enter` clause
+    %% re-arms the export timer. Without this clause an empty tick falls through
+    %% to `handle_event/3` (`keep_state_and_data`) and the handler stays in
+    %% `exporting` forever, never exporting again after the first idle interval.
+    {next_state, idle, Data};
 exporting(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
 

--- a/apps/opentelemetry_experimental/test/otel_log_handler_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_log_handler_SUITE.erl
@@ -1,0 +1,72 @@
+-module(otel_log_handler_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    [exports_logs_after_idle_interval].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(opentelemetry_experimental),
+    OldPrimary = logger:get_primary_config(),
+    ok = logger:update_primary_config(#{level => info}),
+    [{old_primary, OldPrimary} | Config].
+
+end_per_suite(Config) ->
+    ok = logger:set_primary_config(?config(old_primary, Config)),
+    _ = application:stop(opentelemetry_experimental),
+    ok.
+
+%% Regression test for the empty-batch wedge: an export interval that elapses
+%% with no buffered logs must not stop the handler from exporting later logs.
+%%
+%% Before the fix, the first `export_logs` tick that fired with an empty batch
+%% fell through to `handle_event/3` (`keep_state_and_data`) and left the
+%% `gen_statem` parked in the `exporting` state. Because only the `idle` state
+%% re-arms the export timer, the handler never exported again after the first
+%% idle interval.
+exports_logs_after_idle_interval(_Config) ->
+    HandlerId = ?FUNCTION_NAME,
+    ok = logger:add_handler(HandlerId, otel_log_handler,
+                            #{level => info,
+                              exporter => {?MODULE, {logs, self()}},
+                              scheduled_delay_ms => 1}),
+
+    %% Let several export intervals elapse with no logs — the condition that
+    %% used to wedge the handler.
+    timer:sleep(200),
+    ok = flush(),
+
+    %% A log emitted after the idle period must still be exported.
+    logger:log(info, "post-idle log line", #{}),
+
+    try
+        receive
+            {logs, _Batch} -> ok
+        after
+            5000 -> ct:fail(no_export_after_idle_interval)
+        end
+    after
+        _ = logger:remove_handler(HandlerId)
+    end.
+
+flush() ->
+    receive
+        {logs, _} -> flush()
+    after
+        0 -> ok
+    end.
+
+%% --- otel_exporter test double (logs signal) ---
+init({logs, Pid}) ->
+    {ok, Pid}.
+
+export(logs, Data, _Resource, Pid) ->
+    Pid ! {logs, Data},
+    ok;
+export(_Otel, _Data, _Resource, _Pid) ->
+    ok.
+
+shutdown(_) ->
+    ok.

--- a/apps/opentelemetry_experimental/test/otel_log_handler_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_log_handler_SUITE.erl
@@ -62,10 +62,8 @@ flush() ->
 init({logs, Pid}) ->
     {ok, Pid}.
 
-export(logs, Data, _Resource, Pid) ->
-    Pid ! {logs, Data},
-    ok;
-export(_Otel, _Data, _Resource, _Pid) ->
+export(Logs, _Resource, Pid) ->
+    Pid ! {logs, Logs},
     ok.
 
 shutdown(_) ->

--- a/apps/opentelemetry_experimental/test/otel_log_handler_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_log_handler_SUITE.erl
@@ -1,0 +1,70 @@
+-module(otel_log_handler_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    [exports_logs_after_idle_interval].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(opentelemetry_experimental),
+    OldPrimary = logger:get_primary_config(),
+    ok = logger:update_primary_config(#{level => info}),
+    [{old_primary, OldPrimary} | Config].
+
+end_per_suite(Config) ->
+    ok = logger:set_primary_config(?config(old_primary, Config)),
+    _ = application:stop(opentelemetry_experimental),
+    ok.
+
+%% Regression test for the empty-batch wedge: an export interval that elapses
+%% with no buffered logs must not stop the handler from exporting later logs.
+%%
+%% Before the fix, the first `export_logs` tick that fired with an empty batch
+%% fell through to `handle_event/3` (`keep_state_and_data`) and left the
+%% `gen_statem` parked in the `exporting` state. Because only the `idle` state
+%% re-arms the export timer, the handler never exported again after the first
+%% idle interval.
+exports_logs_after_idle_interval(_Config) ->
+    HandlerId = ?FUNCTION_NAME,
+    ok = logger:add_handler(HandlerId, otel_log_handler,
+                            #{level => info,
+                              exporter => {?MODULE, {logs, self()}},
+                              scheduled_delay_ms => 1}),
+
+    %% Let several export intervals elapse with no logs — the condition that
+    %% used to wedge the handler.
+    timer:sleep(200),
+    ok = flush(),
+
+    %% A log emitted after the idle period must still be exported.
+    logger:log(info, "post-idle log line", #{}),
+
+    try
+        receive
+            {logs, _Batch} -> ok
+        after
+            5000 -> ct:fail(no_export_after_idle_interval)
+        end
+    after
+        _ = logger:remove_handler(HandlerId)
+    end.
+
+flush() ->
+    receive
+        {logs, _} -> flush()
+    after
+        0 -> ok
+    end.
+
+%% --- otel_exporter test double (logs signal) ---
+init({logs, Pid}) ->
+    {ok, Pid}.
+
+export(Logs, _Resource, Pid) ->
+    Pid ! {logs, Logs},
+    ok.
+
+shutdown(_) ->
+    ok.


### PR DESCRIPTION
## Problem

`otel_log_handler` stops exporting logs after the first export interval that elapses with an empty batch.

The handler is a `gen_statem`. Only the `idle` state arms the `export_logs` timer (in its `enter` clause). On a tick it transitions `idle -> exporting` with `{next_event, internal, export}`. The `exporting` state handles the export like this:

```erlang
exporting(internal, export, Data=#data{exporter=Exporter, ... batch=Batch}) when map_size(Batch) =/= 0 ->
    _ = export(Exporter, Resource, Batch, Config),
    {next_state, idle, Data#data{batch=#{}}};
exporting(EventType, EventContent, Data) ->
    handle_event(EventType, EventContent, Data).
```

When the batch is **empty**, the guarded clause doesn't match and the event falls through to `handle_event/3`, which returns `keep_state_and_data`. The state machine therefore stays in `exporting` and never returns to `idle` — so the timer is never re-armed. From that point on, `handle_event(cast, {log, ...})` keeps appending to the batch, but the `internal, export` event that drains it is never generated again. **All subsequent logs are buffered forever and never exported.**

## Impact

Any service that isn't continuously logging faster than `scheduled_delay_ms` hits this almost immediately: the first idle interval wedges the handler and log export silently stops. We hit this in production (an Elixir/Phoenix service): logs flowed for the first interval, then stopped.

## Fix

Add an `exporting/3` clause for the empty-batch case that returns to `idle`, re-arming the timer:

```erlang
exporting(internal, export, Data=#data{batch=Batch}) when map_size(Batch) =:= 0 ->
    {next_state, idle, Data};
```

## Test

Adds `otel_log_handler_SUITE` with a regression test: it lets several export intervals elapse with no logs, then emits one log and asserts it is exported within a timeout. Without the fix the handler is wedged and the test times out.

## Validation

Verified against the released `opentelemetry_experimental` 0.5.1 in a downstream Elixir app: a probe test that logs *after* an idle period failed (log never exported) before the fix and passes after applying this exact clause.

## Relationship to #671

#671 rewrites the batch/handler machinery wholesale (via `otel_batch_olp`) and would also resolve this, but it has been open since 2023. This is a minimal, self-contained fix that is safe to land independently and ship in a patch release while #671 is pending.
