### PR TITLE
fix: prevent renovate from pinning hex dependency semver ranges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver",
+    ":preserveSemverRanges"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

#1017 switched the Renovate config to extend `config:best-practices`, which includes pinning behavior. As a result, #1021 attempted to pin hex dependency semver ranges (e.g. `~> 0.10` → `== 0.10.0`), which is undesirable.

As noted in the Renovate bot's own PR description:

> Add the preset `:preserveSemverRanges` to your config if you don't want to pin your dependencies.

This PR adds that preset to `renovate.json` to restore the previous, non-pinning behavior for dependency version ranges.

## Test plan

- [ ] Confirm Renovate no longer proposes pinning existing semver ranges on its next run