### PR TITLE
chore(ci): drop OTP 25 from Elixir test matrix

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27.2"
+          otp-version: "27.2.4"
           elixir-version: "1.18.1"
           version-type: "strict"
       - uses: actions/cache@v5
@@ -39,13 +39,13 @@ jobs:
     name: Test SDK on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "25.3.2.16"]
+        otp_version: ["27.2.4", "26.2.5.21"]
         elixir_version: ["1.18.1", "1.14.5"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
         exclude:
           - elixir_version: "1.14.5"
-          - otp_version: "27.2"
+          - otp_version: "27.2.4"
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir_version }}
@@ -67,13 +67,13 @@ jobs:
     name: Test API on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "25.3.2.16"]
+        otp_version: ["27.2.4", "26.2.5.21"]
         elixir_version: ["1.18.1", "1.14.5"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
         exclude:
           - elixir_version: "1.14.5"
-          - otp_version: "27.2"
+          - otp_version: "27.2.4"
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir_version }}
@@ -113,7 +113,7 @@ jobs:
     name: Dialyze on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2"]
+        otp_version: ["27.2.4"]
         elixir_version: ["1.18.1"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
@@ -150,13 +150,13 @@ jobs:
     name: Test SemConv on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "25.3.2.16"]
+        otp_version: ["27.2.4", "26.2.5.21"]
         elixir_version: ["1.18.1", "1.14.5"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
         exclude:
           - elixir_version: "1.14.5"
-          - otp_version: "27.2"
+          - otp_version: "27.2.4"
     defaults:
       run:
         working-directory: apps/opentelemetry_semantic_conventions


### PR DESCRIPTION
- OTP 25.3.2.16's and 27.2's TLS stacks reject hex.pm's current certificate chain (`key_usage_mismatch`), which fails rebar installation during `setup-beam` on every PR
- OTP 27.2.4 and 26.2.5.21 accept the chain, matching open-telemetry/opentelemetry-erlang-contrib#707
- The remaining `W3C Interop` failure is unrelated and addressed by #1011