### PR TITLE
fix: bump FOSSA workflow OTP pin to 27.2.4 to fix hex.pm TLS failure

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27.2"
+          otp-version: "27.2.4"
           rebar3-version: "3.24.0"
           elixir-version: "1.18.1"
           version-type: "strict"


### PR DESCRIPTION
## Problem

The `FOSSA scanning` workflow (`.github/workflows/fossa.yml`) has been failing on every push to `main` since at least 2026-07-09. Example failing run: https://github.com/open-telemetry/opentelemetry-erlang/actions/runs/28993269874/job/86037536191

```
** (Mix) httpc request failed with: {:failed_connect, [{:to_address, {~c"builds.hex.pm", 443}}, {:inet, [:inet], {:tls_alert, {:unsupported_certificate, ~c"...key_usage_mismatch..."}}}]}
Could not install Rebar because Mix could not download metadata at https://builds.hex.pm/installs/rebar3-1.x.csv.
##[error]Could not mix rebar from any hex.pm mirror
```

## Root cause

`otp-version: "27.2"` (i.e. `27.2.0`) falls in a broken window: OTP's `public_key`/`ssl` apps shipped a stricter X.509 key-usage compatibility check in late 2024 that rejects the certificate served by `builds.hex.pm` (behind Fastly, which serves a cert with `keyUsage: keyCertSign, cRLSign` + `extKeyUsage: serverAuth` — a combination the stricter check flags as `key_usage_mismatch`). This breaks the `mix local.rebar --force` step that `erlef/setup-beam` runs whenever `elixir-version` is set.

The bug is tracked as hexpm/hex#1175 and was fixed upstream in OTP by erlang/otp@e0ef3fbd7e48f8c38c3118335680b2c999ebd96f. Verified via `gh api repos/erlang/otp/compare/<tag>...<fix-sha>` which patch releases contain the fix:

| OTP line | Broken (missing fix) | Fixed in |
|---|---|---|
| 25 | ≤ 25.3.2.17 | 25.3.2.18+ |
| 26 | ≤ 26.2.5.7 | 26.2.5.8+ |
| 27 | ≤ 27.2.1 | **27.2.2+** |
| 28 | — | never broken |

A related instance of this same bug (OTP `25.3.2.16` pinned in `elixir.yml`'s test matrix) was already fixed on `main` by #1012 ("ci: drop OTP 25 from Elixir test matrix"), which moved that matrix to `["27.2.4", "26.2.5.21"]`. That PR didn't touch `fossa.yml`, which is why it's still broken.

## Fix

Bump `otp-version` from `"27.2"` to `"27.2.4"` in `fossa.yml`, matching the pin already used in `elixir.yml`'s test matrix on `main`.

Note: `erlang.yml` also pins a broken-window OTP (`26.2.5.6`) for some jobs, but those jobs never invoke `mix`/hex (only `rebar3`, fetched directly from GitHub releases by `setup-beam`), so they aren't actually exposed to this bug — no change needed there.