### PR TITLE
fix(api): enforce W3C Baggage limits on the extract path

### DIFF
--- a/apps/opentelemetry_api/src/otel_propagator_baggage.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_baggage.erl
@@ -50,6 +50,11 @@
 
 -define(BAGGAGE_HEADER, <<"baggage">>).
 
+%% W3C Baggage size limits, enforced on extract (https://www.w3.org/TR/baggage/#limits).
+-define(MAX_ENTRIES, 180).
+-define(MAX_ENTRY_BYTES, 4096).
+-define(MAX_TOTAL_BYTES, 8192).
+
 %% @private
 fields(_) ->
     [?BAGGAGE_HEADER].
@@ -84,13 +89,22 @@ extract(Ctx, Carrier, _CarrierKeysFun, CarrierGet, _Options) ->
             Ctx;
         String ->
             Pairs = string:lexemes(String, [$,]),
-            DecodedBaggage =
-                lists:foldl(fun(Pair, Acc) ->
-                                    [Key, Value] = string:split(Pair, "="),
-                                    Acc#{decode_key(Key) => decode_value(Value)}
-
-                            end, #{}, Pairs),
+            {DecodedBaggage, _, _} =
+                lists:foldl(fun decode_within_limits/2, {#{}, 0, 0}, Pairs),
             otel_baggage:set_to(Ctx, DecodedBaggage)
+    end.
+
+decode_within_limits(_Pair, {Acc, Count, Bytes}) when Count >= ?MAX_ENTRIES ->
+    {Acc, Count, Bytes};
+decode_within_limits(Pair, {Acc, Count, Bytes}) ->
+    PairBytes = byte_size(Pair),
+    NewBytes = Bytes + PairBytes,
+    case PairBytes =< ?MAX_ENTRY_BYTES andalso NewBytes =< ?MAX_TOTAL_BYTES of
+        false ->
+            {Acc, Count, Bytes};
+        true ->
+            [Key, Value] = string:split(Pair, "="),
+            {Acc#{decode_key(Key) => decode_value(Value)}, Count + 1, NewBytes}
     end.
 
 %%

--- a/apps/opentelemetry_api/src/otel_propagator_baggage.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_baggage.erl
@@ -98,7 +98,8 @@ decode_within_limits(_Pair, {Acc, Count, Bytes}) when Count >= ?MAX_ENTRIES ->
     {Acc, Count, Bytes};
 decode_within_limits(Pair, {Acc, Count, Bytes}) ->
     PairBytes = byte_size(Pair),
-    NewBytes = Bytes + PairBytes,
+    SeparatorBytes = case Count of 0 -> 0; _ -> 1 end,
+    NewBytes = Bytes + SeparatorBytes + PairBytes,
     case PairBytes =< ?MAX_ENTRY_BYTES andalso NewBytes =< ?MAX_TOTAL_BYTES of
         false ->
             {Acc, Count, Bytes};

--- a/apps/opentelemetry_api/test/otel_propagator_baggage_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_propagator_baggage_SUITE.erl
@@ -1,0 +1,62 @@
+-module(otel_propagator_baggage_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    [enforces_max_entries, enforces_max_entry_length,
+     enforces_max_entry_length_is_bytes_not_graphemes, enforces_max_total_length].
+
+init_per_suite(Config) ->
+    application:load(opentelemetry_api),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+extract(Header) ->
+    Carrier = [{<<"baggage">>, Header}],
+    Ctx = otel_propagator_baggage:extract(otel_ctx:new(), Carrier,
+                                          fun otel_propagator_text_map:default_carrier_keys/1,
+                                          fun otel_propagator_text_map:default_carrier_get/2, []),
+    otel_baggage:get_all(Ctx).
+
+enforces_max_entries(_Config) ->
+    Header = iolist_to_binary(lists:join(<<",">>,
+                 [ [<<"k">>, integer_to_binary(I), <<"=v">>] || I <- lists:seq(1, 200) ])),
+    Baggage = extract(Header),
+    ?assertEqual(180, maps:size(Baggage)),
+    ?assert(maps:is_key(<<"k1">>, Baggage)),
+    ?assertNot(maps:is_key(<<"k181">>, Baggage)),
+    ok.
+
+enforces_max_entry_length(_Config) ->
+    Big = binary:copy(<<"x">>, 5000),
+    Header = <<"ok=1,big=", Big/binary>>,
+    Baggage = extract(Header),
+    ?assertEqual(1, maps:size(Baggage)),
+    ?assert(maps:is_key(<<"ok">>, Baggage)),
+    ?assertNot(maps:is_key(<<"big">>, Baggage)),
+    ok.
+
+enforces_max_entry_length_is_bytes_not_graphemes(_Config) ->
+    Multibyte = unicode:characters_to_binary(lists:duplicate(2100, $\x{e9})), %% 2100 graphemes, 4200 bytes
+    Header = <<"ok=1,u=", Multibyte/binary>>,
+    Baggage = extract(Header),
+    ?assertEqual(1, maps:size(Baggage)),
+    ?assert(maps:is_key(<<"ok">>, Baggage)),
+    ?assertNot(maps:is_key(<<"u">>, Baggage)),
+    ok.
+
+enforces_max_total_length(_Config) ->
+    Header = iolist_to_binary(lists:join(<<",">>,
+                 [ [<<"k">>, integer_to_binary(I), <<"=">>, binary:copy(<<"y">>, 200)]
+                   || I <- lists:seq(1, 100) ])),
+    Baggage = extract(Header),
+    Size = maps:size(Baggage),
+    ?assert(Size > 0 andalso Size < 100),
+    ?assert(maps:is_key(<<"k1">>, Baggage)),
+    ?assertNot(maps:is_key(<<"k100">>, Baggage)),
+    ok.

--- a/apps/opentelemetry_api/test/otel_propagator_baggage_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_propagator_baggage_SUITE.erl
@@ -7,7 +7,8 @@
 
 all() ->
     [enforces_max_entries, enforces_max_entry_length,
-     enforces_max_entry_length_is_bytes_not_graphemes, enforces_max_total_length].
+     enforces_max_entry_length_is_bytes_not_graphemes, enforces_max_total_length,
+     charges_a_separator_byte_between_accepted_entries].
 
 init_per_suite(Config) ->
     application:load(opentelemetry_api),
@@ -59,4 +60,18 @@ enforces_max_total_length(_Config) ->
     ?assert(Size > 0 andalso Size < 100),
     ?assert(maps:is_key(<<"k1">>, Baggage)),
     ?assertNot(maps:is_key(<<"k100">>, Baggage)),
+    ok.
+
+charges_a_separator_byte_between_accepted_entries(_Config) ->
+    FillerAPrefix = <<"filler_a=">>,
+    FillerBPrefix = <<"filler_b=">>,
+    SmallPair = <<"small=">>,
+    FillerA = <<FillerAPrefix/binary, (binary:copy(<<"x">>, 4096 - byte_size(FillerAPrefix)))/binary>>,
+    FillerBBytes = 8192 - byte_size(SmallPair) - byte_size(FillerA) - 1,
+    FillerB = <<FillerBPrefix/binary, (binary:copy(<<"x">>, FillerBBytes - byte_size(FillerBPrefix)))/binary>>,
+    Header = iolist_to_binary(lists:join(<<",">>, [FillerA, FillerB, SmallPair])),
+    Baggage = extract(Header),
+    ?assert(maps:is_key(<<"filler_a">>, Baggage)),
+    ?assert(maps:is_key(<<"filler_b">>, Baggage)),
+    ?assertNot(maps:is_key(<<"small">>, Baggage)),
     ok.


### PR DESCRIPTION
The inject path builds the baggage header, but `extract` parsed the inbound header with no limits — every comma-separated pair was folded into the map, so an unbounded inbound `baggage` header was decoded in full. The tracestate propagator already enforces its 32-member cap, so this was the one uncapped extract path.

`extract` now applies the W3C Baggage limits (180 entries / 4096 bytes per entry / 8192 bytes total): over-limit members are dropped once a limit is reached and the earlier ones are kept. Every other OpenTelemetry SDK enforces these on extract — opentelemetry-java did it as CVE-2026-45292 (fixed 1.62.0), and its Jaeger propagator borrows the same W3C limits.

**Update:** the byte accounting summed each pair's own bytes against the 8192-byte total but never charged the `,` that joins entries on the wire, so a header could pass the check while its real wire size was already over the limit. Fixed to charge one separator byte per already-accepted entry, mirroring how `inject` already builds the header.

Adds `otel_propagator_baggage_SUITE` with a case per limit (including a byte-vs-grapheme case and the separator-byte boundary); each fails without the change.

Assisted-By: Claude Fable 5