### PR TITLE
fix(api): accept W3C Trace Context Level 2 tracestate key grammar

### DIFF
--- a/apps/opentelemetry_api/src/otel_tracestate.erl
+++ b/apps/opentelemetry_api/src/otel_tracestate.erl
@@ -42,7 +42,7 @@
 -export_type([t/0,
               members/0]).
 
-%% See https://www.w3.org/TR/trace-context/#tracestate-header
+%% See https://www.w3.org/TR/trace-context-2/#tracestate-header
 %% for the limits and string requirements that make up the regexes
 -define(MAX_MEMBERS, 32).
 %%
@@ -117,7 +117,8 @@ ensure_regex_pterms() ->
         _ = ?KEY_MP
     catch
         error:badarg ->
-            {ok, KeyMP} = re:compile("^(([a-z][_0-9a-z\-\*\/]{0,255})|([a-z0-9][_0-9a-z-*/]{0,240}@[a-z][_0-9a-z-*/]{0,13}))$"),
+            %% key = ( lcalpha / DIGIT ) 0*255 ( lcalpha / DIGIT / "_" / "-" / "*" / "/" / "@" )
+            {ok, KeyMP} = re:compile("^[a-z0-9][a-z0-9_*/@-]{0,255}$"),
             {ok, ValueMP} = re:compile("^([ -+--<>-~]{0,255}[!-+--<>-~])$"),
 
             persistent_term:put({otel_tracestate, key_mp}, KeyMP),

--- a/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_propagators_SUITE.erl
@@ -16,7 +16,7 @@
                             <<"00-10000000000000000000000000000000-1000000000000000-00">>}]).
 
 all() ->
-    [tracestate, rewrite, {group, absence_of_an_installed_sdk}, custom_propagator].
+    [tracestate, tracestate_key_grammar, rewrite, {group, absence_of_an_installed_sdk}, custom_propagator].
 
 groups() ->
     %% Tests of Behavior of the API in the absence of an installed SDK
@@ -63,6 +63,29 @@ tracestate(_Config) ->
 
     TracestateEncoded1 = otel_tracestate:encode_header(Tracestate8),
     ?assertEqual(<<"a=h,c=g">>, TracestateEncoded1),
+
+    ok.
+
+%% key = ( lcalpha / DIGIT ) 0*255 ( lcalpha / DIGIT / "_" / "-" / "*" / "/" / "@" )
+%% https://www.w3.org/TR/trace-context-2/#key
+tracestate_key_grammar(_Config) ->
+    ValidKeys = [<<"foo@">>,
+                 <<"foo@@bar">>,
+                 <<"foo@bar@baz">>,
+                 <<"0mykey">>,
+                 binary:copy(<<"z">>, 256)],
+    lists:foreach(fun(Key) ->
+                          Decoded = otel_tracestate:decode_header(<<Key/binary, "=1,bar=2">>),
+                          ?assertEqual(<<"1">>, otel_tracestate:get(Key, Decoded)),
+                          ?assertEqual(<<"2">>, otel_tracestate:get(<<"bar">>, Decoded))
+                  end, ValidKeys),
+
+    InvalidKeys = [<<"@foo">>,
+                   binary:copy(<<"z">>, 257)],
+    lists:foreach(fun(Key) ->
+                          Decoded = otel_tracestate:decode_header(<<Key/binary, "=1,bar=2">>),
+                          ?assertEqual("", otel_tracestate:get(Key, Decoded))
+                  end, InvalidKeys),
 
     ok.
 


### PR DESCRIPTION
Closes #1010

## Problem

`otel_tracestate` validates keys with a regex implementing the obsolete Trace Context Level 1 grammar, including the separate multi-tenant `tenant@vendor` key form. Level 2 (w3c/trace-context#386) unified the grammar:

```abnf
key     = ( lcalpha / DIGIT ) 0*255 ( keychar )
keychar = lcalpha / DIGIT / "_" / "-" / "*" / "/" / "@"
```

https://www.w3.org/TR/trace-context-2/#key

Under Level 2, `@` is an ordinary key character (allowed anywhere except the first position), keys may start with a digit, and the only length limit is 256 characters total. The old regex rejected keys such as `foo@`, `foo@@bar` and `foo@bar@baz`, and since one invalid member drops the whole header, the entire tracestate was discarded instead of propagated.

This is why the `W3C Interop` check currently fails on every PR: the workflow checks out `w3c/trace-context` at HEAD, and since w3c/trace-context#584 the suite tests the Level 2 grammar (`test_tracestate_key_illegal_vendor_format`, `test_tracestate_key_length_limit`).

## Change

- Replace the key regex with the Level 2 grammar: `^[a-z0-9][a-z0-9_*/@-]{0,255}$`
- Add a `tracestate_key_grammar` regression test covering `@` keys, digit-first keys, and the 256/257 character boundary
- Update the spec reference comment to Level 2

## Validation

- `rebar3 ct --suite otel_propagators_SUITE`: all 6 tests pass
- Ran the W3C interop harness locally against `w3c/trace-context` at HEAD (`STRICT_LEVEL=2`): all 41 tests pass, including the two failing in CI