### PR TITLE
chore(docs): Remove Greg Mefford from emeritus status

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,15 +218,9 @@ For more information about the maintainer role, see the [community repository](h
 ### Approvers
 
 - [Fred Hebert](https://github.com/ferd), [Honeycomb](https://www.honeycomb.io/)
+- [Greg Mefford](https://github.com/GregMefford), [Adobe](https://www.adobe.com/)
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
-
-### Emeritus
-
-- [Greg Mefford](https://github.com/GregMefford), Approver
-
-For more information about the emeritus role, see the
-[community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).
 
 ### Thanks to all the people who have contributed
 


### PR DESCRIPTION
I intend to continue to contribute actively as an Approver, I just didn't get a chance to intercept this change before it got merged. 